### PR TITLE
Part #17, update code coverage

### DIFF
--- a/unit-test/fm_cmds_tests.c
+++ b/unit-test/fm_cmds_tests.c
@@ -2273,9 +2273,9 @@ void UtTest_Setup(void)
     add_FM_NoopCmd_tests();
     add_FM_ResetCountersCmd_tests();
     add_FM_CopyFileCmd_tests();
-    // add_FM_MoveFileCmd_tests();
+    add_FM_MoveFileCmd_tests();
     add_FM_RenameFileCmd_tests();
-    // add_FM_DeleteFileCmd_tests();
+    add_FM_DeleteFileCmd_tests();
     add_FM_DeleteAllFilesCmd_tests();
 
 #ifdef FM_INCLUDE_DECOMPRESS


### PR DESCRIPTION
Increases code coverage for fm_child_tests.c and fm_cmds_tests.c

**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/FM/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
- Part #17 

**Testing performed**
1. lcov --capture --rc lcov_branch_coverage=1 --directory build --output-file coverage_test.info
2. lcov --rc lcov_branch_coverage=1 --add-tracefile coverage_base.info --add-tracefile coverage_test.info --output-file coverage_total.info
3. genhtml coverage_total.info --branch-coverage --output-directory lcov

**Expected behavior changes**
None

**System(s) tested on**
 - OS: Ubuntu 18.04

**Additional context**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
 - Note CLA's apply to software contributions.
