### PR TITLE
Fix #36, Remove redundant conditional to support full coverage

### DIFF
--- a/fsw/src/fm_child.c
+++ b/fsw/src/fm_child.c
@@ -1272,7 +1272,7 @@ void FM_ChildDirListPktCmd(const FM_ChildQueueEntry_t *CmdArgs)
                     EntryLength = strlen(OS_DIRENTRY_NAME(DirEntry));
 
                     /* Verify combined directory plus filename length */
-                    if ((EntryLength < sizeof(ListEntry->EntryName)) && ((PathLength + EntryLength) < OS_MAX_PATH_LEN))
+                    if ((PathLength + EntryLength) < OS_MAX_PATH_LEN)
                     {
                         /* Add filename to directory listing telemetry packet */
                         strncpy(ListEntry->EntryName, OS_DIRENTRY_NAME(DirEntry), EntryLength);
@@ -1282,7 +1282,7 @@ void FM_ChildDirListPktCmd(const FM_ChildQueueEntry_t *CmdArgs)
                         strncpy(LogicalName, CmdArgs->Source2, PathLength);
                         LogicalName[PathLength] = '\0';
 
-                        strncat(LogicalName, OS_DIRENTRY_NAME(DirEntry), (OS_MAX_PATH_LEN - PathLength));
+                        strncat(LogicalName, OS_DIRENTRY_NAME(DirEntry), EntryLength);
 
                         FM_ChildSleepStat(LogicalName, ListEntry, &FilesTillSleep, CmdArgs->GetSizeTimeMode);
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/FM/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #36 

Removes the redundant length check.

**Testing performed**
CI

**Expected behavior changes**
None, the element sizes are already sufficient to fit... can't fail check without overflowing local variables.

**System(s) tested on**
CI

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC