### PR TITLE
Fix #41, Remove unrequired internal delete command handling

### DIFF
--- a/fsw/src/fm_app.c
+++ b/fsw/src/fm_app.c
@@ -359,10 +359,6 @@ void FM_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
             Result = FM_SetTableStateCmd(BufPtr);
             break;
 
-        case FM_DELETE_INT_CC:
-            Result = FM_DeleteFileCmd(BufPtr);
-            break;
-
         case FM_SET_FILE_PERM_CC:
             Result = FM_SetPermissionsCmd(BufPtr);
             break;
@@ -377,7 +373,7 @@ void FM_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
     if (Result == true)
     {
         /* Increment command success counter */
-        if ((CommandCode != FM_RESET_CC) && (CommandCode != FM_DELETE_INT_CC))
+        if (CommandCode != FM_RESET_CC)
         {
             FM_GlobalData.CommandCounter++;
         }

--- a/fsw/src/fm_child.c
+++ b/fsw/src/fm_child.c
@@ -258,10 +258,6 @@ void FM_ChildProcess(void)
             FM_ChildDirListPktCmd(CmdArgs);
             break;
 
-        case FM_DELETE_INT_CC:
-            FM_ChildDeleteCmd(CmdArgs);
-            break;
-
         case FM_SET_FILE_PERM_CC:
             FM_ChildSetPermissionsCmd(CmdArgs);
             break;
@@ -446,12 +442,9 @@ void FM_ChildDeleteCmd(const FM_ChildQueueEntry_t *CmdArgs)
     {
         FM_GlobalData.ChildCmdCounter++;
 
-        if (CmdArgs->CommandCode != FM_DELETE_INT_CC)
-        {
-            /* Send command completion event (info) */
-            CFE_EVS_SendEvent(FM_DELETE_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: file = %s", CmdText,
-                              CmdArgs->Source1);
-        }
+        /* Send command completion event (info) */
+        CFE_EVS_SendEvent(FM_DELETE_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: file = %s", CmdText,
+                          CmdArgs->Source1);
     }
 
     /* Report previous child task activity */

--- a/fsw/src/fm_msgdefs.h
+++ b/fsw/src/fm_msgdefs.h
@@ -921,23 +921,6 @@
 #define FM_SET_TABLE_STATE_CC 17
 
 /**
- * \brief Delete File (internal)
- *
- *  \par Description
- *       This is a special version of the #FM_DELETE_CC command for
- *       use when the command is sent by another application, rather
- *       than from the ground.  This version of the command will not
- *       generate a success event, nor will the command increment the
- *       command success counter.  The intent is to avoid confusion
- *       resulting from telemetry representing the results of delete
- *       commands sent by other applications and those sent from the
- *       ground.  Refer to #FM_DELETE_CC command for use details.
- *
- *  \sa #FM_DELETE_CC
- */
-#define FM_DELETE_INT_CC 18
-
-/**
  * \brief Set Permissions of a file
  *
  *  \par Description

--- a/unit-test/fm_app_tests.c
+++ b/unit-test/fm_app_tests.c
@@ -709,24 +709,6 @@ void Test_FM_ProcessCmd_SetTableStateCCReturn(void)
     UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
 }
 
-void Test_FM_ProcessCmd_DeleteFileIntCCReturn(void)
-{
-    // Arrange
-    CFE_MSG_FcnCode_t fcn_code = FM_DELETE_INT_CC;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_DeleteFileCmd), true);
-
-    // Act
-    UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
-
-    // Assert
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    UtAssert_STUB_COUNT(FM_DeleteFileCmd, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
-}
-
 void Test_FM_ProcessCmd_SetPermissionsCCReturn(void)
 {
     // Arrange
@@ -868,9 +850,6 @@ void add_FM_ProcessCmd_tests(void)
 
     UtTest_Add(Test_FM_ProcessCmd_SetTableStateCCReturn, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_PRocessCmd_SetTableStateCCReturn");
-
-    UtTest_Add(Test_FM_ProcessCmd_DeleteFileIntCCReturn, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_PRocessCmd_DeleteFileIntCCReturn");
 
     UtTest_Add(Test_FM_ProcessCmd_SetPermissionsCCReturn, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_PRocessCmd_SetPermissionsCCReturn");

--- a/unit-test/fm_child_tests.c
+++ b/unit-test/fm_child_tests.c
@@ -399,26 +399,6 @@ void Test_FM_ChildProcess_FMGetDirListsPktCC(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_PKT_CMD_EID);
 }
 
-void Test_FM_ChildProcess_FMDeleteIntCC(void)
-{
-    // Arrange
-    FM_GlobalData.ChildQueue[0].CommandCode = FM_DELETE_INT_CC;
-    FM_GlobalData.ChildCurrentCC            = 1;
-
-    UT_SetDefaultReturnValue(UT_KEY(OS_remove), !OS_SUCCESS);
-
-    // Act
-    UtAssert_VOIDCALL(FM_ChildProcess());
-
-    // Assert
-    UT_FM_Child_Cmd_Assert(0, 1, 0, FM_GlobalData.ChildQueue[0].CommandCode);
-
-    UtAssert_STUB_COUNT(OS_remove, 1);
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_OS_ERR_EID);
-}
-
 void Test_FM_ChildProcess_FMSetFilePermCC(void)
 {
     // Arrange
@@ -605,21 +585,6 @@ void Test_FM_ChildDeleteCmd_OSRemoveNotSuccess(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_OS_ERR_EID);
-}
-
-void Test_FM_ChildDeleteCmd_CommandCodeIsDeleteIntCC(void)
-{
-    // Arrange
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_INT_CC};
-
-    // Act
-    UtAssert_VOIDCALL(FM_ChildDeleteCmd(&queue_entry));
-
-    // Assert
-    UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
-
-    UtAssert_STUB_COUNT(OS_remove, 1);
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 /* ****************
@@ -2321,9 +2286,6 @@ void add_FM_ChildProcess_tests(void)
     UtTest_Add(Test_FM_ChildProcess_FMGetDirListsPktCC, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_ChildProcess_FMGetDirListsPktCC");
 
-    UtTest_Add(Test_FM_ChildProcess_FMDeleteIntCC, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildProcess_FMDeleteIntCC");
-
     UtTest_Add(Test_FM_ChildProcess_FMSetFilePermCC, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_ChildProcess_FMSetFilePermCC");
 
@@ -2362,9 +2324,6 @@ void add_FM_ChildRenameCmd_tests(void)
 
 void add_FM_ChildDeleteCmd_tests(void)
 {
-    UtTest_Add(Test_FM_ChildDeleteCmd_CommandCodeIsDeleteIntCC, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildDeleteCmd_CommandCodeIsDeleteIntCC");
-
     UtTest_Add(Test_FM_ChildDeleteCmd_OSRemoveSuccess, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_ChildDeleteCmd_OSRemoveSuccess");
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/FM/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #41

**Testing performed**
CI

**Expected behavior changes**
No longer supports FM_DELETE_INT_CC or the related strange (out of family) logic.  FM is operator interface to file management (even the design document says it doesn't do "automated" actions).

**System(s) tested on**
CI

**Additional context**
Could have deprecated, but can't find any external references to it so put in this PR to see if there is support for a direct removal.  It didn't behave as described to begin with.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC