### PR TITLE
Fix #14, initialize DirListData with zeros before using

### DIFF
--- a/fsw/src/fm_child.c
+++ b/fsw/src/fm_child.c
@@ -1468,6 +1468,7 @@ void FM_ChildDirListFileLoop(osal_id_t DirId, osal_id_t FileHandle, const char *
                     strncat(TempName, OS_DIRENTRY_NAME(DirEntry), (OS_MAX_PATH_LEN - PathLength));
 
                     /* Populate directory list file entry */
+                    memset(&DirListData, 0, sizeof(DirListData));
                     strncpy(DirListData.EntryName, OS_DIRENTRY_NAME(DirEntry), EntryLength);
                     DirListData.EntryName[EntryLength] = '\0';
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [X] I reviewed the [Contributing Guide](https://github.com/nasa/FM/blob/main/CONTRIBUTING.md).
* [X] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fix #14, zero out DirListData buffer in FM_ChildDirListFileLoop

**Testing performed**
Unit testing

**Expected behavior changes**
DirListData.EntryName won't have garbage values.

**System(s) tested on**
 - OS:  Ubuntu 18.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Haven Carlson - NASA