### PR TITLE
Fix #55, Remove unnecessary parentheses around return values.

### DIFF
--- a/fsw/src/fm_app.c
+++ b/fsw/src/fm_app.c
@@ -237,7 +237,7 @@ int32 FM_AppInit(void)
         }
     }
 
-    return (Result);
+    return Result;
 
 } /* End of FM_AppInit() */
 

--- a/fsw/src/fm_child.c
+++ b/fsw/src/fm_child.c
@@ -105,7 +105,7 @@ int32 FM_ChildInit(void)
                           TaskText, (int)Result);
     }
 
-    return (Result);
+    return Result;
 
 } /* End of FM_ChildInit() */
 
@@ -1402,7 +1402,7 @@ bool FM_ChildDirListFileInit(osal_id_t *FileHandlePtr, const char *Directory, co
                           "%s error: OS_OpenCreate failed: result = %d, file = %s", CmdText, (int)Status, Filename);
     }
 
-    return (CommandResult);
+    return CommandResult;
 
 } /* End FM_ChildDirListFileInit */
 
@@ -1571,7 +1571,7 @@ int32 FM_ChildSizeTimeMode(const char *Filename, uint32 *FileSize, uint32 *FileT
         *FileMode = OS_FILESTAT_MODE(FileStatus);
     }
 
-    return (Result);
+    return Result;
 
 } /* End of FM_ChildSizeTimeMode */
 

--- a/fsw/src/fm_cmd_utils.c
+++ b/fsw/src/fm_cmd_utils.c
@@ -61,7 +61,7 @@ bool FM_IsValidCmdPktLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLeng
                           (int)ExpectedLength, (int)ActualLength);
     }
 
-    return (FunctionResult);
+    return FunctionResult;
 
 } /* FM_IsValidCmdPktLength */
 
@@ -83,7 +83,7 @@ bool FM_VerifyOverwrite(uint16 Overwrite, uint32 EventID, const char *CmdText)
         FunctionResult = false;
     }
 
-    return (FunctionResult);
+    return FunctionResult;
 
 } /* End FM_VerifyOverwrite */
 
@@ -130,7 +130,7 @@ uint32 FM_GetOpenFilesData(const FM_OpenFilesEntry_t *OpenFilesData)
 
     OS_ForEachObject(OS_OBJECT_CREATOR_ANY, LoadOpenFileData, (void *)OpenFilesData);
 
-    return (OpenFileCount);
+    return OpenFileCount;
 
 } /* End FM_GetOpenFilesData */
 
@@ -239,7 +239,7 @@ uint32 FM_GetFilenameState(char *Filename, uint32 BufferSize, bool FileInfoCmd)
         }
     }
 
-    return (FilenameState);
+    return FilenameState;
 
 } /* End FM_GetFilenameState */
 
@@ -263,7 +263,7 @@ uint32 FM_VerifyNameValid(char *Name, uint32 BufferSize, uint32 EventID, const c
         CFE_EVS_SendEvent(EventID, CFE_EVS_EventType_ERROR, "%s error: invalid name: name = %s", CmdText, Name);
     }
 
-    return (FilenameState);
+    return FilenameState;
 
 } /* End FM_VerifyNameValid */
 
@@ -308,7 +308,7 @@ bool FM_VerifyFileClosed(char *Filename, uint32 BufferSize, uint32 EventID, cons
                           "%s error: filename is invalid: name = %s", CmdText, Filename);
     }
 
-    return (Result);
+    return Result;
 
 } /* End FM_VerifyFileClosed */
 
@@ -348,7 +348,7 @@ bool FM_VerifyFileExists(char *Filename, uint32 BufferSize, uint32 EventID, cons
                           "%s error: filename is invalid: name = %s", CmdText, Filename);
     }
 
-    return (Result);
+    return Result;
 
 } /* End FM_VerifyFileExists */
 
@@ -388,7 +388,7 @@ bool FM_VerifyFileNoExist(char *Filename, uint32 BufferSize, uint32 EventID, con
                           "%s error: filename is invalid: name = %s", CmdText, Filename);
     }
 
-    return (Result);
+    return Result;
 
 } /* End FM_VerifyFileNoExist */
 
@@ -432,7 +432,7 @@ bool FM_VerifyFileNotOpen(char *Filename, uint32 BufferSize, uint32 EventID, con
                           "%s error: filename is invalid: name = %s", CmdText, Filename);
     }
 
-    return (Result);
+    return Result;
 
 } /* End FM_VerifyFileNotOpen */
 
@@ -472,7 +472,7 @@ bool FM_VerifyDirExists(char *Directory, uint32 BufferSize, uint32 EventID, cons
                           "%s error: directory name is invalid: name = %s", CmdText, Directory);
     }
 
-    return (Result);
+    return Result;
 
 } /* End FM_VerifyDirExists */
 
@@ -512,7 +512,7 @@ bool FM_VerifyDirNoExist(char *Name, uint32 BufferSize, uint32 EventID, const ch
                           "%s error: directory name is invalid: name = %s", CmdText, Name);
     }
 
-    return (Result);
+    return Result;
 
 } /* End FM_VerifyDirNoExist */
 
@@ -563,7 +563,7 @@ bool FM_VerifyChildTask(uint32 EventID, const char *CmdText)
         Result = true;
     }
 
-    return (Result);
+    return Result;
 
 } /* End FM_VerifyChildTask */
 

--- a/fsw/src/fm_cmds.c
+++ b/fsw/src/fm_cmds.c
@@ -60,7 +60,7 @@ bool FM_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
                           FM_MAJOR_VERSION, FM_MINOR_VERSION, FM_REVISION, FM_MISSION_REV);
     }
 
-    return (CommandResult);
+    return CommandResult;
 
 } /* End of FM_NoopCmd() */
 
@@ -92,7 +92,7 @@ bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
         CFE_EVS_SendEvent(FM_RESET_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command", CmdText);
     }
 
-    return (CommandResult);
+    return CommandResult;
 
 } /* End of FM_ResetCountersCmd() */
 
@@ -160,7 +160,7 @@ bool FM_CopyFileCmd(const CFE_SB_Buffer_t *BufPtr)
         FM_InvokeChildTask();
     }
 
-    return (CommandResult);
+    return CommandResult;
 
 } /* End of FM_CopyFileCmd() */
 
@@ -229,7 +229,7 @@ bool FM_MoveFileCmd(const CFE_SB_Buffer_t *BufPtr)
         FM_InvokeChildTask();
     }
 
-    return (CommandResult);
+    return CommandResult;
 
 } /* End of FM_MoveFileCmd() */
 
@@ -285,7 +285,7 @@ bool FM_RenameFileCmd(const CFE_SB_Buffer_t *BufPtr)
         FM_InvokeChildTask();
     }
 
-    return (CommandResult);
+    return CommandResult;
 
 } /* End of FM_RenameFileCmd() */
 
@@ -332,7 +332,7 @@ bool FM_DeleteFileCmd(const CFE_SB_Buffer_t *BufPtr)
         FM_InvokeChildTask();
     }
 
-    return (CommandResult);
+    return CommandResult;
 
 } /* End of FM_DeleteFileCmd() */
 
@@ -388,7 +388,7 @@ bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr)
         FM_InvokeChildTask();
     }
 
-    return (CommandResult);
+    return CommandResult;
 
 } /* End of FM_DeleteAllFilesCmd() */
 
@@ -443,7 +443,7 @@ bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr)
         FM_InvokeChildTask();
     }
 
-    return (CommandResult);
+    return CommandResult;
 
 } /* End of FM_DecompressFileCmd() */
 
@@ -507,7 +507,7 @@ bool FM_ConcatFilesCmd(const CFE_SB_Buffer_t *BufPtr)
         FM_InvokeChildTask();
     }
 
-    return (CommandResult);
+    return CommandResult;
 
 } /* End of FM_ConcatFilesCmd() */
 
@@ -569,7 +569,7 @@ bool FM_GetFileInfoCmd(const CFE_SB_Buffer_t *BufPtr)
         FM_InvokeChildTask();
     }
 
-    return (CommandResult);
+    return CommandResult;
 
 } /* End of FM_GetFileInfoCmd() */
 
@@ -606,7 +606,7 @@ bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr)
         CFE_EVS_SendEvent(FM_GET_OPEN_FILES_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command", CmdText);
     }
 
-    return (CommandResult);
+    return CommandResult;
 
 } /* End of FM_GetOpenFilesCmd() */
 
@@ -653,7 +653,7 @@ bool FM_CreateDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
         FM_InvokeChildTask();
     }
 
-    return (CommandResult);
+    return CommandResult;
 
 } /* End of FM_CreateDirectoryCmd() */
 
@@ -700,7 +700,7 @@ bool FM_DeleteDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
         FM_InvokeChildTask();
     }
 
-    return (CommandResult);
+    return CommandResult;
 
 } /* End of FM_DeleteDirectoryCmd() */
 
@@ -780,7 +780,7 @@ bool FM_GetDirListFileCmd(const CFE_SB_Buffer_t *BufPtr)
         FM_InvokeChildTask();
     }
 
-    return (CommandResult);
+    return CommandResult;
 
 } /* End of FM_GetDirListFileCmd() */
 
@@ -839,7 +839,7 @@ bool FM_GetDirListPktCmd(const CFE_SB_Buffer_t *BufPtr)
         FM_InvokeChildTask();
     }
 
-    return (CommandResult);
+    return CommandResult;
 
 } /* End of FM_GetDirListPktCmd() */
 
@@ -914,7 +914,7 @@ bool FM_GetFreeSpaceCmd(const CFE_SB_Buffer_t *BufPtr)
         }
     }
 
-    return (CommandResult);
+    return CommandResult;
 
 } /* End of FM_GetFreeSpaceCmd() */
 
@@ -984,7 +984,7 @@ bool FM_SetTableStateCmd(const CFE_SB_Buffer_t *BufPtr)
         }
     }
 
-    return (CommandResult);
+    return CommandResult;
 
 } /* End of FM_SetTableStateCmd() */
 
@@ -1035,7 +1035,7 @@ bool FM_SetPermissionsCmd(const CFE_SB_Buffer_t *BufPtr)
         FM_InvokeChildTask();
     }
 
-    return (CommandResult);
+    return CommandResult;
 
 } /* End of FM_SetPermissionsCmd() */
 

--- a/fsw/src/fm_tbl.c
+++ b/fsw/src/fm_tbl.c
@@ -59,7 +59,7 @@ int32 FM_TableInit(void)
         FM_AcquireTablePointers();
     }
 
-    return (Status);
+    return Status;
 
 } /* End FM_TableInit */
 
@@ -85,7 +85,7 @@ int32 FM_ValidateTable(FM_FreeSpaceTable_t *TablePtr)
         CFE_EVS_SendEvent(FM_TABLE_VERIFY_NULL_PTR_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Free Space Table verify error - null pointer detected");
 
-        return (FM_TABLE_VALIDATION_ERR);
+        return FM_TABLE_VALIDATION_ERR;
     }
 
     /*
@@ -176,7 +176,7 @@ int32 FM_ValidateTable(FM_FreeSpaceTable_t *TablePtr)
         Result = FM_TABLE_VALIDATION_ERR;
     }
 
-    return (Result);
+    return Result;
 
 } /* End FM_ValidateTable */
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #55
Removes parentheses in return statements in FM that return a single value/term.
This is aligns these return statements with the predominant style of cFS.

**Testing performed**
None, prior to submission of the pull request.

**Expected behavior changes**
No impact on behavior.

**Contributor Info - All information REQUIRED for consideration of pull request**
@thnkslprpt 