### PR TITLE
Fix #57, Remove redundant/inconsistent comments (/* end of function */, /* end if */ etc.) and clean up empty lines.

### DIFF
--- a/fsw/src/fm_app.c
+++ b/fsw/src/fm_app.c
@@ -156,8 +156,7 @@ void FM_AppMain(void)
     ** Let cFE kill the task (and any child tasks)...
     */
     CFE_ES_ExitApp(RunStatus);
-
-} /* End FM_AppMain */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -238,8 +237,7 @@ int32 FM_AppInit(void)
     }
 
     return Result;
-
-} /* End of FM_AppInit() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -271,8 +269,7 @@ void FM_ProcessPkt(const CFE_SB_Buffer_t *BufPtr)
                               (unsigned long)CFE_SB_MsgIdToValue(MessageID));
             break;
     }
-
-} /* End of FM_ProcessPkt */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -381,8 +378,7 @@ void FM_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
         /* Increment command error counter */
         FM_GlobalData.CommandErrCounter++;
     }
-
-} // End of FM_ProcessCmd
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -427,9 +423,4 @@ void FM_ReportHK(const CFE_MSG_CommandHeader_t *Msg)
         CFE_SB_TimeStampMsg(&FM_GlobalData.HousekeepingPkt.TlmHeader.Msg);
         CFE_SB_TransmitMsg(&FM_GlobalData.HousekeepingPkt.TlmHeader.Msg, true);
     }
-
-} // End of FM_ReportHK
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/fm_child.c
+++ b/fsw/src/fm_child.c
@@ -80,7 +80,6 @@ int32 FM_ChildInit(void)
 
         if (Result != CFE_SUCCESS)
         {
-
             TaskEID = FM_CHILD_INIT_QSEM_ERR_EID;
             strncpy(TaskText, "create queue count semaphore failed", TaskTextLen - 1);
             TaskText[TaskTextLen - 1] = '\0';
@@ -106,8 +105,7 @@ int32 FM_ChildInit(void)
     }
 
     return Result;
-
-} /* End of FM_ChildInit() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -133,8 +131,7 @@ void FM_ChildTask(void)
 
     /* This call allows cFE to clean-up system resources */
     CFE_ES_ExitChildTask();
-
-} /* End of FM_ChildTask() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -189,8 +186,7 @@ void FM_ChildLoop(void)
 
         CFE_ES_PerfLogExit(FM_CHILD_TASK_PERF_ID);
     }
-
-} /* End of FM_ChildLoop() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -277,8 +273,7 @@ void FM_ChildProcess(void)
     OS_MutSemTake(FM_GlobalData.ChildQueueCountSem);
     FM_GlobalData.ChildQueueCount--;
     OS_MutSemGive(FM_GlobalData.ChildQueueCountSem);
-
-} /* End of FM_ChildProcess() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -318,8 +313,7 @@ void FM_ChildCopyCmd(const FM_ChildQueueEntry_t *CmdArgs)
     /* Report previous child task activity */
     FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
     FM_GlobalData.ChildCurrentCC  = 0;
-
-} /* End of FM_ChildCopyCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -358,8 +352,7 @@ void FM_ChildMoveCmd(const FM_ChildQueueEntry_t *CmdArgs)
     /* Report previous child task activity */
     FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
     FM_GlobalData.ChildCurrentCC  = 0;
-
-} /* End of FM_ChildMoveCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -398,8 +391,7 @@ void FM_ChildRenameCmd(const FM_ChildQueueEntry_t *CmdArgs)
     /* Report previous child task activity */
     FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
     FM_GlobalData.ChildCurrentCC  = 0;
-
-} /* End of FM_ChildRenameCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -438,8 +430,7 @@ void FM_ChildDeleteCmd(const FM_ChildQueueEntry_t *CmdArgs)
     /* Report previous child task activity */
     FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
     FM_GlobalData.ChildCurrentCC  = 0;
-
-} /* End of FM_ChildDeleteCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -590,8 +581,7 @@ void FM_ChildDeleteAllCmd(FM_ChildQueueEntry_t *CmdArgs)
     /* Report previous child task activity */
     FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
     FM_GlobalData.ChildCurrentCC  = 0;
-
-} /* End of FM_ChildDeleteAllCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -633,8 +623,7 @@ void FM_ChildDecompressCmd(const FM_ChildQueueEntry_t *CmdArgs)
     /* Report previous child task activity */
     FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
     FM_GlobalData.ChildCurrentCC  = 0;
-
-} /* End of FM_ChildDecompressCmd() */
+}
 
 #endif
 
@@ -810,8 +799,7 @@ void FM_ChildConcatCmd(const FM_ChildQueueEntry_t *CmdArgs)
     /* Report previous child task activity */
     FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
     FM_GlobalData.ChildCurrentCC  = 0;
-
-} /* End of FM_ChildConcatCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -969,8 +957,7 @@ void FM_ChildFileInfoCmd(FM_ChildQueueEntry_t *CmdArgs)
     /* Report previous child task activity */
     FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
     FM_GlobalData.ChildCurrentCC  = 0;
-
-} /* End of FM_ChildFileInfoCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -1009,8 +996,7 @@ void FM_ChildCreateDirCmd(const FM_ChildQueueEntry_t *CmdArgs)
     /* Report previous child task activity */
     FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
     FM_GlobalData.ChildCurrentCC  = 0;
-
-} /* End of FM_ChildCreateDirCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -1088,8 +1074,7 @@ void FM_ChildDeleteDirCmd(const FM_ChildQueueEntry_t *CmdArgs)
     /* Report previous child task activity */
     FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
     FM_GlobalData.ChildCurrentCC  = 0;
-
-} /* End of FM_ChildDeleteDirCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -1149,8 +1134,7 @@ void FM_ChildDirListFileCmd(const FM_ChildQueueEntry_t *CmdArgs)
     /* Report previous child task activity */
     FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
     FM_GlobalData.ChildCurrentCC  = 0;
-
-} /* End of FM_ChildDirListFileCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -1283,8 +1267,7 @@ void FM_ChildDirListPktCmd(const FM_ChildQueueEntry_t *CmdArgs)
     /* Report previous child task activity */
     FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
     FM_GlobalData.ChildCurrentCC  = 0;
-
-} /* End of FM_ChildDirListPktCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -1319,8 +1302,7 @@ void FM_ChildSetPermissionsCmd(const FM_ChildQueueEntry_t *CmdArgs)
     /* Report previous child task activity */
     FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
     FM_GlobalData.ChildCurrentCC  = 0;
-
-} /* End of FM_ChildSetPermissionsCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -1400,8 +1382,7 @@ bool FM_ChildDirListFileInit(osal_id_t *FileHandlePtr, const char *Directory, co
     }
 
     return CommandResult;
-
-} /* End FM_ChildDirListFileInit */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -1537,8 +1518,7 @@ void FM_ChildDirListFileLoop(osal_id_t DirId, osal_id_t FileHandle, const char *
                           "%s command: wrote %d of %d names: dir = %s, filename = %s", CmdText, (int)FileEntries,
                           (int)DirEntries, Directory, Filename);
     }
-
-} /* End of FM_ChildDirListFileLoop */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -1569,8 +1549,7 @@ int32 FM_ChildSizeTimeMode(const char *Filename, uint32 *FileSize, uint32 *FileT
     }
 
     return Result;
-
-} /* End of FM_ChildSizeTimeMode */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -1603,8 +1582,4 @@ void FM_ChildSleepStat(const char *Filename, FM_DirListEntry_t *DirListData, int
         DirListData->ModifyTime = 0;
         DirListData->Mode       = 0;
     }
-} /* FM_ChildSleepStat */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/fm_cmd_utils.c
+++ b/fsw/src/fm_cmd_utils.c
@@ -62,8 +62,7 @@ bool FM_IsValidCmdPktLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLeng
     }
 
     return FunctionResult;
-
-} /* FM_IsValidCmdPktLength */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -84,8 +83,7 @@ bool FM_VerifyOverwrite(uint16 Overwrite, uint32 EventID, const char *CmdText)
     }
 
     return FunctionResult;
-
-} /* End FM_VerifyOverwrite */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -121,8 +119,7 @@ static void LoadOpenFileData(osal_id_t ObjId, void *CallbackArg)
 
         OpenFileCount++;
     }
-
-} /* End LoadOpenFileData() */
+}
 
 uint32 FM_GetOpenFilesData(const FM_OpenFilesEntry_t *OpenFilesData)
 {
@@ -131,8 +128,7 @@ uint32 FM_GetOpenFilesData(const FM_OpenFilesEntry_t *OpenFilesData)
     OS_ForEachObject(OS_OBJECT_CREATOR_ANY, LoadOpenFileData, (void *)OpenFilesData);
 
     return OpenFileCount;
-
-} /* End FM_GetOpenFilesData */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -149,7 +145,6 @@ static void SearchOpenFileData(osal_id_t ObjId, void *CallbackArg)
 
     if (OS_IdentifyObject(ObjId) == OS_OBJECT_TYPE_OS_STREAM)
     {
-
         /* Get system info for each file descriptor table entry */
         /* If the FD table entry is valid - then the file is open */
         if (OS_FDGetInfo(ObjId, &FdProp) == OS_SUCCESS)
@@ -160,8 +155,7 @@ static void SearchOpenFileData(osal_id_t ObjId, void *CallbackArg)
             }
         }
     }
-
-} /* End SearchOpenFileData() */
+}
 
 uint32 FM_GetFilenameState(char *Filename, uint32 BufferSize, bool FileInfoCmd)
 {
@@ -240,8 +234,7 @@ uint32 FM_GetFilenameState(char *Filename, uint32 BufferSize, bool FileInfoCmd)
     }
 
     return FilenameState;
-
-} /* End FM_GetFilenameState */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -264,8 +257,7 @@ uint32 FM_VerifyNameValid(char *Name, uint32 BufferSize, uint32 EventID, const c
     }
 
     return FilenameState;
-
-} /* End FM_VerifyNameValid */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -369,8 +361,7 @@ bool FM_VerifyFileState(FM_File_States State, char *Filename, uint32 BufferSize,
     }
 
     return Result;
-
-} /* End FM_VerifyFileState */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -380,10 +371,8 @@ bool FM_VerifyFileState(FM_File_States State, char *Filename, uint32 BufferSize,
 
 bool FM_VerifyFileClosed(char *Filename, uint32 BufferSize, uint32 EventID, const char *CmdText)
 {
-
     return FM_VerifyFileState(FM_FILE_CLOSED, Filename, BufferSize, EventID, CmdText);
-
-} /* End FM_VerifyFileClosed */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -393,10 +382,8 @@ bool FM_VerifyFileClosed(char *Filename, uint32 BufferSize, uint32 EventID, cons
 
 bool FM_VerifyFileExists(char *Filename, uint32 BufferSize, uint32 EventID, const char *CmdText)
 {
-
     return FM_VerifyFileState(FM_FILE_EXISTS, Filename, BufferSize, EventID, CmdText);
-
-} /* End FM_VerifyFileExists */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -406,10 +393,8 @@ bool FM_VerifyFileExists(char *Filename, uint32 BufferSize, uint32 EventID, cons
 
 bool FM_VerifyFileNoExist(char *Filename, uint32 BufferSize, uint32 EventID, const char *CmdText)
 {
-
     return FM_VerifyFileState(FM_FILE_NOEXIST, Filename, BufferSize, EventID, CmdText);
-
-} /* End FM_VerifyFileNoExist */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -419,10 +404,8 @@ bool FM_VerifyFileNoExist(char *Filename, uint32 BufferSize, uint32 EventID, con
 
 bool FM_VerifyFileNotOpen(char *Filename, uint32 BufferSize, uint32 EventID, const char *CmdText)
 {
-
     return FM_VerifyFileState(FM_FILE_NOTOPEN, Filename, BufferSize, EventID, CmdText);
-
-} /* End FM_VerifyFileNotOpen */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -432,10 +415,8 @@ bool FM_VerifyFileNotOpen(char *Filename, uint32 BufferSize, uint32 EventID, con
 
 bool FM_VerifyDirExists(char *Directory, uint32 BufferSize, uint32 EventID, const char *CmdText)
 {
-
     return FM_VerifyFileState(FM_DIR_EXISTS, Directory, BufferSize, EventID, CmdText);
-
-} /* End FM_VerifyDirExists */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -445,10 +426,8 @@ bool FM_VerifyDirExists(char *Directory, uint32 BufferSize, uint32 EventID, cons
 
 bool FM_VerifyDirNoExist(char *Name, uint32 BufferSize, uint32 EventID, const char *CmdText)
 {
-
     return FM_VerifyFileState(FM_DIR_NOEXIST, Name, BufferSize, EventID, CmdText);
-
-} /* End FM_VerifyDirNoExist */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -498,8 +477,7 @@ bool FM_VerifyChildTask(uint32 EventID, const char *CmdText)
     }
 
     return Result;
-
-} /* End FM_VerifyChildTask */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -528,8 +506,7 @@ void FM_InvokeChildTask(void)
         /* Signal child task to call command handler */
         OS_CountSemGive(FM_GlobalData.ChildSemaphore);
     }
-
-} /* End of FM_InvokeChildTask */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -561,9 +538,4 @@ void FM_AppendPathSep(char *Directory, uint32 BufferSize)
             strcat(Directory, "/");
         }
     }
-
-} /* End of FM_AppendPathSep */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/fm_cmds.c
+++ b/fsw/src/fm_cmds.c
@@ -61,8 +61,7 @@ bool FM_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return CommandResult;
-
-} /* End of FM_NoopCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -93,8 +92,7 @@ bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return CommandResult;
-
-} /* End of FM_ResetCountersCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -161,8 +159,7 @@ bool FM_CopyFileCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return CommandResult;
-
-} /* End of FM_CopyFileCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -230,8 +227,7 @@ bool FM_MoveFileCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return CommandResult;
-
-} /* End of FM_MoveFileCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -286,8 +282,7 @@ bool FM_RenameFileCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return CommandResult;
-
-} /* End of FM_RenameFileCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -333,8 +328,7 @@ bool FM_DeleteFileCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return CommandResult;
-
-} /* End of FM_DeleteFileCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -389,8 +383,7 @@ bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return CommandResult;
-
-} /* End of FM_DeleteAllFilesCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -444,8 +437,7 @@ bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return CommandResult;
-
-} /* End of FM_DecompressFileCmd() */
+}
 
 #endif
 
@@ -508,8 +500,7 @@ bool FM_ConcatFilesCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return CommandResult;
-
-} /* End of FM_ConcatFilesCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -570,8 +561,7 @@ bool FM_GetFileInfoCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return CommandResult;
-
-} /* End of FM_GetFileInfoCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -607,8 +597,7 @@ bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return CommandResult;
-
-} /* End of FM_GetOpenFilesCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -654,8 +643,7 @@ bool FM_CreateDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return CommandResult;
-
-} /* End of FM_CreateDirectoryCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -701,8 +689,7 @@ bool FM_DeleteDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return CommandResult;
-
-} /* End of FM_DeleteDirectoryCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -781,8 +768,7 @@ bool FM_GetDirListFileCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return CommandResult;
-
-} /* End of FM_GetDirListFileCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -840,8 +826,7 @@ bool FM_GetDirListPktCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return CommandResult;
-
-} /* End of FM_GetDirListPktCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -915,8 +900,7 @@ bool FM_GetFreeSpaceCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return CommandResult;
-
-} /* End of FM_GetFreeSpaceCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -985,8 +969,7 @@ bool FM_SetTableStateCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return CommandResult;
-
-} /* End of FM_SetTableStateCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -1036,9 +1019,4 @@ bool FM_SetPermissionsCmd(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return CommandResult;
-
-} /* End of FM_SetPermissionsCmd() */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/fm_msg.h
+++ b/fsw/src/fm_msg.h
@@ -49,7 +49,6 @@
 typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
-
 } FM_HousekeepingCmd_t;
 
 /**
@@ -59,9 +58,7 @@ typedef struct
  */
 typedef struct
 {
-
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
-
 } FM_NoopCmd_t;
 
 /**
@@ -71,9 +68,7 @@ typedef struct
  */
 typedef struct
 {
-
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
-
 } FM_ResetCmd_t;
 
 /**
@@ -83,13 +78,11 @@ typedef struct
  */
 typedef struct
 {
-
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
     uint16 Overwrite;               /**< \brief Allow overwrite */
     char   Source[OS_MAX_PATH_LEN]; /**< \brief Source filename */
     char   Target[OS_MAX_PATH_LEN]; /**< \brief Target filename */
-
 } FM_CopyFileCmd_t;
 
 /**
@@ -104,7 +97,6 @@ typedef struct
     uint16 Overwrite;               /**< \brief Allow overwrite */
     char   Source[OS_MAX_PATH_LEN]; /**< \brief Source filename */
     char   Target[OS_MAX_PATH_LEN]; /**< \brief Target filename */
-
 } FM_MoveFileCmd_t;
 
 /**
@@ -118,7 +110,6 @@ typedef struct
 
     char Source[OS_MAX_PATH_LEN]; /**< \brief Source filename */
     char Target[OS_MAX_PATH_LEN]; /**< \brief Target filename */
-
 } FM_RenameFileCmd_t;
 
 /**
@@ -130,7 +121,6 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader;                 /**< \brief Command header */
     char                    Filename[OS_MAX_PATH_LEN]; /**< \brief Delete filename */
-
 } FM_DeleteFileCmd_t;
 
 /**
@@ -142,7 +132,6 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader;                  /**< \brief Command header */
     char                    Directory[OS_MAX_PATH_LEN]; /**< \brief Directory name */
-
 } FM_DeleteAllCmd_t;
 
 /**
@@ -155,7 +144,6 @@ typedef struct
     CFE_MSG_CommandHeader_t CmdHeader;               /**< \brief Command header */
     char                    Source[OS_MAX_PATH_LEN]; /**< \brief Source filename */
     char                    Target[OS_MAX_PATH_LEN]; /**< \brief Target filename */
-
 } FM_DecompressCmd_t;
 
 /**
@@ -170,7 +158,6 @@ typedef struct
     char Source1[OS_MAX_PATH_LEN]; /**< \brief Source 1 filename */
     char Source2[OS_MAX_PATH_LEN]; /**< \brief Source 2 filename */
     char Target[OS_MAX_PATH_LEN];  /**< \brief Target filename */
-
 } FM_ConcatCmd_t;
 
 /**
@@ -184,7 +171,6 @@ typedef struct
 
     char   Filename[OS_MAX_PATH_LEN]; /**< \brief Filename */
     uint32 FileInfoCRC;               /**< \brief File info CRC method */
-
 } FM_GetFileInfoCmd_t;
 
 /**
@@ -194,9 +180,7 @@ typedef struct
  */
 typedef struct
 {
-
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
-
 } FM_GetOpenFilesCmd_t;
 
 /**
@@ -209,7 +193,6 @@ typedef struct
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
     char Directory[OS_MAX_PATH_LEN]; /**< \brief Directory name */
-
 } FM_CreateDirCmd_t;
 
 /**
@@ -222,7 +205,6 @@ typedef struct
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
     char Directory[OS_MAX_PATH_LEN]; /**< \brief Directory name */
-
 } FM_DeleteDirCmd_t;
 
 /**
@@ -238,7 +220,6 @@ typedef struct
     char  Filename[OS_MAX_PATH_LEN];  /**< \brief Filename */
     uint8 GetSizeTimeMode;            /**< \brief Option to query size, time, and mode of files (CPU intensive) */
     uint8 Spare01[3];                 /**< \brief Padding to 32 bit boundary */
-
 } FM_GetDirFileCmd_t;
 
 /**
@@ -248,14 +229,12 @@ typedef struct
  */
 typedef struct
 {
-
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
     char   Directory[OS_MAX_PATH_LEN]; /**< \brief Directory name */
     uint32 DirListOffset;              /**< \brief Index of 1st dir entry to put in packet */
     uint8  GetSizeTimeMode;            /**< \brief Option to query size, time, and mode of files (CPU intensive) */
     uint8  Spare01[3];                 /**< \brief Padding to 32 bit boundary */
-
 } FM_GetDirPktCmd_t;
 
 /**
@@ -265,9 +244,7 @@ typedef struct
  */
 typedef struct
 {
-
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
-
 } FM_GetFreeSpaceCmd_t;
 
 /**
@@ -281,7 +258,6 @@ typedef struct
 
     uint32 TableEntryIndex; /**< \brief Table entry index */
     uint32 TableEntryState; /**< \brief New table entry state */
-
 } FM_SetTableStateCmd_t;
 
 /**
@@ -295,7 +271,6 @@ typedef struct
 
     char   FileName[OS_MAX_PATH_LEN]; /**< \brief File name of the permissions to set */
     uint32 Mode;                      /**< \brief Permissions, passed directly to OS_chmod */
-
 } FM_SetPermCmd_t;
 
 /**\}*/
@@ -350,7 +325,6 @@ typedef struct
     char   DirName[OS_MAX_PATH_LEN]; /**< \brief Directory name */
     uint32 DirEntries;               /**< \brief Number of entries in the directory */
     uint32 FileEntries;              /**< \brief Number of entries written to output file */
-
 } FM_DirListFileStats_t;
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -389,7 +363,6 @@ typedef struct
 {
     char LogicalName[OS_MAX_PATH_LEN]; /**< \brief Logical filename */
     char AppName[OS_MAX_API_NAME];     /**< \brief Application that opened file */
-
 } FM_OpenFilesEntry_t;
 
 /**
@@ -455,7 +428,6 @@ typedef struct
 
     uint8 ChildCurrentCC;  /**< \brief Command code currently executing */
     uint8 ChildPreviousCC; /**< \brief Command code previously executed */
-
 } FM_HousekeepingPkt_t;
 
 /**\}*/
@@ -473,7 +445,6 @@ typedef struct
 {
     uint32 State;                 /**< \brief Table entry enable/disable state */
     char   Name[OS_MAX_PATH_LEN]; /**< \brief File system name = string */
-
 } FM_TableEntry_t;
 
 /**
@@ -482,7 +453,6 @@ typedef struct
 typedef struct
 {
     FM_TableEntry_t FileSys[FM_TABLE_ENTRY_COUNT]; /**< \brief One entry for each file system */
-
 } FM_FreeSpaceTable_t;
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -569,7 +539,6 @@ typedef struct
     FS_LIB_Decompress_State_t DecompressState;
 
 #endif
-
 } FM_GlobalData_t;
 
 /** \brief File Manager global */

--- a/fsw/src/fm_tbl.c
+++ b/fsw/src/fm_tbl.c
@@ -60,8 +60,7 @@ int32 FM_TableInit(void)
     }
 
     return Status;
-
-} /* End FM_TableInit */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -177,8 +176,7 @@ int32 FM_ValidateTable(FM_FreeSpaceTable_t *TablePtr)
     }
 
     return Result;
-
-} /* End FM_ValidateTable */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -201,8 +199,7 @@ void FM_AcquireTablePointers(void)
         /* Make sure we don't try to use the empty table buffer */
         FM_GlobalData.FreeSpaceTablePtr = (FM_FreeSpaceTable_t *)NULL;
     }
-
-} /* End FM_AcquireTablePointers */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -217,9 +214,4 @@ void FM_ReleaseTablePointers(void)
 
     /* Prevent table pointer use while released */
     FM_GlobalData.FreeSpaceTablePtr = (FM_FreeSpaceTable_t *)NULL;
-
-} /* End FM_ReleaseTablePointers */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/tables/fm_freespace.c
+++ b/fsw/tables/fm_freespace.c
@@ -99,7 +99,3 @@ FM_FreeSpaceTable_t FM_FreeSpaceTable = {
         },
     },
 };
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/unit-test/fm_app_tests.c
+++ b/unit-test/fm_app_tests.c
@@ -62,14 +62,14 @@
  * ********************************/
 void Test_FM_AppMain_AppInitNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(CFE_EVS_Register), !CFE_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_RunLoop), false);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_AppMain());
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_ES_RunLoop, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_STUB_COUNT(CFE_ES_ExitApp, 1);
@@ -81,15 +81,15 @@ void Test_FM_AppMain_AppInitNotSuccess(void)
 
 void Test_FM_AppMain_SBReceiveBufferDefaultOption(void)
 {
-    // Arrange
+    /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_RunLoop), true);
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_RunLoop), 2, false);
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_ReceiveBuffer), -1);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_AppMain());
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_ES_RunLoop, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 3);
     UtAssert_STUB_COUNT(CFE_ES_ExitApp, 1);
@@ -104,15 +104,15 @@ void Test_FM_AppMain_SBReceiveBufferDefaultOption(void)
 
 void Test_FM_AppMain_SBReceiveBufferIsTimeOut(void)
 {
-    // Arrange
+    /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_RunLoop), true);
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_RunLoop), 2, false);
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_ReceiveBuffer), CFE_SB_TIME_OUT);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_AppMain());
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_ES_RunLoop, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_STUB_COUNT(CFE_ES_ExitApp, 1);
@@ -125,7 +125,7 @@ void Test_FM_AppMain_SBReceiveBufferIsTimeOut(void)
 
 void Test_FM_AppMain_ReceiveBufferSuccessBufPtrIsNull(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_SB_Buffer_t *sbbufptr = NULL;
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_RunLoop), true);
@@ -133,10 +133,10 @@ void Test_FM_AppMain_ReceiveBufferSuccessBufPtrIsNull(void)
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_ReceiveBuffer), CFE_SUCCESS);
     UT_SetDataBuffer(UT_KEY(CFE_SB_ReceiveBuffer), &sbbufptr, sizeof(sbbufptr), false);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_AppMain());
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_ES_RunLoop, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 3);
     UtAssert_STUB_COUNT(CFE_ES_ExitApp, 1);
@@ -149,7 +149,7 @@ void Test_FM_AppMain_ReceiveBufferSuccessBufPtrIsNull(void)
 
 void Test_FM_AppMain_BufPtrNotEqualNull(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_SB_Buffer_t  sbbuf;
     CFE_SB_Buffer_t *sbbufptr = &sbbuf;
     CFE_SB_MsgId_t   msgid    = CFE_SB_INVALID_MSG_ID;
@@ -160,10 +160,10 @@ void Test_FM_AppMain_BufPtrNotEqualNull(void)
     UT_SetDataBuffer(UT_KEY(CFE_SB_ReceiveBuffer), &sbbufptr, sizeof(sbbufptr), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &msgid, sizeof(msgid), false);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_AppMain());
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_ES_RunLoop, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 3);
     UtAssert_STUB_COUNT(CFE_ES_ExitApp, 1);
@@ -179,7 +179,7 @@ void Test_FM_AppMain_BufPtrNotEqualNull(void)
  * ********************************/
 void Test_FM_ProcessPkt_CheckMessageReturnHKRequest(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_SB_MsgId_t msgid = CFE_SB_ValueToMsgId(FM_SEND_HK_MID);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &msgid, sizeof(msgid), false);
@@ -188,24 +188,24 @@ void Test_FM_ProcessPkt_CheckMessageReturnHKRequest(void)
     /* Act */
     UtAssert_VOIDCALL(FM_ProcessPkt(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(FM_IsValidCmdPktLength, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void Test_FM_ProcessPkt_CheckMessageReturnGroundCommand(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_SB_MsgId_t    msgid    = CFE_SB_ValueToMsgId(FM_CMD_MID);
     CFE_MSG_FcnCode_t fcn_code = -1;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &msgid, sizeof(msgid), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ProcessPkt(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 1);
     UtAssert_STUB_COUNT(CFE_MSG_GetFcnCode, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -215,15 +215,15 @@ void Test_FM_ProcessPkt_CheckMessageReturnGroundCommand(void)
 
 void Test_FM_ProcessPkt_CheckDefaultSwitchMessage(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_SB_MsgId_t msgid = CFE_SB_INVALID_MSG_ID;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &msgid, sizeof(msgid), false);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ProcessPkt(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_MID_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -234,13 +234,13 @@ void Test_FM_ProcessPkt_CheckDefaultSwitchMessage(void)
  * *******************************/
 void Test_FM_AppInit_EVSRegisterNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(CFE_EVS_Register), !CFE_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_INT32_EQ(FM_AppInit(), !CFE_SUCCESS);
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_Register, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_STARTUP_EVENTS_ERR_EID);
@@ -249,14 +249,14 @@ void Test_FM_AppInit_EVSRegisterNotSuccess(void)
 
 void Test_FM_AppInit_CreatePipeFail(void)
 {
-    // Arrange
+    /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(CFE_EVS_Register), CFE_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_CreatePipe), !CFE_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_INT32_EQ(FM_AppInit(), !CFE_SUCCESS);
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_Register, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_STUB_COUNT(CFE_SB_CreatePipe, 1);
@@ -266,15 +266,15 @@ void Test_FM_AppInit_CreatePipeFail(void)
 
 void Test_FM_AppInit_HKSubscribeFail(void)
 {
-    // Arrange
+    /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(CFE_EVS_Register), CFE_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_CreatePipe), CFE_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_Subscribe), !CFE_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_INT32_EQ(FM_AppInit(), !CFE_SUCCESS);
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_Register, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_STUB_COUNT(CFE_SB_CreatePipe, 1);
@@ -285,16 +285,16 @@ void Test_FM_AppInit_HKSubscribeFail(void)
 
 void Test_FM_AppInit_GroundCmdSubscribeFail(void)
 {
-    // Arrange
+    /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(CFE_EVS_Register), CFE_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_CreatePipe), CFE_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_Subscribe), CFE_SUCCESS);
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_Subscribe), 2, !CFE_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_INT32_EQ(FM_AppInit(), !CFE_SUCCESS);
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_Register, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_STUB_COUNT(CFE_SB_CreatePipe, 1);
@@ -305,16 +305,16 @@ void Test_FM_AppInit_GroundCmdSubscribeFail(void)
 
 void Test_FM_AppInit_TableInitNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(CFE_EVS_Register), CFE_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_CreatePipe), CFE_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_Subscribe), CFE_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(FM_TableInit), !CFE_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_INT32_EQ(FM_AppInit(), !CFE_SUCCESS);
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_Register, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_STUB_COUNT(CFE_SB_CreatePipe, 1);
@@ -325,16 +325,16 @@ void Test_FM_AppInit_TableInitNotSuccess(void)
 
 void Test_FM_AppInit_TableInitSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(CFE_EVS_Register), CFE_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_CreatePipe), CFE_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_Subscribe), CFE_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(FM_TableInit), CFE_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_INT32_EQ(FM_AppInit(), CFE_SUCCESS);
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_Register, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_STUB_COUNT(CFE_SB_CreatePipe, 1);
@@ -349,7 +349,7 @@ void Test_FM_AppInit_TableInitSuccess(void)
  * *******************************/
 void Test_FM_ReportHK_ReturnPktLengthTrue(void)
 {
-    // Arrange
+    /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_GetOpenFilesData), 0);
 
@@ -363,10 +363,10 @@ void Test_FM_ReportHK_ReturnPktLengthTrue(void)
     FM_GlobalData.ChildCurrentCC      = 7;
     FM_GlobalData.ChildPreviousCC     = 8;
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ReportHK(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(FM_IsValidCmdPktLength, 1);
     UtAssert_STUB_COUNT(FM_ReleaseTablePointers, 1);
     UtAssert_STUB_COUNT(FM_AcquireTablePointers, 1);
@@ -387,13 +387,13 @@ void Test_FM_ReportHK_ReturnPktLengthTrue(void)
 
 void Test_FM_ReportHK_ReturnPktLengthFalse(void)
 {
-    // Arrange
+    /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ReportHK(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(FM_ReleaseTablePointers, 0);
     UtAssert_STUB_COUNT(CFE_SB_TransmitMsg, 0);
 }
@@ -403,16 +403,16 @@ void Test_FM_ReportHK_ReturnPktLengthFalse(void)
  * *******************************/
 void Test_FM_ProcessCmd_NoopCmdCCReturn(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_MSG_FcnCode_t fcn_code = FM_NOOP_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_NoopCmd), true);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_NoopCmd, 1);
     UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
@@ -421,16 +421,16 @@ void Test_FM_ProcessCmd_NoopCmdCCReturn(void)
 
 void Test_FM_ProcessCmd_ResetCountersCCReturn(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_MSG_FcnCode_t fcn_code = FM_RESET_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_ResetCountersCmd), true);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_ResetCountersCmd, 1);
     UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 0);
@@ -439,16 +439,16 @@ void Test_FM_ProcessCmd_ResetCountersCCReturn(void)
 
 void Test_FM_ProcessCmd_CopyFileCCReturn(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_MSG_FcnCode_t fcn_code = FM_COPY_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_CopyFileCmd), true);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_CopyFileCmd, 1);
     UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
@@ -457,16 +457,16 @@ void Test_FM_ProcessCmd_CopyFileCCReturn(void)
 
 void Test_FM_ProcessCmd_MoveFileCCReturn(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_MSG_FcnCode_t fcn_code = FM_MOVE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_MoveFileCmd), true);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_MoveFileCmd, 1);
     UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
@@ -475,16 +475,16 @@ void Test_FM_ProcessCmd_MoveFileCCReturn(void)
 
 void Test_FM_ProcessCmd_RenameFileCCReturn(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_MSG_FcnCode_t fcn_code = FM_RENAME_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_RenameFileCmd), true);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_RenameFileCmd, 1);
     UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
@@ -493,16 +493,16 @@ void Test_FM_ProcessCmd_RenameFileCCReturn(void)
 
 void Test_FM_ProcessCmd_DeleteFileCCReturn(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_MSG_FcnCode_t fcn_code = FM_DELETE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_DeleteFileCmd), true);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_DeleteFileCmd, 1);
     UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
@@ -511,16 +511,16 @@ void Test_FM_ProcessCmd_DeleteFileCCReturn(void)
 
 void Test_FM_ProcessCmd_DeleteAllFilesCCReturn(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_MSG_FcnCode_t fcn_code = FM_DELETE_ALL_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_DeleteAllFilesCmd), true);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_DeleteAllFilesCmd, 1);
     UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
@@ -530,16 +530,16 @@ void Test_FM_ProcessCmd_DeleteAllFilesCCReturn(void)
 #ifdef FM_INCLUDE_DECOMPRESS
 void Test_FM_ProcessCmd_DecompressFileCCReturn(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_MSG_FcnCode_t fcn_code = FM_DECOMPRESS_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_DecompressFileCmd), true);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_DecompressFileCmd, 1);
     UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
@@ -549,16 +549,16 @@ void Test_FM_ProcessCmd_DecompressFileCCReturn(void)
 
 void Test_FM_ProcessCmd_ConcatFilesCCReturn(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_MSG_FcnCode_t fcn_code = FM_CONCAT_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_ConcatFilesCmd), true);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_ConcatFilesCmd, 1);
     UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
@@ -567,16 +567,16 @@ void Test_FM_ProcessCmd_ConcatFilesCCReturn(void)
 
 void Test_FM_ProcessCmd_GetFileInfoCCReturn(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_MSG_FcnCode_t fcn_code = FM_GET_FILE_INFO_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_GetFileInfoCmd), true);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_GetFileInfoCmd, 1);
     UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
@@ -585,16 +585,16 @@ void Test_FM_ProcessCmd_GetFileInfoCCReturn(void)
 
 void Test_FM_ProcessCmd_GetOpenFilesCCReturn(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_MSG_FcnCode_t fcn_code = FM_GET_OPEN_FILES_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_GetOpenFilesCmd), true);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_GetOpenFilesCmd, 1);
     UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
@@ -603,16 +603,16 @@ void Test_FM_ProcessCmd_GetOpenFilesCCReturn(void)
 
 void Test_FM_ProcessCmd_CreateDirectoryCCReturn(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_MSG_FcnCode_t fcn_code = FM_CREATE_DIR_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_CreateDirectoryCmd), true);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_CreateDirectoryCmd, 1);
     UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
@@ -621,16 +621,16 @@ void Test_FM_ProcessCmd_CreateDirectoryCCReturn(void)
 
 void Test_FM_ProcessCmd_DeleteDirectoryCCReturn(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_MSG_FcnCode_t fcn_code = FM_DELETE_DIR_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_DeleteDirectoryCmd), true);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_DeleteDirectoryCmd, 1);
     UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
@@ -639,16 +639,16 @@ void Test_FM_ProcessCmd_DeleteDirectoryCCReturn(void)
 
 void Test_FM_ProcessCmd_GetDirListFileCCReturn(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_MSG_FcnCode_t fcn_code = FM_GET_DIR_FILE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_GetDirListFileCmd), true);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_GetDirListFileCmd, 1);
     UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
@@ -657,16 +657,16 @@ void Test_FM_ProcessCmd_GetDirListFileCCReturn(void)
 
 void Test_FM_ProcessCmd_GetDirListPktCCReturn(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_MSG_FcnCode_t fcn_code = FM_GET_DIR_PKT_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_GetDirListPktCmd), true);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_GetDirListPktCmd, 1);
     UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
@@ -675,16 +675,16 @@ void Test_FM_ProcessCmd_GetDirListPktCCReturn(void)
 
 void Test_FM_ProcessCmd_GetFreeSpaceCCReturn(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_MSG_FcnCode_t fcn_code = FM_GET_FREE_SPACE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_GetFreeSpaceCmd), true);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_GetFreeSpaceCmd, 1);
     UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
@@ -693,16 +693,16 @@ void Test_FM_ProcessCmd_GetFreeSpaceCCReturn(void)
 
 void Test_FM_ProcessCmd_SetTableStateCCReturn(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_MSG_FcnCode_t fcn_code = FM_SET_TABLE_STATE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_SetTableStateCmd), true);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_SetTableStateCmd, 1);
     UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
@@ -711,16 +711,16 @@ void Test_FM_ProcessCmd_SetTableStateCCReturn(void)
 
 void Test_FM_ProcessCmd_SetPermissionsCCReturn(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_MSG_FcnCode_t fcn_code = FM_SET_FILE_PERM_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_SetPermissionsCmd), true);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_SetPermissionsCmd, 1);
     UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
@@ -729,15 +729,15 @@ void Test_FM_ProcessCmd_SetPermissionsCCReturn(void)
 
 void Test_FM_ProcessCmd_DefaultReturn(void)
 {
-    // Arrange
+    /* Arrange */
     CFE_MSG_FcnCode_t fcn_code = -1;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 0);
     UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 1);
@@ -863,6 +863,7 @@ void add_FM_ReportHK_tests(void)
     UtTest_Add(Test_FM_ReportHK_ReturnPktLengthFalse, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_ReportHK_ReturnPktLengthFalse");
 }
+
 /*
  * Register the test cases to execute with the unit test tool
  */

--- a/unit-test/fm_child_tests.c
+++ b/unit-test/fm_child_tests.c
@@ -76,10 +76,10 @@ void UT_FM_Child_Cmd_Assert(int32 cmd_ctr, int32 cmderr_ctr, int32 cmdwarn_ctr, 
  * ***************/
 void Test_FM_ChildInit_CountSemCreateNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(OS_CountSemCreate), !CFE_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_INT32_EQ(FM_ChildInit(), !CFE_SUCCESS);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -88,10 +88,10 @@ void Test_FM_ChildInit_CountSemCreateNotSuccess(void)
 
 void Test_FM_ChildInit_MutSemCreateNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(OS_MutSemCreate), !CFE_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_INT32_EQ(FM_ChildInit(), !CFE_SUCCESS);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -100,10 +100,10 @@ void Test_FM_ChildInit_MutSemCreateNotSuccess(void)
 
 void Test_FM_ChildInit_MuteSemCreateSuccess_CreateChildTaskNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_CreateChildTask), !CFE_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_INT32_EQ(FM_ChildInit(), !CFE_SUCCESS);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -122,19 +122,19 @@ void Test_FM_ChildInit_ReturnSuccess(void)
  * ***************/
 void Test_FM_ChildTask_ChildLoopCalled(void)
 {
-    // Arrange
+    /* Arrange */
     FM_GlobalData.ChildSemaphore = FM_UT_OBJID_1;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_CountSemTake), !CFE_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildTask());
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_STUB_COUNT(CFE_ES_ExitChildTask, 1);
 
-    // Assert
-    // SendEvent called once in ChildTask and should be called once in ChildLoop
+    /* Assert */
+    /* SendEvent called once in ChildTask and should be called once in ChildLoop */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CHILD_INIT_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_CHILD_TERM_SEM_ERR_EID);
@@ -146,14 +146,14 @@ void Test_FM_ChildTask_ChildLoopCalled(void)
  * ***************/
 void Test_FM_ChildProcess_ChildReadIndexGreaterChildQDepth(void)
 {
-    // Arrange
+    /* Arrange */
     FM_GlobalData.ChildReadIndex                                       = FM_CHILD_QUEUE_DEPTH - 1;
     FM_GlobalData.ChildQueue[FM_GlobalData.ChildReadIndex].CommandCode = -1;
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildProcess());
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildReadIndex, 0);
 
@@ -164,13 +164,13 @@ void Test_FM_ChildProcess_ChildReadIndexGreaterChildQDepth(void)
 
 void Test_FM_ChildProcess_FMCopyCC(void)
 {
-    // Arrange
+    /* Arrange */
     FM_GlobalData.ChildQueue[0].CommandCode = FM_COPY_CC;
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildProcess());
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, FM_GlobalData.ChildQueue[0].CommandCode);
 
     UtAssert_STUB_COUNT(OS_cp, 1);
@@ -181,13 +181,13 @@ void Test_FM_ChildProcess_FMCopyCC(void)
 
 void Test_FM_ChildProcess_FMMoveCC(void)
 {
-    // Arrange
+    /* Arrange */
     FM_GlobalData.ChildQueue[0].CommandCode = FM_MOVE_CC;
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildProcess());
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, FM_GlobalData.ChildQueue[0].CommandCode);
 
     UtAssert_STUB_COUNT(OS_mv, 1);
@@ -198,13 +198,13 @@ void Test_FM_ChildProcess_FMMoveCC(void)
 
 void Test_FM_ChildProcess_FMRenameCC(void)
 {
-    // Arrange
+    /* Arrange */
     FM_GlobalData.ChildQueue[0].CommandCode = FM_RENAME_CC;
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildProcess());
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, FM_GlobalData.ChildQueue[0].CommandCode);
 
     UtAssert_STUB_COUNT(OS_rename, 1);
@@ -215,13 +215,13 @@ void Test_FM_ChildProcess_FMRenameCC(void)
 
 void Test_FM_ChildProcess_FMDeleteCC(void)
 {
-    // Arrange
+    /* Arrange */
     FM_GlobalData.ChildQueue[0].CommandCode = FM_DELETE_CC;
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildProcess());
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, FM_GlobalData.ChildQueue[0].CommandCode);
 
     UtAssert_STUB_COUNT(OS_remove, 1);
@@ -232,15 +232,15 @@ void Test_FM_ChildProcess_FMDeleteCC(void)
 
 void Test_FM_ChildProcess_FMDeleteAllCC(void)
 {
-    // Arrange
+    /* Arrange */
     FM_GlobalData.ChildQueue[0].CommandCode = FM_DELETE_ALL_CC;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryOpen), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildProcess());
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, FM_GlobalData.ChildQueue[0].CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -253,15 +253,15 @@ void Test_FM_ChildProcess_FMDeleteAllCC(void)
 #ifdef FM_INCLUDE_DECOMPRESS
 void Test_FM_ChildProcess_FMDecompressCC(void)
 {
-    // Arrange
+    /* Arrange */
     FM_GlobalData.ChildQueue[0].CommandCode = FM_DECOMPRESS_CC;
 
     UT_SetDefaultReturnValue(UT_KEY(FS_LIB_Decompress), !CFE_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildProcess());
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, FM_GlobalData.ChildQueue[0].CommandCode);
 
     UtAssert_STUB_COUNT(FS_LIB_Decompress, 1);
@@ -273,16 +273,16 @@ void Test_FM_ChildProcess_FMDecompressCC(void)
 
 void Test_FM_ChildProcess_FMConcatCC(void)
 {
-    // Arrange
+    /* Arrange */
     FM_GlobalData.ChildQueue[0].CommandCode = FM_CONCAT_CC;
     FM_GlobalData.ChildCurrentCC            = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_cp), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildProcess());
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, FM_GlobalData.ChildQueue[0].CommandCode);
 
     UtAssert_STUB_COUNT(OS_cp, 1);
@@ -293,16 +293,16 @@ void Test_FM_ChildProcess_FMConcatCC(void)
 
 void Test_FM_ChildProcess_FMCreateDirCC(void)
 {
-    // Arrange
+    /* Arrange */
     FM_GlobalData.ChildQueue[0].CommandCode = FM_CREATE_DIR_CC;
     FM_GlobalData.ChildCurrentCC            = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_mkdir), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildProcess());
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, FM_GlobalData.ChildQueue[0].CommandCode);
 
     UtAssert_STUB_COUNT(OS_mkdir, 1);
@@ -313,16 +313,16 @@ void Test_FM_ChildProcess_FMCreateDirCC(void)
 
 void Test_FM_ChildProcess_FMDeleteDirCC(void)
 {
-    // Arrange
+    /* Arrange */
     FM_GlobalData.ChildQueue[0].CommandCode = FM_DELETE_DIR_CC;
     FM_GlobalData.ChildCurrentCC            = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryOpen), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildProcess());
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, FM_GlobalData.ChildQueue[0].CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -333,7 +333,7 @@ void Test_FM_ChildProcess_FMDeleteDirCC(void)
 
 void Test_FM_ChildProcess_FMGetFileInfoCC(void)
 {
-    // Arrange
+    /* Arrange */
     FM_GlobalData.ChildQueue[0].CommandCode   = FM_GET_FILE_INFO_CC;
     FM_GlobalData.ChildQueue[0].FileInfoCRC   = !FM_IGNORE_CRC;
     FM_GlobalData.ChildQueue[0].FileInfoState = FM_NAME_IS_FILE_OPEN;
@@ -341,10 +341,10 @@ void Test_FM_ChildProcess_FMGetFileInfoCC(void)
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_MSG_Init), CFE_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildProcess());
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, FM_GlobalData.ChildQueue[0].CommandCode);
 
     UtAssert_STUB_COUNT(CFE_MSG_Init, 1);
@@ -358,16 +358,16 @@ void Test_FM_ChildProcess_FMGetFileInfoCC(void)
 
 void Test_FM_ChildProcess_FMGetDirListsFileCC(void)
 {
-    // Arrange
+    /* Arrange */
     FM_GlobalData.ChildQueue[0].CommandCode = FM_GET_DIR_FILE_CC;
     FM_GlobalData.ChildCurrentCC            = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryOpen), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildProcess());
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, FM_GlobalData.ChildQueue[0].CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -378,16 +378,16 @@ void Test_FM_ChildProcess_FMGetDirListsFileCC(void)
 
 void Test_FM_ChildProcess_FMGetDirListsPktCC(void)
 {
-    // Arrange
+    /* Arrange */
     FM_GlobalData.ChildQueue[0].CommandCode = FM_GET_DIR_PKT_CC;
     FM_GlobalData.ChildCurrentCC            = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryRead), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildProcess());
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, FM_GlobalData.ChildQueue[0].CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -401,16 +401,16 @@ void Test_FM_ChildProcess_FMGetDirListsPktCC(void)
 
 void Test_FM_ChildProcess_FMSetFilePermCC(void)
 {
-    // Arrange
+    /* Arrange */
     FM_GlobalData.ChildQueue[0].CommandCode = FM_SET_FILE_PERM_CC;
     FM_GlobalData.ChildCurrentCC            = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_chmod), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildProcess());
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, FM_GlobalData.ChildQueue[0].CommandCode);
 
     UtAssert_STUB_COUNT(OS_chmod, 1);
@@ -421,13 +421,13 @@ void Test_FM_ChildProcess_FMSetFilePermCC(void)
 
 void Test_FM_ChildProcess_DefaultSwitch(void)
 {
-    // Arrange
+    /* Arrange */
     FM_GlobalData.ChildQueue[0].CommandCode = -1;
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildProcess());
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -442,10 +442,10 @@ void Test_FM_ChildCopyCmd_OScpIsSuccess(void)
 {
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_COPY_CC};
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildCopyCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -457,13 +457,13 @@ void Test_FM_ChildCopyCmd_OScpNotSuccess(void)
 {
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_COPY_CC};
 
-    // Arrange
+    /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(OS_cp), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildCopyCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -478,13 +478,13 @@ void Test_FM_ChildMoveCmd_OSmvNotSuccess(void)
 {
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_MOVE_CC};
 
-    // Arrange
+    /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(OS_mv), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildMoveCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_mv, 1);
@@ -497,10 +497,10 @@ void Test_FM_ChildMoveCmd_OSmvSuccess(void)
 {
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_MOVE_CC};
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildMoveCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_mv, 1);
@@ -514,13 +514,13 @@ void Test_FM_ChildMoveCmd_OSmvSuccess(void)
  * ***************/
 void Test_FM_ChildRenameCmd_OSRenameSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_RENAME_CC};
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildRenameCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_rename, 1);
@@ -531,15 +531,15 @@ void Test_FM_ChildRenameCmd_OSRenameSuccess(void)
 
 void Test_FM_ChildRenameCmd_OSRenameNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_RENAME_CC};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_rename), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildRenameCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_rename, 1);
@@ -553,13 +553,13 @@ void Test_FM_ChildRenameCmd_OSRenameNotSuccess(void)
  * ***************/
 void Test_FM_ChildDeleteCmd_OSRemoveSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_CC};
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDeleteCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_remove, 1);
@@ -570,15 +570,15 @@ void Test_FM_ChildDeleteCmd_OSRemoveSuccess(void)
 
 void Test_FM_ChildDeleteCmd_OSRemoveNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_CC};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_remove), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDeleteCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_remove, 1);
@@ -592,16 +592,16 @@ void Test_FM_ChildDeleteCmd_OSRemoveNotSuccess(void)
  * ***************/
 void Test_FM_ChildDeleteAllCmd_DirOpenNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryOpen), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -613,16 +613,16 @@ void Test_FM_ChildDeleteAllCmd_DirOpenNotSuccess(void)
 
 void Test_FM_ChildDeleteAllCmd_DirReadNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryRead), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -634,7 +634,7 @@ void Test_FM_ChildDeleteAllCmd_DirReadNotSuccess(void)
 
 void Test_FM_ChildDeleteAllCmd_DirEntryThisDirectory(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = FM_THIS_DIRECTORY};
@@ -642,10 +642,10 @@ void Test_FM_ChildDeleteAllCmd_DirEntryThisDirectory(void)
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -659,7 +659,7 @@ void Test_FM_ChildDeleteAllCmd_DirEntryThisDirectory(void)
 
 void Test_FM_ChildDeleteAllCmd_DirEntryParentDirectory(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = FM_PARENT_DIRECTORY};
@@ -667,10 +667,10 @@ void Test_FM_ChildDeleteAllCmd_DirEntryParentDirectory(void)
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -684,7 +684,7 @@ void Test_FM_ChildDeleteAllCmd_DirEntryParentDirectory(void)
 
 void Test_FM_ChildDeleteAllCmd_PathFilenameLengthGreaterMaxPthLen(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_ALL_CC,
                                         .Source1     = "dummy_source1",
                                         .Source2     = "dummy_source2HasAReallyLongNameSomeSayTheNameIs42Characters"};
@@ -693,10 +693,10 @@ void Test_FM_ChildDeleteAllCmd_PathFilenameLengthGreaterMaxPthLen(void)
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -712,7 +712,7 @@ void Test_FM_ChildDeleteAllCmd_PathFilenameLengthGreaterMaxPthLen(void)
 
 void Test_FM_ChildDeleteAllCmd_InvalidFilenameState(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = "ThisDirectory"};
@@ -721,10 +721,10 @@ void Test_FM_ChildDeleteAllCmd_InvalidFilenameState(void)
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_GetFilenameState), FM_NAME_IS_INVALID);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -740,7 +740,7 @@ void Test_FM_ChildDeleteAllCmd_InvalidFilenameState(void)
 
 void Test_FM_ChildDeleteAllCmd_NotInUseFilenameState(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = "ThisDirectory"};
@@ -749,10 +749,10 @@ void Test_FM_ChildDeleteAllCmd_NotInUseFilenameState(void)
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_GetFilenameState), FM_NAME_IS_NOT_IN_USE);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -768,7 +768,7 @@ void Test_FM_ChildDeleteAllCmd_NotInUseFilenameState(void)
 
 void Test_FM_ChildDeleteAllCmd_DirectoryFilenameState(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = "ThisDirectory"};
@@ -777,10 +777,10 @@ void Test_FM_ChildDeleteAllCmd_DirectoryFilenameState(void)
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_GetFilenameState), FM_NAME_IS_DIRECTORY);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -796,7 +796,7 @@ void Test_FM_ChildDeleteAllCmd_DirectoryFilenameState(void)
 
 void Test_FM_ChildDeleteAllCmd_OpenFilenameState(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = "ThisDirectory"};
@@ -805,10 +805,10 @@ void Test_FM_ChildDeleteAllCmd_OpenFilenameState(void)
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_GetFilenameState), FM_NAME_IS_FILE_OPEN);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -824,7 +824,7 @@ void Test_FM_ChildDeleteAllCmd_OpenFilenameState(void)
 
 void Test_FM_ChildDeleteAllCmd_ClosedFilename_OSRmNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = "ThisDirectory"};
@@ -834,10 +834,10 @@ void Test_FM_ChildDeleteAllCmd_ClosedFilename_OSRmNotSuccess(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_GetFilenameState), FM_NAME_IS_FILE_CLOSED);
     UT_SetDefaultReturnValue(UT_KEY(OS_remove), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -854,7 +854,7 @@ void Test_FM_ChildDeleteAllCmd_ClosedFilename_OSRmNotSuccess(void)
 
 void Test_FM_ChildDeleteAllCmd_ClosedFilename_OSrmSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = "ThisDirectory"};
@@ -863,10 +863,10 @@ void Test_FM_ChildDeleteAllCmd_ClosedFilename_OSrmSuccess(void)
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_GetFilenameState), FM_NAME_IS_FILE_CLOSED);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -882,19 +882,19 @@ void Test_FM_ChildDeleteAllCmd_ClosedFilename_OSrmSuccess(void)
 
 void Test_FM_ChildDeleteAllCmd_FilenameStateDefaultReturn(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = "ThisDirectory"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_GetFilenameState), -1); // default case
+    UT_SetDefaultReturnValue(UT_KEY(FM_GetFilenameState), -1); /* default case */
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -914,15 +914,15 @@ void Test_FM_ChildDeleteAllCmd_FilenameStateDefaultReturn(void)
 #ifdef FM_INCLUDE_DECOMPRESS
 void Test_FM_ChildDecompressCmd_FSDecompressSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DECOMPRESS_CC};
 
     FM_GlobalData.ChildCurrentCC = 1;
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDecompressCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(FS_LIB_Decompress, 1);
@@ -933,16 +933,16 @@ void Test_FM_ChildDecompressCmd_FSDecompressSuccess(void)
 
 void Test_FM_ChildDecompressCmd_FSDecompressNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DECOMPRESS_CC};
 
     FM_GlobalData.ChildCurrentCC = 1;
     UT_SetDefaultReturnValue(UT_KEY(FS_LIB_Decompress), !CFE_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDecompressCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(FS_LIB_Decompress, 1);
@@ -957,17 +957,17 @@ void Test_FM_ChildDecompressCmd_FSDecompressNotSuccess(void)
  * ***************/
 void Test_FM_ChildConcatCmd_OSCpNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_CONCAT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
     FM_GlobalData.ChildCurrentCC = 1;
     UT_SetDefaultReturnValue(UT_KEY(OS_cp), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildConcatCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_cp, 1);
@@ -978,16 +978,16 @@ void Test_FM_ChildConcatCmd_OSCpNotSuccess(void)
 
 void Test_FM_ChildConcatCmd_OSOpenCreateSourceNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_CONCAT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildConcatCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_cp, 1);
@@ -1000,16 +1000,16 @@ void Test_FM_ChildConcatCmd_OSOpenCreateSourceNotSuccess(void)
 
 void Test_FM_ChildConcatCmd_OSOpenCreateTargetNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_CONCAT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_OpenCreate), 2, !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildConcatCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_cp, 1);
@@ -1023,16 +1023,16 @@ void Test_FM_ChildConcatCmd_OSOpenCreateTargetNotSuccess(void)
 
 void Test_FM_ChildConcatCmd_OSReadBytesZero(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_CONCAT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_read), 0);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildConcatCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_read, 1);
@@ -1047,16 +1047,16 @@ void Test_FM_ChildConcatCmd_OSReadBytesZero(void)
 
 void Test_FM_ChildConcatCmd_OSReadBytesLessThanZero(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_CONCAT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_read), -1);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildConcatCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_read, 1);
@@ -1071,17 +1071,17 @@ void Test_FM_ChildConcatCmd_OSReadBytesLessThanZero(void)
 
 void Test_FM_ChildConcatCmd_BytesWrittenNotEqualBytesRead(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_CONCAT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_read), 1);
     UT_SetDefaultReturnValue(UT_KEY(OS_write), 0);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildConcatCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_read, 1);
@@ -1096,7 +1096,7 @@ void Test_FM_ChildConcatCmd_BytesWrittenNotEqualBytesRead(void)
 
 void Test_FM_ChildConcatCmd_CopyInProgressTrueLoopCountEqualChildFileLoopCount(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_CONCAT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
@@ -1104,10 +1104,10 @@ void Test_FM_ChildConcatCmd_CopyInProgressTrueLoopCountEqualChildFileLoopCount(v
     UT_SetDefaultReturnValue(UT_KEY(OS_write), 1);
     UT_SetDeferredRetcode(UT_KEY(OS_read), FM_CHILD_FILE_LOOP_COUNT + 1, -1);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildConcatCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_read, FM_CHILD_FILE_LOOP_COUNT + 1);
@@ -1126,17 +1126,17 @@ void Test_FM_ChildConcatCmd_CopyInProgressTrueLoopCountEqualChildFileLoopCount(v
  * ***************/
 void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualIgnoreCRC(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode   = FM_GET_FILE_INFO_CC,
                                         .Source1       = "dummy_source1",
                                         .Source2       = "dummy_source2",
                                         .FileInfoCRC   = FM_IGNORE_CRC,
                                         .FileInfoState = FM_NAME_IS_FILE_CLOSED};
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildFileInfoCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_OpenCreate, 0);
@@ -1147,17 +1147,17 @@ void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualIgnoreCRC(void)
 
 void Test_FM_ChildFileInfoCmd_FileInfoStateIsNotFileClosed(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode   = FM_GET_FILE_INFO_CC,
                                         .Source1       = "dummy_source1",
                                         .Source2       = "dummy_source2",
                                         .FileInfoCRC   = CFE_MISSION_ES_CRC_8,
                                         .FileInfoState = FM_NAME_IS_FILE_OPEN};
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildFileInfoCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_OpenCreate, 0);
@@ -1170,7 +1170,7 @@ void Test_FM_ChildFileInfoCmd_FileInfoStateIsNotFileClosed(void)
 
 void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualMission8(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode   = FM_GET_FILE_INFO_CC,
                                         .Source1       = "dummy_source1",
                                         .Source2       = "dummy_source2",
@@ -1179,10 +1179,10 @@ void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualMission8(void)
 
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildFileInfoCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_OpenCreate, 1);
@@ -1195,7 +1195,7 @@ void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualMission8(void)
 
 void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualMission16(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode   = FM_GET_FILE_INFO_CC,
                                         .Source1       = "dummy_source1",
                                         .Source2       = "dummy_source2",
@@ -1204,10 +1204,10 @@ void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualMission16(void)
 
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildFileInfoCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_OpenCreate, 1);
@@ -1220,7 +1220,7 @@ void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualMission16(void)
 
 void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualMission32(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode   = FM_GET_FILE_INFO_CC,
                                         .Source1       = "dummy_source1",
                                         .Source2       = "dummy_source2",
@@ -1229,10 +1229,10 @@ void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualMission32(void)
 
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildFileInfoCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_OpenCreate, 1);
@@ -1245,17 +1245,17 @@ void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualMission32(void)
 
 void Test_FM_ChildFileInfoCmd_FileInfoCRCNotEqualToAnyMissionES(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode   = FM_GET_FILE_INFO_CC,
                                         .Source1       = "dummy_source1",
                                         .Source2       = "dummy_source2",
                                         .FileInfoCRC   = -1,
                                         .FileInfoState = FM_NAME_IS_FILE_CLOSED};
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildFileInfoCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_OpenCreate, 0);
@@ -1268,7 +1268,7 @@ void Test_FM_ChildFileInfoCmd_FileInfoCRCNotEqualToAnyMissionES(void)
 
 void Test_FM_ChildFileInfoCmd_OSOpenCreateTrueBytesReadZero(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode   = FM_GET_FILE_INFO_CC,
                                         .Source1       = "dummy_source1",
                                         .Source2       = "dummy_source2",
@@ -1277,10 +1277,10 @@ void Test_FM_ChildFileInfoCmd_OSOpenCreateTrueBytesReadZero(void)
 
     UT_SetDefaultReturnValue(UT_KEY(OS_read), 0);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildFileInfoCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_read, 1);
@@ -1293,7 +1293,7 @@ void Test_FM_ChildFileInfoCmd_OSOpenCreateTrueBytesReadZero(void)
 
 void Test_FM_ChildFileInfoCmd_BytesReadLessThanZero(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode   = FM_GET_FILE_INFO_CC,
                                         .Source1       = "dummy_source1",
                                         .Source2       = "dummy_source2",
@@ -1302,10 +1302,10 @@ void Test_FM_ChildFileInfoCmd_BytesReadLessThanZero(void)
 
     UT_SetDefaultReturnValue(UT_KEY(OS_read), -1);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildFileInfoCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_read, 1);
@@ -1320,7 +1320,7 @@ void Test_FM_ChildFileInfoCmd_BytesReadLessThanZero(void)
 
 void Test_FM_ChildFileInfoCmd_BytesReadGreaterThanZero(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode   = FM_GET_FILE_INFO_CC,
                                         .Source1       = "dummy_source1",
                                         .Source2       = "dummy_source2",
@@ -1331,10 +1331,10 @@ void Test_FM_ChildFileInfoCmd_BytesReadGreaterThanZero(void)
     UT_SetDeferredRetcode(UT_KEY(OS_read), FM_CHILD_FILE_LOOP_COUNT + 1, 0);
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_CalculateCRC), 0);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildFileInfoCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_read, FM_CHILD_FILE_LOOP_COUNT + 1);
@@ -1351,13 +1351,13 @@ void Test_FM_ChildFileInfoCmd_BytesReadGreaterThanZero(void)
  * ***************/
 void Test_FM_ChildCreateDirCmd_OSMkDirSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_CREATE_DIR_CC};
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildCreateDirCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_mkdir, 1);
@@ -1368,15 +1368,15 @@ void Test_FM_ChildCreateDirCmd_OSMkDirSuccess(void)
 
 void Test_FM_ChildCreateDirCmd_OSMkDirNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_CREATE_DIR_CC};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_mkdir), !CFE_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildCreateDirCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_mkdir, 1);
@@ -1390,15 +1390,15 @@ void Test_FM_ChildCreateDirCmd_OSMkDirNotSuccess(void)
  * ***************/
 void Test_FM_ChildDeleteDirCmd_OSDirectoryOpenNoSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_DIR_CC};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryOpen), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDeleteDirCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -1409,15 +1409,15 @@ void Test_FM_ChildDeleteDirCmd_OSDirectoryOpenNoSuccess(void)
 
 void Test_FM_ChildDeleteDirCmd_OSDirectoryReadNoSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_DIR_CC};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryRead), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDeleteDirCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -1430,17 +1430,17 @@ void Test_FM_ChildDeleteDirCmd_OSDirectoryReadNoSuccess(void)
 
 void Test_FM_ChildDeleteDirCmd_StrCmpThisDirectoryZero(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_DIR_CC};
     os_dirent_t          direntry    = {.FileName = FM_THIS_DIRECTORY};
 
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDeleteDirCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -1452,16 +1452,16 @@ void Test_FM_ChildDeleteDirCmd_StrCmpThisDirectoryZero(void)
 
 void Test_FM_ChildDeleteDirCmd_StrCmpParentDirectoryZero(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_DIR_CC};
     os_dirent_t          direntry    = {.FileName = FM_PARENT_DIRECTORY};
 
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDeleteDirCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -1473,15 +1473,15 @@ void Test_FM_ChildDeleteDirCmd_StrCmpParentDirectoryZero(void)
 
 void Test_FM_ChildDeleteDirCmd_RemoveTheDirIsTrueRmDirSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_DIR_CC};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryRead), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDeleteDirCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -1493,16 +1493,16 @@ void Test_FM_ChildDeleteDirCmd_RemoveTheDirIsTrueRmDirSuccess(void)
 
 void Test_FM_ChildDeleteDirCmd_RemoveDirTrueOSRmDirNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_DIR_CC};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryRead), !OS_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(OS_rmdir), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDeleteDirCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -1517,15 +1517,15 @@ void Test_FM_ChildDeleteDirCmd_RemoveDirTrueOSRmDirNotSuccess(void)
  * ***************/
 void Test_FM_ChildDirListFileCmd_OSDirOpenNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_GET_DIR_FILE_CC};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryOpen), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDirListFileCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -1537,16 +1537,16 @@ void Test_FM_ChildDirListFileCmd_OSDirOpenNotSuccess(void)
 
 void Test_FM_ChildDirListFileCmd_ChildDirListFileInitFalse(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_GET_DIR_FILE_CC, .Source1 = "dummy_source1", .Target = "dummy_target"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDirListFileCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -1559,16 +1559,16 @@ void Test_FM_ChildDirListFileCmd_ChildDirListFileInitFalse(void)
 
 void Test_FM_ChildDirListFileCmd_ChildDirListFileInitTrue(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_GET_DIR_FILE_CC, .Source1 = "dummy_source1", .Target = "dummy_target"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryRead), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDirListFileCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -1584,16 +1584,16 @@ void Test_FM_ChildDirListFileCmd_ChildDirListFileInitTrue(void)
  * ***************/
 void Test_FM_ChildDirListPktCmd_OSDirOpenNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_GET_DIR_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryOpen), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDirListPktCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -1604,16 +1604,16 @@ void Test_FM_ChildDirListPktCmd_OSDirOpenNotSuccess(void)
 
 void Test_FM_ChildDirListPktCmd_OSDirReadNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_GET_DIR_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryRead), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDirListPktCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -1626,7 +1626,7 @@ void Test_FM_ChildDirListPktCmd_OSDirReadNotSuccess(void)
 
 void Test_FM_ChildDirListPktCmd_DirEntryNameThisDirectory(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_GET_DIR_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = FM_THIS_DIRECTORY};
@@ -1634,10 +1634,10 @@ void Test_FM_ChildDirListPktCmd_DirEntryNameThisDirectory(void)
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDirListPktCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -1650,7 +1650,7 @@ void Test_FM_ChildDirListPktCmd_DirEntryNameThisDirectory(void)
 
 void Test_FM_ChildDirListPktCmd_DirEntryNameParentDirectory(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_GET_DIR_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = FM_PARENT_DIRECTORY};
@@ -1658,10 +1658,10 @@ void Test_FM_ChildDirListPktCmd_DirEntryNameParentDirectory(void)
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDirListPktCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -1674,7 +1674,7 @@ void Test_FM_ChildDirListPktCmd_DirEntryNameParentDirectory(void)
 
 void Test_FM_ChildDirListPktCmd_DirListOffsetNotExceeded(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_GET_DIR_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2", .DirListOffset = 1};
     os_dirent_t direntry = {.FileName = "filename"};
@@ -1682,10 +1682,10 @@ void Test_FM_ChildDirListPktCmd_DirListOffsetNotExceeded(void)
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDirListPktCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -1701,7 +1701,7 @@ void Test_FM_ChildDirListPktCmd_DirListOffsetNotExceeded(void)
 
 void Test_FM_ChildDirListPktCmd_DirListOffsetExceeded(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_GET_DIR_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry[FM_DIR_LIST_PKT_ENTRIES + 1];
@@ -1713,10 +1713,10 @@ void Test_FM_ChildDirListPktCmd_DirListOffsetExceeded(void)
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), sizeof(direntry) / sizeof(direntry[0]) + 1, !OS_SUCCESS);
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDirListPktCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -1732,7 +1732,7 @@ void Test_FM_ChildDirListPktCmd_DirListOffsetExceeded(void)
 
 void Test_FM_ChildDirListPktCmd_PathAndEntryLengthGreaterMaxPathLength(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_ALL_CC,
                                         .Source1     = "dummy_source1",
                                         .Source2 = "dummy_source2_has_a_long_name_to_make_path_length_longer_than_64"};
@@ -1741,10 +1741,10 @@ void Test_FM_ChildDirListPktCmd_PathAndEntryLengthGreaterMaxPathLength(void)
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDirListPktCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
@@ -1763,13 +1763,13 @@ void Test_FM_ChildDirListPktCmd_PathAndEntryLengthGreaterMaxPathLength(void)
  * ***************/
 void Test_FM_ChildSetPermissionsCmd_OSChmodSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_SET_FILE_PERM_CC};
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildSetPermissionsCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_chmod, 1);
@@ -1780,15 +1780,15 @@ void Test_FM_ChildSetPermissionsCmd_OSChmodSuccess(void)
 
 void Test_FM_ChildSetPermissionsCmd_OSChmodNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_SET_FILE_PERM_CC};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_chmod), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildSetPermissionsCmd(&queue_entry));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(OS_chmod, 1);
@@ -1802,17 +1802,17 @@ void Test_FM_ChildSetPermissionsCmd_OSChmodNotSuccess(void)
  * ***************/
 void Test_FM_ChildDirListFileInit_OSOpenCreateFail(void)
 {
-    // Arrange
+    /* Arrange */
     osal_id_t   fileid;
     const char *directory = "directory";
     const char *filename  = "filename";
 
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_BOOL_FALSE(FM_ChildDirListFileInit(&fileid, directory, filename));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, 0);
 
     UtAssert_STUB_COUNT(OS_OpenCreate, 1);
@@ -1825,7 +1825,7 @@ void Test_FM_ChildDirListFileInit_OSOpenCreateFail(void)
 
 void Test_FM_ChildDirListFileInit_FSWriteHeaderNotSameSizeFSHeadert(void)
 {
-    // Arrange
+    /* Arrange */
     osal_id_t   fileid;
     osal_id_t   LocalFileHandle = FM_UT_OBJID_1;
     const char *directory       = "directory";
@@ -1834,10 +1834,10 @@ void Test_FM_ChildDirListFileInit_FSWriteHeaderNotSameSizeFSHeadert(void)
     UT_SetDataBuffer(UT_KEY(OS_OpenCreate), &LocalFileHandle, sizeof(osal_id_t), false);
     UT_SetDefaultReturnValue(UT_KEY(CFE_FS_WriteHeader), sizeof(CFE_FS_Header_t) - 1);
 
-    // Act
+    /* Act */
     UtAssert_BOOL_FALSE(FM_ChildDirListFileInit(&fileid, directory, filename));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, 0);
 
     UtAssert_STUB_COUNT(OS_OpenCreate, 1);
@@ -1850,7 +1850,7 @@ void Test_FM_ChildDirListFileInit_FSWriteHeaderNotSameSizeFSHeadert(void)
 
 void Test_FM_ChildDirListFileInit_OSWriteNotSameSizeDirListFileStatst(void)
 {
-    // Arrange
+    /* Arrange */
     osal_id_t   fileid;
     const char *directory       = "directory";
     const char *filename        = "filename";
@@ -1859,10 +1859,10 @@ void Test_FM_ChildDirListFileInit_OSWriteNotSameSizeDirListFileStatst(void)
     UT_SetDataBuffer(UT_KEY(OS_OpenCreate), &LocalFileHandle, sizeof(osal_id_t), false);
     UT_SetDefaultReturnValue(UT_KEY(OS_write), sizeof(FM_DirListFileStats_t) - 1);
 
-    // Act
+    /* Act */
     UtAssert_BOOL_FALSE(FM_ChildDirListFileInit(&fileid, directory, filename));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, 0);
 
     UtAssert_STUB_COUNT(OS_OpenCreate, 1);
@@ -1876,15 +1876,15 @@ void Test_FM_ChildDirListFileInit_OSWriteNotSameSizeDirListFileStatst(void)
 
 void Test_FM_ChildDirListFileInit_OSWriteSameSizeDirListFileStatst(void)
 {
-    // Arrange
+    /* Arrange */
     osal_id_t   fileid;
     const char *directory = "directory";
     const char *filename  = "filename";
 
-    // Act
+    /* Act */
     UtAssert_BOOL_TRUE(FM_ChildDirListFileInit(&fileid, directory, filename));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 0, 0, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -1899,13 +1899,13 @@ void Test_FM_ChildDirListFileInit_OSWriteSameSizeDirListFileStatst(void)
  * ***************/
 void Test_FM_ChildDirListFileLoop_OSDirReadNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryRead), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDirListFileLoop(FM_UT_OBJID_1, FM_UT_OBJID_2, "dir", "dir/", "fname", false));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, 0);
 
     UtAssert_STUB_COUNT(OS_DirectoryRead, 1);
@@ -1921,16 +1921,16 @@ void Test_FM_ChildDirListFileLoop_OSDirReadNotSuccess(void)
 
 void Test_FM_ChildDirListFileLoop_OSDirEntryNameIsThisDirectory(void)
 {
-    // Arrange
+    /* Arrange */
     os_dirent_t direntry = {.FileName = FM_THIS_DIRECTORY};
 
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDirListFileLoop(FM_UT_OBJID_1, FM_UT_OBJID_2, "dir", "dir/", "fname", false));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, 0);
 
     UtAssert_STUB_COUNT(OS_DirectoryRead, 2);
@@ -1946,16 +1946,16 @@ void Test_FM_ChildDirListFileLoop_OSDirEntryNameIsThisDirectory(void)
 
 void Test_FM_ChildDirListFileLoop_OSDirEntryNameIsParentDirectory(void)
 {
-    // Arrange
+    /* Arrange */
     os_dirent_t direntry = {.FileName = FM_PARENT_DIRECTORY};
 
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDirListFileLoop(FM_UT_OBJID_1, FM_UT_OBJID_2, "dir", "dir/", "fname", false));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, 0);
 
     UtAssert_STUB_COUNT(OS_DirectoryRead, 2);
@@ -1968,7 +1968,7 @@ void Test_FM_ChildDirListFileLoop_OSDirEntryNameIsParentDirectory(void)
 
 void Test_FM_ChildDirListFileLoop_PathLengthAndEntryLengthGreaterMaxPathLen(void)
 {
-    // Arrange
+    /* Arrange */
     char        dirwithsep[OS_MAX_PATH_LEN];
     os_dirent_t direntry = {.FileName = "directory_nam"};
 
@@ -1978,7 +1978,7 @@ void Test_FM_ChildDirListFileLoop_PathLengthAndEntryLengthGreaterMaxPathLen(void
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDirListFileLoop(FM_UT_OBJID_1, FM_UT_OBJID_2, "dir", dirwithsep, "fname", false));
 
     /* Assert */
@@ -2005,10 +2005,10 @@ void Test_FM_ChildDirListFileLoop_FileEntriesGreaterFMDirListFileEntries(void)
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), entrycnt + 1, !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDirListFileLoop(FM_UT_OBJID_1, FM_UT_OBJID_2, "dir", "dir/", "fname", false));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, 0);
 
     UtAssert_STUB_COUNT(OS_DirectoryRead, entrycnt + 1);
@@ -2024,17 +2024,17 @@ void Test_FM_ChildDirListFileLoop_FileEntriesGreaterFMDirListFileEntries(void)
 
 void Test_FM_ChildDirListFileLoop_BytesWrittenNotEqualWriteLength(void)
 {
-    // Arrange
+    /* Arrange */
     os_dirent_t direntry = {.FileName = "directory_nam"};
 
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
     UT_SetDefaultReturnValue(UT_KEY(OS_write), sizeof(FM_DirListEntry_t));
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDirListFileLoop(FM_UT_OBJID_1, FM_UT_OBJID_2, "dir", "dir/", "fname", false));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, 0);
 
     UtAssert_STUB_COUNT(OS_DirectoryRead, 2);
@@ -2050,17 +2050,17 @@ void Test_FM_ChildDirListFileLoop_BytesWrittenNotEqualWriteLength(void)
 
 void Test_FM_ChildDirListFileLoop_BytesWrittenNotEqualWriteLengthInLoop(void)
 {
-    // Arrange
+    /* Arrange */
     os_dirent_t direntry = {.FileName = "directory_nam"};
 
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(OS_write), sizeof(FM_DirListEntry_t) - 1);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildDirListFileLoop(FM_UT_OBJID_1, FM_UT_OBJID_2, "dir", "dir/", "fname", false));
 
-    // Assert
+    /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -2079,17 +2079,17 @@ void Test_FM_ChildDirListFileLoop_BytesWrittenNotEqualWriteLengthInLoop(void)
  * ***************/
 void Test_FM_ChildSizeTimeMode_OsStatNoSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     uint32 filesize = 1;
     uint32 filetime = 1;
     uint32 filemode = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_stat), !OS_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_INT32_EQ(FM_ChildSizeTimeMode("fname", &filesize, &filetime, &filemode), !OS_SUCCESS);
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(OS_stat, 1);
     UtAssert_UINT32_EQ(filesize, 0);
     UtAssert_UINT32_EQ(filetime, 0);
@@ -2098,7 +2098,7 @@ void Test_FM_ChildSizeTimeMode_OsStatNoSuccess(void)
 
 void Test_FM_ChildSizeTimeMode_OSFilestateTimeDefined(void)
 {
-    // Arrange
+    /* Arrange */
     uint32 filesize = 0;
     uint32 filetime = 0;
     uint32 filemode = 0;
@@ -2108,10 +2108,10 @@ void Test_FM_ChildSizeTimeMode_OSFilestateTimeDefined(void)
 
     UT_SetDataBuffer(UT_KEY(OS_stat), &filestatus, sizeof(filestatus), false);
 
-    // Act
+    /* Act */
     UtAssert_INT32_EQ(FM_ChildSizeTimeMode("fname", &filesize, &filetime, &filemode), OS_SUCCESS);
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(OS_stat, 1);
     UtAssert_UINT32_EQ(filetime, OS_FILESTAT_TIME(filestatus));
     UtAssert_UINT32_EQ(filesize, OS_FILESTAT_SIZE(filestatus));
@@ -2123,13 +2123,13 @@ void Test_FM_ChildSizeTimeMode_OSFilestateTimeDefined(void)
  * ***************/
 void Test_FM_ChildLoop_CountSemTakeNotSuccess(void)
 {
-    // Arrange
+    /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(OS_CountSemTake), !CFE_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildLoop());
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(OS_CountSemTake, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CHILD_TERM_SEM_ERR_EID);
@@ -2139,10 +2139,10 @@ void Test_FM_ChildLoop_CountSemTakeNotSuccess(void)
 
 void Test_FM_ChildLoop_ChildQCountEqualZero(void)
 {
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildLoop());
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(OS_CountSemTake, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CHILD_TERM_EMPTYQ_ERR_EID);
@@ -2152,14 +2152,14 @@ void Test_FM_ChildLoop_ChildQCountEqualZero(void)
 
 void Test_FM_ChildLoop_ChildReadIndexEqualChildQDepth(void)
 {
-    // Arrange
+    /* Arrange */
     FM_GlobalData.ChildQueueCount = 1;
     FM_GlobalData.ChildReadIndex  = FM_CHILD_QUEUE_DEPTH;
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildLoop());
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(OS_CountSemTake, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CHILD_TERM_QIDX_ERR_EID);
@@ -2169,7 +2169,7 @@ void Test_FM_ChildLoop_ChildReadIndexEqualChildQDepth(void)
 
 void Test_FM_ChildLoop_CountSemTakeSuccessDefault(void)
 {
-    // Arrange
+    /* Arrange */
     FM_GlobalData.ChildQueueCount    = 1;
     FM_GlobalData.ChildReadIndex     = 0;
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = -1};
@@ -2177,10 +2177,10 @@ void Test_FM_ChildLoop_CountSemTakeSuccessDefault(void)
     FM_GlobalData.ChildQueue[0] = queue_entry;
     UT_SetDeferredRetcode(UT_KEY(OS_CountSemTake), 2, !CFE_SUCCESS);
 
-    // Act
+    /* Act */
     UtAssert_VOIDCALL(FM_ChildLoop());
 
-    // Assert
+    /* Assert */
     UtAssert_STUB_COUNT(OS_CountSemTake, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CHILD_EXE_ERR_EID);
@@ -2196,11 +2196,11 @@ void Test_FM_ChildLoop_CountSemTakeSuccessDefault(void)
 
 void Test_FM_ChildSleepStat_getSizeTimeModeFalse(void)
 {
-    // Arrange
+    /* Arrange */
     FM_DirListEntry_t DirListData    = {.EntrySize = 1, .ModifyTime = 1, .Mode = 1};
     int32             FilesTillSleep = 1;
 
-    // Assert
+    /* Assert */
     UtAssert_VOIDCALL(FM_ChildSleepStat("fname", &DirListData, &FilesTillSleep, false));
     UtAssert_INT32_EQ(DirListData.EntrySize, 0);
     UtAssert_INT32_EQ(DirListData.ModifyTime, 0);
@@ -2209,23 +2209,23 @@ void Test_FM_ChildSleepStat_getSizeTimeModeFalse(void)
 
 void Test_FM_ChildSleepStat_FilesTillSleepPositive(void)
 {
-    // Arrange
+    /* Arrange */
     FM_DirListEntry_t DirListData           = {.EntrySize = 1, .ModifyTime = 1, .Mode = 1};
     int32             FilesTillSleep        = FM_CHILD_STAT_SLEEP_FILECOUNT + 1;
     int32             FilesTillSleep_before = FilesTillSleep;
 
-    // Assert
+    /* Assert */
     UtAssert_VOIDCALL(FM_ChildSleepStat("fname", &DirListData, &FilesTillSleep, true));
     UtAssert_INT32_EQ(FilesTillSleep, FilesTillSleep_before - 1);
 }
 
 void Test_FM_ChildSleepStat_FilesTillSleepLTEQZero(void)
 {
-    // Arrange
+    /* Arrange */
     FM_DirListEntry_t DirListData    = {.EntrySize = 1, .ModifyTime = 1, .Mode = 1};
     int32             FilesTillSleep = 0;
 
-    // Assert
+    /* Assert */
     UtAssert_VOIDCALL(FM_ChildSleepStat("fname", &DirListData, &FilesTillSleep, true));
     UtAssert_STUB_COUNT(OS_TaskDelay, 1);
     UtAssert_INT32_EQ(FilesTillSleep, FM_CHILD_STAT_SLEEP_FILECOUNT - 1);
@@ -2445,7 +2445,6 @@ void add_FM_ChildCreateDirCmd_tests(void)
 
 void add_FM_ChildDeleteDirCmd_tests(void)
 {
-
     UtTest_Add(Test_FM_ChildDeleteDirCmd_OSDirectoryOpenNoSuccess, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_ChildDeleteDirCmd_OSDirectoryOpenNoSuccess");
 

--- a/unit-test/fm_cmds_tests.c
+++ b/unit-test/fm_cmds_tests.c
@@ -87,7 +87,6 @@ void Test_FM_NoopCmd_Success(void)
 
 void Test_FM_NoopCmd_BadLength(void)
 {
-
     UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
 
     bool Result = FM_NoopCmd(&UT_CmdBuf.Buf);
@@ -214,7 +213,6 @@ void Test_FM_CopyFileCmd_Success(void)
 
 void Test_FM_CopyFileCmd_BadLength(void)
 {
-
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
@@ -238,7 +236,6 @@ void Test_FM_CopyFileCmd_BadLength(void)
 
 void Test_FM_CopyFileCmd_BadOverwrite(void)
 {
-
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
@@ -262,7 +259,6 @@ void Test_FM_CopyFileCmd_BadOverwrite(void)
 
 void Test_FM_CopyFileCmd_SourceNotExist(void)
 {
-
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
@@ -286,7 +282,6 @@ void Test_FM_CopyFileCmd_SourceNotExist(void)
 
 void Test_FM_CopyFileCmd_NoOverwriteTargetExists(void)
 {
-
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
@@ -310,7 +305,6 @@ void Test_FM_CopyFileCmd_NoOverwriteTargetExists(void)
 
 void Test_FM_CopyFileCmd_OverwriteFileOpen(void)
 {
-
     UT_CmdBuf.CopyFileCmd.Overwrite         = 1;
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -335,7 +329,6 @@ void Test_FM_CopyFileCmd_OverwriteFileOpen(void)
 
 void Test_FM_CopyFileCmd_NoChildTask(void)
 {
-
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
@@ -383,7 +376,6 @@ void add_FM_CopyFileCmd_tests(void)
 
 void Test_FM_MoveFileCmd_Success(void)
 {
-
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
@@ -407,7 +399,6 @@ void Test_FM_MoveFileCmd_Success(void)
 
 void Test_FM_MoveFileCmd_BadLength(void)
 {
-
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
@@ -908,7 +899,6 @@ void add_FM_DeleteAllFilesCmd_tests(void)
 
 void Test_FM_DecompressFileCmd_Success(void)
 {
-
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
@@ -1311,7 +1301,6 @@ void Test_FM_GetOpenFilesCmd_Success(void)
 
 void Test_FM_GetOpenFilesCmd_BadLength(void)
 {
-
     UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
 
     bool Result = FM_GetOpenFilesCmd(&UT_CmdBuf.Buf);

--- a/unit-test/stubs/fm_app_stubs.c
+++ b/unit-test/stubs/fm_app_stubs.c
@@ -68,7 +68,7 @@ FM_GlobalData_t FM_GlobalData;
 void FM_AppMain(void)
 {
     UT_DEFAULT_IMPL(FM_AppMain);
-} /* End FM_AppMain */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -79,7 +79,7 @@ void FM_AppMain(void)
 int32 FM_AppInit(void)
 {
     return UT_DEFAULT_IMPL(FM_AppInit);
-} /* End of FM_AppInit() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -90,7 +90,7 @@ int32 FM_AppInit(void)
 void FM_ProcessPkt(const CFE_SB_Buffer_t *MessagePtr)
 {
     UT_DEFAULT_IMPL(FM_ProcessPkt);
-} /* End of FM_ProcessPkt */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -102,7 +102,7 @@ void FM_ProcessCmd(const CFE_SB_Buffer_t *MessagePtr)
 {
     UT_DEFAULT_IMPL(FM_ProcessCmd);
     UT_Stub_CopyFromLocal(UT_KEY(FM_ProcessCmd), &MessagePtr, sizeof(MessagePtr));
-} /* End of FM_ProcessCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -113,8 +113,4 @@ void FM_ProcessCmd(const CFE_SB_Buffer_t *MessagePtr)
 void FM_ReportHK(const CFE_MSG_CommandHeader_t *Msg)
 {
     UT_DEFAULT_IMPL(FM_ReportHK);
-} /* End of FM_ReportHK */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/stubs/fm_child_stubs.c
+++ b/unit-test/stubs/fm_child_stubs.c
@@ -66,7 +66,7 @@
 int32 FM_ChildInit(void)
 {
     return UT_DEFAULT_IMPL(FM_ChildInit);
-} /* End of FM_ChildInit() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -77,7 +77,7 @@ int32 FM_ChildInit(void)
 void FM_ChildTask(void)
 {
     UT_DEFAULT_IMPL(FM_ChildTask);
-} /* End of FM_ChildTask() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -88,7 +88,7 @@ void FM_ChildTask(void)
 void FM_ChildLoop(void)
 {
     UT_DEFAULT_IMPL(FM_ChildLoop);
-} /* End of FM_ChildLoop() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -99,7 +99,7 @@ void FM_ChildLoop(void)
 void FM_ChildProcess(void)
 {
     UT_DEFAULT_IMPL(FM_ChildProcess);
-} /* End of FM_ChildProcess() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -111,7 +111,7 @@ void FM_ChildCopyCmd(const FM_ChildQueueEntry_t *CmdArgs)
 {
     UT_Stub_RegisterContext(UT_KEY(FM_ChildCopyCmd), CmdArgs);
     UT_DEFAULT_IMPL(FM_ChildCopyCmd);
-} /* End of FM_ChildCopyCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -122,7 +122,7 @@ void FM_ChildCopyCmd(const FM_ChildQueueEntry_t *CmdArgs)
 void FM_ChildMoveCmd(const FM_ChildQueueEntry_t *CmdArgs)
 {
     UT_DEFAULT_IMPL(FM_ChildMoveCmd);
-} /* End of FM_ChildMoveCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -133,7 +133,7 @@ void FM_ChildMoveCmd(const FM_ChildQueueEntry_t *CmdArgs)
 void FM_ChildRenameCmd(const FM_ChildQueueEntry_t *CmdArgs)
 {
     UT_DEFAULT_IMPL(FM_ChildRenameCmd);
-} /* End of FM_ChildRenameCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -144,7 +144,7 @@ void FM_ChildRenameCmd(const FM_ChildQueueEntry_t *CmdArgs)
 void FM_ChildDeleteCmd(const FM_ChildQueueEntry_t *CmdArgs)
 {
     UT_DEFAULT_IMPL(FM_ChildDeleteCmd);
-} /* End of FM_ChildDeleteCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -155,7 +155,7 @@ void FM_ChildDeleteCmd(const FM_ChildQueueEntry_t *CmdArgs)
 void FM_ChildDeleteAllCmd(FM_ChildQueueEntry_t *CmdArgs)
 {
     UT_DEFAULT_IMPL(FM_ChildDeleteAllCmd);
-} /* End of FM_ChildDeleteAllCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -168,7 +168,7 @@ void FM_ChildDeleteAllCmd(FM_ChildQueueEntry_t *CmdArgs)
 void FM_ChildDecompressCmd(const FM_ChildQueueEntry_t *CmdArgs)
 {
     UT_DEFAULT_IMPL(FM_ChildDecompressCmd);
-} /* End of FM_ChildDecompressCmd() */
+}
 
 #endif
 
@@ -181,7 +181,7 @@ void FM_ChildDecompressCmd(const FM_ChildQueueEntry_t *CmdArgs)
 void FM_ChildConcatCmd(const FM_ChildQueueEntry_t *CmdArgs)
 {
     UT_DEFAULT_IMPL(FM_ChildConcatCmd);
-} /* End of FM_ChildConcatCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -192,7 +192,7 @@ void FM_ChildConcatCmd(const FM_ChildQueueEntry_t *CmdArgs)
 void FM_ChildFileInfoCmd(FM_ChildQueueEntry_t *CmdArgs)
 {
     UT_DEFAULT_IMPL(FM_ChildFileInfoCmd);
-} /* End of FM_ChildFileInfoCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -203,7 +203,7 @@ void FM_ChildFileInfoCmd(FM_ChildQueueEntry_t *CmdArgs)
 void FM_ChildCreateDirCmd(const FM_ChildQueueEntry_t *CmdArgs)
 {
     UT_DEFAULT_IMPL(FM_ChildCreateDirCmd);
-} /* End of FM_ChildCreateDirCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -214,8 +214,7 @@ void FM_ChildCreateDirCmd(const FM_ChildQueueEntry_t *CmdArgs)
 void FM_ChildDeleteDirCmd(const FM_ChildQueueEntry_t *CmdArgs)
 {
     UT_DEFAULT_IMPL(FM_ChildDeleteDirCmd);
-
-} /* End of FM_ChildDeleteDirCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -226,7 +225,7 @@ void FM_ChildDeleteDirCmd(const FM_ChildQueueEntry_t *CmdArgs)
 void FM_ChildDirListFileCmd(const FM_ChildQueueEntry_t *CmdArgs)
 {
     UT_DEFAULT_IMPL(FM_ChildDeleteDirCmd);
-} /* End of FM_ChildDirListFileCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -237,7 +236,7 @@ void FM_ChildDirListFileCmd(const FM_ChildQueueEntry_t *CmdArgs)
 void FM_ChildDirListPktCmd(const FM_ChildQueueEntry_t *CmdArgs)
 {
     UT_DEFAULT_IMPL(FM_ChildDirListPktCmd);
-} /* End of FM_ChildDirListPktCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -247,7 +246,7 @@ void FM_ChildDirListPktCmd(const FM_ChildQueueEntry_t *CmdArgs)
 void FM_ChildSetPermissionsCmd(const FM_ChildQueueEntry_t *CmdArgs)
 {
     UT_DEFAULT_IMPL(FM_ChildSetPermissionsCmd);
-} /* End of FM_ChildSetPermissionsCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -258,7 +257,7 @@ void FM_ChildSetPermissionsCmd(const FM_ChildQueueEntry_t *CmdArgs)
 bool FM_ChildDirListFileInit(osal_id_t *FileHandlePtr, const char *Directory, const char *Filename)
 {
     return UT_DEFAULT_IMPL(FM_ChildDirListFileInit);
-} /* End FM_ChildDirListFileInit */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -270,7 +269,7 @@ void FM_ChildDirListFileLoop(osal_id_t DirId, osal_id_t FileHandle, const char *
                              const char *Filename, uint8 getSizeTimeMode)
 {
     UT_DEFAULT_IMPL(FM_ChildDirListFileLoop);
-} /* End of FM_ChildDirListFileLoop */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -281,7 +280,7 @@ void FM_ChildDirListFileLoop(osal_id_t DirId, osal_id_t FileHandle, const char *
 int32 FM_ChildSizeTimeMode(const char *Filename, uint32 *FileSize, uint32 *FileTime, uint32 *FileMode)
 {
     return UT_DEFAULT_IMPL(FM_ChildSizeTimeMode);
-} /* End of FM_ChildSizeTimeMode */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -297,8 +296,4 @@ void FM_ChildSleepStat(const char *Filename, FM_DirListEntry_t *DirListData, int
     UT_Stub_RegisterContext(UT_KEY(FM_ChildSleepStat), FilesTillSleep);
     UT_Stub_RegisterContextGenericArg(UT_KEY(FM_ChildSleepStat), getSizeTimeMode);
     UT_DEFAULT_IMPL(FM_ChildSleepStat);
-} /* FM_ChildSleepStat */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/stubs/fm_cmd_utils_stubs.c
+++ b/unit-test/stubs/fm_cmd_utils_stubs.c
@@ -44,8 +44,8 @@
 #include "uttest.h"
 #include "utstubs.h"
 
-// static uint32 OpenFileCount = 0;
-// static bool FileIsOpen = false;
+/* static uint32 OpenFileCount = 0; */
+/* static bool FileIsOpen = false; */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -65,7 +65,7 @@ bool FM_IsValidCmdPktLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLeng
     status = UT_DEFAULT_IMPL(FM_IsValidCmdPktLength);
 
     return status;
-} /* FM_IsValidCmdPktLength */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -76,7 +76,7 @@ bool FM_IsValidCmdPktLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLeng
 bool FM_VerifyOverwrite(uint16 Overwrite, uint32 EventID, const char *CmdText)
 {
     return UT_DEFAULT_IMPL(FM_VerifyOverwrite);
-} /* End FM_VerifyOverwrite */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -87,7 +87,7 @@ bool FM_VerifyOverwrite(uint16 Overwrite, uint32 EventID, const char *CmdText)
 uint32 FM_GetOpenFilesData(const FM_OpenFilesEntry_t *OpenFilesData)
 {
     return UT_DEFAULT_IMPL(FM_GetOpenFilesData);
-} /* End FM_GetOpenFilesData */
+}
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* FM utility function -- query filename state                     */
@@ -101,7 +101,7 @@ uint32 FM_GetFilenameState(char *Filename, uint32 BufferSize, bool FileInfoCmd)
     UT_Stub_RegisterContextGenericArg(UT_KEY(FM_GetFilenameState), FileInfoCmd);
 
     return UT_DEFAULT_IMPL(FM_GetFilenameState);
-} /* End FM_GetFilenameState */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -112,7 +112,7 @@ uint32 FM_GetFilenameState(char *Filename, uint32 BufferSize, bool FileInfoCmd)
 uint32 FM_VerifyNameValid(char *Name, uint32 BufferSize, uint32 EventID, const char *CmdText)
 {
     return UT_DEFAULT_IMPL(FM_VerifyNameValid);
-} /* End FM_VerifyNameValid */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -123,7 +123,7 @@ uint32 FM_VerifyNameValid(char *Name, uint32 BufferSize, uint32 EventID, const c
 bool FM_VerifyFileClosed(char *Filename, uint32 BufferSize, uint32 EventID, const char *CmdText)
 {
     return UT_DEFAULT_IMPL(FM_VerifyFileClosed);
-} /* End FM_VerifyFileClosed */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -134,7 +134,7 @@ bool FM_VerifyFileClosed(char *Filename, uint32 BufferSize, uint32 EventID, cons
 bool FM_VerifyFileExists(char *Filename, uint32 BufferSize, uint32 EventID, const char *CmdText)
 {
     return UT_DEFAULT_IMPL(FM_VerifyFileExists);
-} /* End FM_VerifyFileExists */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -145,7 +145,7 @@ bool FM_VerifyFileExists(char *Filename, uint32 BufferSize, uint32 EventID, cons
 bool FM_VerifyFileNoExist(char *Filename, uint32 BufferSize, uint32 EventID, const char *CmdText)
 {
     return UT_DEFAULT_IMPL(FM_VerifyFileNoExist);
-} /* End FM_VerifyFileNoExist */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -156,7 +156,7 @@ bool FM_VerifyFileNoExist(char *Filename, uint32 BufferSize, uint32 EventID, con
 bool FM_VerifyFileNotOpen(char *Filename, uint32 BufferSize, uint32 EventID, const char *CmdText)
 {
     return UT_DEFAULT_IMPL(FM_VerifyFileNotOpen);
-} /* End FM_VerifyFileNotOpen */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -167,7 +167,7 @@ bool FM_VerifyFileNotOpen(char *Filename, uint32 BufferSize, uint32 EventID, con
 bool FM_VerifyDirExists(char *Directory, uint32 BufferSize, uint32 EventID, const char *CmdText)
 {
     return UT_DEFAULT_IMPL(FM_VerifyDirExists);
-} /* End FM_VerifyDirExists */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -177,9 +177,8 @@ bool FM_VerifyDirExists(char *Directory, uint32 BufferSize, uint32 EventID, cons
 
 bool FM_VerifyDirNoExist(char *Name, uint32 BufferSize, uint32 EventID, const char *CmdText)
 {
-
     return UT_DEFAULT_IMPL(FM_VerifyDirNoExist);
-} /* End FM_VerifyDirNoExist */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -189,9 +188,8 @@ bool FM_VerifyDirNoExist(char *Name, uint32 BufferSize, uint32 EventID, const ch
 
 bool FM_VerifyChildTask(uint32 EventID, const char *CmdText)
 {
-
     return UT_DEFAULT_IMPL(FM_VerifyChildTask);
-} /* End FM_VerifyChildTask */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -201,9 +199,8 @@ bool FM_VerifyChildTask(uint32 EventID, const char *CmdText)
 
 void FM_InvokeChildTask(void)
 {
-
     UT_DEFAULT_IMPL(FM_InvokeChildTask);
-} /* End of FM_InvokeChildTask */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -214,8 +211,4 @@ void FM_InvokeChildTask(void)
 void FM_AppendPathSep(char *Directory, uint32 BufferSize)
 {
     UT_DEFAULT_IMPL(FM_AppendPathSep);
-} /* End of FM_AppendPathSep */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/stubs/fm_cmds_stubs.c
+++ b/unit-test/stubs/fm_cmds_stubs.c
@@ -54,7 +54,7 @@
 bool FM_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     return UT_DEFAULT_IMPL(FM_NoopCmd) != 0;
-} /* End of FM_NoopCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -65,7 +65,7 @@ bool FM_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
 bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     return UT_DEFAULT_IMPL(FM_ResetCountersCmd) != 0;
-} /* End of FM_ResetCountersCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -76,7 +76,7 @@ bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
 bool FM_CopyFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     return UT_DEFAULT_IMPL(FM_CopyFileCmd) != 0;
-} /* End of FM_CopyFileCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -87,7 +87,7 @@ bool FM_CopyFileCmd(const CFE_SB_Buffer_t *BufPtr)
 bool FM_MoveFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     return UT_DEFAULT_IMPL(FM_MoveFileCmd) != 0;
-} /* End of FM_MoveFileCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -98,7 +98,7 @@ bool FM_MoveFileCmd(const CFE_SB_Buffer_t *BufPtr)
 bool FM_RenameFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     return UT_DEFAULT_IMPL(FM_RenameFileCmd) != 0;
-} /* End of FM_RenameFileCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -109,7 +109,7 @@ bool FM_RenameFileCmd(const CFE_SB_Buffer_t *BufPtr)
 bool FM_DeleteFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     return UT_DEFAULT_IMPL(FM_DeleteFileCmd) != 0;
-} /* End of FM_DeleteFileCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -120,7 +120,7 @@ bool FM_DeleteFileCmd(const CFE_SB_Buffer_t *BufPtr)
 bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     return UT_DEFAULT_IMPL(FM_DeleteAllFilesCmd) != 0;
-} /* End of FM_DeleteAllFilesCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -132,7 +132,7 @@ bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     return UT_DEFAULT_IMPL(FM_DecompressFileCmd) != 0;
-} /* End of FM_DecompressFileCmd() */
+}
 
 #endif
 
@@ -145,7 +145,7 @@ bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr)
 bool FM_ConcatFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     return UT_DEFAULT_IMPL(FM_ConcatFilesCmd) != 0;
-} /* End of FM_ConcatFilesCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -156,7 +156,7 @@ bool FM_ConcatFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 bool FM_GetFileInfoCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     return UT_DEFAULT_IMPL(FM_GetFileInfoCmd) != 0;
-} /* End of FM_GetFileInfoCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -167,7 +167,7 @@ bool FM_GetFileInfoCmd(const CFE_SB_Buffer_t *BufPtr)
 bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     return UT_DEFAULT_IMPL(FM_GetOpenFilesCmd) != 0;
-} /* End of FM_GetOpenFilesCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -178,7 +178,7 @@ bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 bool FM_CreateDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     return UT_DEFAULT_IMPL(FM_CreateDirectoryCmd);
-} /* End of FM_CreateDirectoryCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -189,7 +189,7 @@ bool FM_CreateDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
 bool FM_DeleteDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     return UT_DEFAULT_IMPL(FM_DeleteDirectoryCmd) != 0;
-} /* End of FM_DeleteDirectoryCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -200,7 +200,7 @@ bool FM_DeleteDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
 bool FM_GetDirListFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     return UT_DEFAULT_IMPL(FM_GetDirListFileCmd) != 0;
-} /* End of FM_GetDirListFileCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -211,7 +211,7 @@ bool FM_GetDirListFileCmd(const CFE_SB_Buffer_t *BufPtr)
 bool FM_GetDirListPktCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     return UT_DEFAULT_IMPL(FM_GetDirListPktCmd) != 0;
-} /* End of FM_GetDirListPktCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -222,7 +222,7 @@ bool FM_GetDirListPktCmd(const CFE_SB_Buffer_t *BufPtr)
 bool FM_GetFreeSpaceCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     return UT_DEFAULT_IMPL(FM_GetFreeSpaceCmd) != 0;
-} /* End of FM_GetFreeSpaceCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -233,7 +233,7 @@ bool FM_GetFreeSpaceCmd(const CFE_SB_Buffer_t *BufPtr)
 bool FM_SetTableStateCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     return UT_DEFAULT_IMPL(FM_SetTableStateCmd) != 0;
-} /* End of FM_SetTableStateCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -244,8 +244,4 @@ bool FM_SetTableStateCmd(const CFE_SB_Buffer_t *BufPtr)
 bool FM_SetPermissionsCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     return UT_DEFAULT_IMPL(FM_SetPermissionsCmd) != 0;
-} /* End of FM_SetPermissionsCmd() */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/stubs/fm_tbl_stubs.c
+++ b/unit-test/stubs/fm_tbl_stubs.c
@@ -52,7 +52,7 @@ int32 FM_TableInit(void)
     int32 status;
     status = UT_DEFAULT_IMPL(FM_TableInit);
     return status;
-} /* End FM_TableInit */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -65,7 +65,7 @@ int32 FM_ValidateTable(FM_FreeSpaceTable_t *TablePtr)
     int32 status;
     status = UT_DEFAULT_IMPL(FM_ValidateTable);
     return status;
-} /* End FM_ValidateTable */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -76,7 +76,7 @@ int32 FM_ValidateTable(FM_FreeSpaceTable_t *TablePtr)
 void FM_AcquireTablePointers(void)
 {
     UT_DEFAULT_IMPL(FM_AcquireTablePointers);
-} /* End FM_AcquireTablePointers */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -87,8 +87,4 @@ void FM_AcquireTablePointers(void)
 void FM_ReleaseTablePointers(void)
 {
     UT_DEFAULT_IMPL(FM_ReleaseTablePointers);
-} /* End FM_ReleaseTablePointers */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/utilities/fm_test_utils.c
+++ b/unit-test/utilities/fm_test_utils.c
@@ -64,7 +64,6 @@ void UT_Handler_CFE_EVS_SendEvent(void *UserObj, UT_EntryKey_t FuncKey, const UT
 
 void FM_Test_Setup(void)
 {
-
     UT_ResetState(0);
 
     memset(&FM_GlobalData, 0, sizeof(FM_GlobalData));


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #57
Removes redundant and inconsistent comments (e.g. `/* end of function */`, `/* end if */`, function name in function header comments).
There were also a few cases of unnecessary empty lines (e.g. on the last line before the closing brace of a function) and also missing empty lines (e.g. between functions) which were corrected. Some of these empty lines trigger the CI format checks.
I've left the commits separated for now to make life easier for whoever reviews this. I can squash them if/when this is ready for merge.

**Testing performed**
None (comment and whitespace changes only).

**Expected behavior changes**
No impact on behavior.
These updates will reduce clutter and inconsistency in the code, improving readability.

**Contributor Info**
@thnkslprpt 