### PR TITLE
Fix #59, Apply consistent Event ID names to common events

### DIFF
--- a/fsw/inc/fm_events.h
+++ b/fsw/inc/fm_events.h
@@ -39,7 +39,7 @@
  *  This event message is issued after the File Manager application has
  *  successfully completed startup initialization.
  */
-#define FM_STARTUP_EID 1
+#define FM_INIT_INF_EID 1
 
 /**
  * \brief FM Initialization Register For Event Services Failed Event ID
@@ -71,7 +71,7 @@
  *  This is a fatal error that will cause the File Manager application
  *  to terminate.
  */
-#define FM_STARTUP_CREAT_PIPE_ERR_EID 3
+#define FM_CR_PIPE_ERR_EID 3
 
 /**
  * \brief FM Initialization Subscribe to HK Request Failed Event ID
@@ -188,7 +188,7 @@
  *  This event message is generated upon receipt of a housekeeping
  *  request command packet with an invalid length.
  */
-#define FM_HK_REQ_ERR_EID 11
+#define FM_HKREQ_LEN_ERR_EID 11
 
 /**
  * \brief FM No-op Command Event ID
@@ -200,7 +200,7 @@
  *  This event message signals the successful completion of a
  *  /FM_Noop command.
  */
-#define FM_NOOP_CMD_EID 12
+#define FM_NOOP_INF_EID 12
 
 /**
  * \brief FM No-op Command Length Invalid Event ID
@@ -227,7 +227,7 @@
  *  This event message signals the successful completion of a
  *  /FM_ResetCtrs command.
  */
-#define FM_RESET_CMD_EID 14
+#define FM_RESET_INF_EID 14
 
 /**
  * \brief FM Reset Counters Command Length Invalid Event ID

--- a/fsw/inc/fm_msgdefs.h
+++ b/fsw/inc/fm_msgdefs.h
@@ -44,7 +44,7 @@
  *       #FM_NoopCmd_t
  *
  *  \par Command Success Verification
- *       - Informational event #FM_NOOP_CMD_EID will be sent
+ *       - Informational event #FM_NOOP_INF_EID will be sent
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment
  *
  *  \par Command Error Conditions
@@ -75,7 +75,7 @@
  *
  *  \par Command Success Verification
  *       - Command counters will be set to zero (see description)
- *       - Debug event #FM_RESET_CMD_EID will be sent
+ *       - Debug event #FM_RESET_INF_EID will be sent
  *
  *  \par Command Error Conditions
  *       - Invalid command packet length

--- a/fsw/src/fm_app.c
+++ b/fsw/src/fm_app.c
@@ -186,8 +186,8 @@ CFE_Status_t FM_AppInit(void)
         Result = CFE_SB_CreatePipe(&FM_GlobalData.CmdPipe, FM_APP_PIPE_DEPTH, FM_APP_PIPE_NAME);
         if (Result != CFE_SUCCESS)
         {
-            CFE_EVS_SendEvent(FM_STARTUP_CREAT_PIPE_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "%s create SB input pipe: result = 0x%08X", ErrText, (unsigned int)Result);
+            CFE_EVS_SendEvent(FM_CR_PIPE_ERR_EID, CFE_EVS_EventType_ERROR, "%s create SB input pipe: result = 0x%08X",
+                              ErrText, (unsigned int)Result);
         }
         else
         {
@@ -229,7 +229,7 @@ CFE_Status_t FM_AppInit(void)
                 FM_ChildInit();
 
                 /* Application startup event message */
-                CFE_EVS_SendEvent(FM_STARTUP_EID, CFE_EVS_EventType_INFORMATION,
+                CFE_EVS_SendEvent(FM_INIT_INF_EID, CFE_EVS_EventType_INFORMATION,
                                   "Initialization complete: version %d.%d.%d.%d", FM_MAJOR_VERSION, FM_MINOR_VERSION,
                                   FM_REVISION, FM_MISSION_REV);
             }

--- a/fsw/src/fm_cmds.c
+++ b/fsw/src/fm_cmds.c
@@ -57,7 +57,7 @@ bool FM_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     const char *CmdText = "No-op";
 
-    CFE_EVS_SendEvent(FM_NOOP_CMD_EID, CFE_EVS_EventType_INFORMATION, "%s command: FM version %d.%d.%d.%d", CmdText,
+    CFE_EVS_SendEvent(FM_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "%s command: FM version %d.%d.%d.%d", CmdText,
                       FM_MAJOR_VERSION, FM_MINOR_VERSION, FM_REVISION, FM_MISSION_REV);
 
     return true;
@@ -81,7 +81,7 @@ bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
     FM_GlobalData.ChildCmdWarnCounter = 0;
 
     /* Send command completion event (debug) */
-    CFE_EVS_SendEvent(FM_RESET_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command", CmdText);
+    CFE_EVS_SendEvent(FM_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "%s command", CmdText);
 
     return true;
 }

--- a/fsw/src/fm_dispatch.c
+++ b/fsw/src/fm_dispatch.c
@@ -390,7 +390,7 @@ bool FM_SetPermissionsVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 void FM_SendHkVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 {
     /* Verify command packet length */
-    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_SendHkCmd_t), FM_HK_REQ_ERR_EID, "HK Request"))
+    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_SendHkCmd_t), FM_HKREQ_LEN_ERR_EID, "HK Request"))
     {
         return;
     }

--- a/unit-test/fm_app_tests.c
+++ b/unit-test/fm_app_tests.c
@@ -94,7 +94,7 @@ void Test_FM_AppMain_SBReceiveBufferDefaultOption(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 3);
     UtAssert_STUB_COUNT(CFE_ES_ExitApp, 1);
     UtAssert_STUB_COUNT(CFE_SB_ReceiveBuffer, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_STARTUP_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_INIT_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_SB_RECEIVE_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
@@ -168,7 +168,7 @@ void Test_FM_AppMain_BufPtrNotEqualNull(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_STUB_COUNT(CFE_ES_ExitApp, 1);
     UtAssert_STUB_COUNT(CFE_SB_ReceiveBuffer, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_STARTUP_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_INIT_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_EXIT_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
@@ -202,7 +202,7 @@ void Test_FM_AppInit_CreatePipeFail(void)
     UtAssert_STUB_COUNT(CFE_EVS_Register, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_STUB_COUNT(CFE_SB_CreatePipe, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_STARTUP_CREAT_PIPE_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CR_PIPE_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 }
 
@@ -282,7 +282,7 @@ void Test_FM_AppInit_TableInitSuccess(void)
     UtAssert_STUB_COUNT(CFE_SB_CreatePipe, 1);
     UtAssert_STUB_COUNT(CFE_SB_Subscribe, 2);
     UtAssert_STUB_COUNT(FM_ChildInit, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_STARTUP_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_INIT_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 }
 

--- a/unit-test/fm_cmds_tests.c
+++ b/unit-test/fm_cmds_tests.c
@@ -74,7 +74,7 @@ void Test_FM_NoopCmd_Success(void)
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_NOOP_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_NOOP_INF_EID);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
@@ -114,7 +114,7 @@ void Test_FM_ResetCountersCmd_Success(void)
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_RESET_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_RESET_INF_EID);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #59 
  - Consistent event IDs have been applied to the inconsistent cases to align them with a common Event ID naming convention.

**Testing performed**
Only GitHub CI actions.

**Expected behavior changes**
No impact on code behavior (no logic changes).
Consistent Event ID names for the events which are common to all/most cFS components and apps will improve consistency and ease make code review/debugging easier.

**Contributor Info**
Avi Weiss @thnkslprpt