### PR TITLE
Fix #62, Remove initializations causing Cppcheck errors

### DIFF
--- a/fsw/src/fm_cmd_utils.c
+++ b/fsw/src/fm_cmd_utils.c
@@ -162,7 +162,7 @@ uint32 FM_GetFilenameState(char *Filename, uint32 BufferSize, bool FileInfoCmd)
     os_fstat_t FileStatus;
     uint32     FilenameState   = FM_NAME_IS_INVALID;
     bool       FilenameIsValid = false;
-    int32      StringLength    = 0;
+    int32      StringLength;
 
     memset(&FileStatus, 0, sizeof(FileStatus));
 

--- a/fsw/src/fm_tbl.c
+++ b/fsw/src/fm_tbl.c
@@ -70,9 +70,9 @@ int32 FM_TableInit(void)
 
 int32 FM_ValidateTable(FM_FreeSpaceTable_t *TablePtr)
 {
-    int32 Result     = CFE_SUCCESS;
-    int32 NameLength = 0;
-    int32 i          = 0;
+    int32 Result = CFE_SUCCESS;
+    int32 NameLength;
+    int32 i = 0;
 
     int32 CountGood   = 0;
     int32 CountBad    = 0;


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #62 
Both seem fine to change from initialization at the top of the function to a plain declaration.
`StringLength` is used in only one `if` block, and it is assigned a value at its first use in the init-statement of the `for` loop on line 172.
Subsequent references to `StringLength` all logically follow this assignment, so the initialization at the top of the function block (line 165) is redundant and can safely be converted to a plain declaration.

The same goes for `NameLength`. It is used in only one `if` block, and is assigned a value there at its first use in the init-statement of the `for` loop on line 110. The initialization on line 74 can thus be converted to a simple declaration.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully if separate issue https://github.com/nasa/FM/issues/63 is suppressed
![image](https://user-images.githubusercontent.com/9024662/200171664-29c67fe8-6b19-4f8f-a244-6088506532d9.png)
The log from the successful build (with the GCC suppressions that can't be included in this PR) can be viewed here:
https://github.com/thnkslprpt/FM/actions/runs/3404338406/jobs/5661598438

**Expected behavior changes**
No impact on code behavior.
Cppcheck now passes without error again.

**Contributor Info**
Avi @thnkslprpt