### PR TITLE
Fix #75, move app global to internal include

### DIFF
--- a/fsw/inc/fm_msg.h
+++ b/fsw/inc/fm_msg.h
@@ -28,10 +28,6 @@
 #include <fm_platform_cfg.h>
 #include <fm_extern_typedefs.h>
 
-#ifdef FM_INCLUDE_DECOMPRESS
-#include <cfs_fs_lib.h>
-#endif
-
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* FM -- command packet structures                                 */
@@ -529,71 +525,5 @@ typedef struct
     uint8             GetSizeTimeMode; /**< \brief Whether to invoke stat call for size and time (CPU intensive) */
     uint32            Mode;            /**< \brief File Mode */
 } FM_ChildQueueEntry_t;
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM -- application global data structure                         */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-/**
- *  \brief Application global data structure
- */
-typedef struct
-{
-    FM_MonitorTable_t *MonitorTablePtr;    /**< \brief File System Table Pointer */
-    CFE_TBL_Handle_t   MonitorTableHandle; /**< \brief File System Table Handle */
-
-    CFE_SB_PipeId_t CmdPipe; /**< \brief cFE software bus command pipe */
-
-    CFE_ES_TaskId_t ChildTaskID;        /**< \brief Child task ID */
-    osal_id_t       ChildSemaphore;     /**< \brief Child task wakeup counting semaphore */
-    osal_id_t       ChildQueueCountSem; /**< \brief Child queue counter mutex semaphore */
-
-    uint8 ChildCmdCounter;     /**< \brief Child task command success counter */
-    uint8 ChildCmdErrCounter;  /**< \brief Child task command error counter */
-    uint8 ChildCmdWarnCounter; /**< \brief Child task command warning counter */
-
-    uint8 ChildWriteIndex; /**< \brief Array index for next write to command args */
-    uint8 ChildReadIndex;  /**< \brief Array index for next read from command args */
-    uint8 ChildQueueCount; /**< \brief Number of pending commands in queue */
-
-    uint8 CommandCounter;    /**< \brief Application command success counter */
-    uint8 CommandErrCounter; /**< \brief Application command error counter */
-    uint8 Spare8a;           /**< \brief Placeholder for unused command warning counter */
-
-    uint8 ChildCurrentCC;  /**< \brief Command code currently executing */
-    uint8 ChildPreviousCC; /**< \brief Command code previously executed */
-    uint8 Spare8b;         /**< \brief Structure alignment spare */
-
-    uint32 FileStatTime; /**< \brief Modify time from most recent OS_stat */
-    uint32 FileStatSize; /**< \brief File size from most recent OS_stat */
-    uint32 FileStatMode; /**< \brief File mode from most recent OS_stat (OS_FILESTAT_MODE) */
-
-    FM_DirListFileStats_t DirListFileStats; /**< \brief Get dir list to file statistics structure */
-
-    FM_DirListPkt_t DirListPkt; /**< \brief Get dir list to packet telemetry packet */
-
-    FM_MonitorReportPkt_t
-        MonitorReportPkt; /**< \brief Telemetry packet reporting status of items in the monitor table */
-
-    FM_FileInfoPkt_t FileInfoPkt; /**< \brief Get file info telemetry packet */
-
-    FM_OpenFilesPkt_t OpenFilesPkt; /**< \brief Get open files telemetry packet */
-
-    FM_HousekeepingPkt_t HousekeepingPkt; /**< \brief Application housekeeping telemetry packet */
-
-    char ChildBuffer[FM_CHILD_FILE_BLOCK_SIZE]; /**< \brief Child task file I/O buffer */
-
-    FM_ChildQueueEntry_t ChildQueue[FM_CHILD_QUEUE_DEPTH]; /**< \brief Child task command queue */
-
-#ifdef FM_INCLUDE_DECOMPRESS
-    FS_LIB_Decompress_State_t DecompressState;
-
-#endif
-} FM_GlobalData_t;
-
-/** \brief File Manager global */
-extern FM_GlobalData_t FM_GlobalData;
 
 #endif

--- a/fsw/src/fm_app.h
+++ b/fsw/src/fm_app.h
@@ -25,10 +25,15 @@
 #define FM_APP_H
 
 #include "cfe.h"
+#include "fm_msg.h"
+
+#ifdef FM_INCLUDE_DECOMPRESS
+#include "cfs_fs_lib.h"
+#endif
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* FM application global function prototypes                       */
+/* FM -- application global constants                              */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -40,6 +45,75 @@
  *      message was received or not.
  */
 #define FM_SB_TIMEOUT 1000
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM -- application global data structure                         */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+/**
+ *  \brief Application global data structure
+ */
+typedef struct
+{
+    FM_MonitorTable_t *MonitorTablePtr;    /**< \brief File System Table Pointer */
+    CFE_TBL_Handle_t   MonitorTableHandle; /**< \brief File System Table Handle */
+
+    CFE_SB_PipeId_t CmdPipe; /**< \brief cFE software bus command pipe */
+
+    CFE_ES_TaskId_t ChildTaskID;        /**< \brief Child task ID */
+    osal_id_t       ChildSemaphore;     /**< \brief Child task wakeup counting semaphore */
+    osal_id_t       ChildQueueCountSem; /**< \brief Child queue counter mutex semaphore */
+
+    uint8 ChildCmdCounter;     /**< \brief Child task command success counter */
+    uint8 ChildCmdErrCounter;  /**< \brief Child task command error counter */
+    uint8 ChildCmdWarnCounter; /**< \brief Child task command warning counter */
+
+    uint8 ChildWriteIndex; /**< \brief Array index for next write to command args */
+    uint8 ChildReadIndex;  /**< \brief Array index for next read from command args */
+    uint8 ChildQueueCount; /**< \brief Number of pending commands in queue */
+
+    uint8 CommandCounter;    /**< \brief Application command success counter */
+    uint8 CommandErrCounter; /**< \brief Application command error counter */
+    uint8 Spare8a;           /**< \brief Placeholder for unused command warning counter */
+
+    uint8 ChildCurrentCC;  /**< \brief Command code currently executing */
+    uint8 ChildPreviousCC; /**< \brief Command code previously executed */
+    uint8 Spare8b;         /**< \brief Structure alignment spare */
+
+    uint32 FileStatTime; /**< \brief Modify time from most recent OS_stat */
+    uint32 FileStatSize; /**< \brief File size from most recent OS_stat */
+    uint32 FileStatMode; /**< \brief File mode from most recent OS_stat (OS_FILESTAT_MODE) */
+
+    FM_DirListFileStats_t DirListFileStats; /**< \brief Get dir list to file statistics structure */
+
+    FM_DirListPkt_t DirListPkt; /**< \brief Get dir list to packet telemetry packet */
+
+    FM_MonitorReportPkt_t
+        MonitorReportPkt; /**< \brief Telemetry packet reporting status of items in the monitor table */
+
+    FM_FileInfoPkt_t FileInfoPkt; /**< \brief Get file info telemetry packet */
+
+    FM_OpenFilesPkt_t OpenFilesPkt; /**< \brief Get open files telemetry packet */
+
+    FM_HousekeepingPkt_t HousekeepingPkt; /**< \brief Application housekeeping telemetry packet */
+
+    char ChildBuffer[FM_CHILD_FILE_BLOCK_SIZE]; /**< \brief Child task file I/O buffer */
+
+    FM_ChildQueueEntry_t ChildQueue[FM_CHILD_QUEUE_DEPTH]; /**< \brief Child task command queue */
+
+#ifdef FM_INCLUDE_DECOMPRESS
+    FS_LIB_Decompress_State_t DecompressState;
+
+#endif
+} FM_GlobalData_t;
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM application global function prototypes                       */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /**
  *  \brief Application entry point and main process loop
@@ -128,5 +202,14 @@ void FM_ProcessCmd(const CFE_SB_Buffer_t *BufPtr);
  *  \sa #FM_HousekeepingCmd_t, #FM_HousekeepingPkt_t
  */
 void FM_ReportHK(const CFE_MSG_CommandHeader_t *Msg);
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM application global data structure instance                   */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+/** \brief File Manager global */
+extern FM_GlobalData_t FM_GlobalData;
 
 #endif

--- a/fsw/src/fm_cmd_utils.c
+++ b/fsw/src/fm_cmd_utils.c
@@ -26,6 +26,7 @@
  */
 
 #include "cfe.h"
+#include "fm_app.h"
 #include "fm_msg.h"
 #include "fm_cmd_utils.h"
 #include "fm_child.h"

--- a/fsw/src/fm_tbl.c
+++ b/fsw/src/fm_tbl.c
@@ -26,7 +26,7 @@
  */
 
 #include "fm_platform_cfg.h"
-#include "fm_msg.h"
+#include "fm_app.h"
 #include "fm_tbl.h"
 #include "fm_events.h"
 

--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -9,6 +9,7 @@
 
 add_cfe_coverage_stubs("fm_internal"
   utilities/fm_test_utils.c
+  stubs/fm_global_stubs.c
   stubs/fm_cmds_stubs.c
   stubs/fm_cmd_utils_stubs.c
   stubs/fm_cmd_utils_handlers.c

--- a/unit-test/fm_cmd_utils_tests.c
+++ b/unit-test/fm_cmd_utils_tests.c
@@ -24,7 +24,7 @@
 
 #include "cfe.h"
 #include "fm_cmd_utils.h"
-#include "fm_msg.h"
+#include "fm_app.h"
 #include "fm_child.h"
 #include "fm_perfids.h"
 #include "fm_events.h"

--- a/unit-test/fm_tbl_tests.c
+++ b/unit-test/fm_tbl_tests.c
@@ -24,7 +24,7 @@
 
 #include "cfe.h"
 #include "fm_platform_cfg.h"
-#include "fm_msg.h"
+#include "fm_app.h"
 #include "fm_tbl.h"
 #include "fm_events.h"
 

--- a/unit-test/stubs/fm_app_stubs.c
+++ b/unit-test/stubs/fm_app_stubs.c
@@ -19,98 +19,70 @@
 
 /**
  * @file
- *  The File Manager (FM) Application provides onboard file system
- *  management services by processing commands for copying and moving
- *  files, decompressing files, concatenating files, creating directories,
- *  deleting files and directories, and providing file and directory status.
- *  When the File Manager application receives a housekeeping request
- *  (scheduled within the scheduler application), FM  reports it's housekeeping
- *  status values via telemetry messaging.
+ *
+ * Auto-Generated stub implementations for functions defined in fm_app header
  */
 
-#include "cfe.h"
-#include "fm_msg.h"
-#include "fm_msgdefs.h"
-#include "fm_msgids.h"
 #include "fm_app.h"
-#include "fm_tbl.h"
-#include "fm_child.h"
-#include "fm_cmds.h"
-#include "fm_cmd_utils.h"
-#include "fm_events.h"
-#include "fm_perfids.h"
-#include "fm_platform_cfg.h"
-#include "fm_version.h"
-#include "fm_verify.h"
-#include "fm_test_utils.h"
+#include "utgenstub.h"
 
-#include <string.h>
-
-/* UT includes */
-#include "uttest.h"
-#include "utassert.h"
-#include "utstubs.h"
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM application global data                                      */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-FM_GlobalData_t FM_GlobalData;
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM application -- entry point and main loop processor           */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void FM_AppMain(void)
-{
-    UT_DEFAULT_IMPL(FM_AppMain);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM application -- startup initialization processor              */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_AppInit()
+ * ----------------------------------------------------
+ */
 int32 FM_AppInit(void)
 {
-    return UT_DEFAULT_IMPL(FM_AppInit);
+    UT_GenStub_SetupReturnBuffer(FM_AppInit, int32);
+
+    UT_GenStub_Execute(FM_AppInit, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_AppInit, int32);
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM application -- input packet processor                        */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_AppMain()
+ * ----------------------------------------------------
+ */
+void FM_AppMain(void)
+{
 
+    UT_GenStub_Execute(FM_AppMain, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_ProcessCmd()
+ * ----------------------------------------------------
+ */
+void FM_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(FM_ProcessCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(FM_ProcessCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_ProcessPkt()
+ * ----------------------------------------------------
+ */
 void FM_ProcessPkt(const CFE_SB_Buffer_t *MessagePtr)
 {
-    UT_DEFAULT_IMPL(FM_ProcessPkt);
+    UT_GenStub_AddParam(FM_ProcessPkt, const CFE_SB_Buffer_t *, MessagePtr);
+
+    UT_GenStub_Execute(FM_ProcessPkt, Basic, NULL);
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM application -- command packet processor                      */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void FM_ProcessCmd(const CFE_SB_Buffer_t *MessagePtr)
-{
-    UT_DEFAULT_IMPL(FM_ProcessCmd);
-    UT_Stub_CopyFromLocal(UT_KEY(FM_ProcessCmd), &MessagePtr, sizeof(MessagePtr));
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM application -- housekeeping request packet processor         */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_ReportHK()
+ * ----------------------------------------------------
+ */
 void FM_ReportHK(const CFE_MSG_CommandHeader_t *Msg)
 {
-    UT_DEFAULT_IMPL(FM_ReportHK);
+    UT_GenStub_AddParam(FM_ReportHK, const CFE_MSG_CommandHeader_t *, Msg);
+
+    UT_GenStub_Execute(FM_ReportHK, Basic, NULL);
 }

--- a/unit-test/stubs/fm_global_stubs.c
+++ b/unit-test/stubs/fm_global_stubs.c
@@ -1,0 +1,28 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,918-1, and identified as “Core Flight
+ * Software System (cFS) File Manager Application Version 2.6.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+#include "fm_app.h"
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM application global data                                      */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+FM_GlobalData_t FM_GlobalData;

--- a/unit-test/utilities/fm_test_utils.c
+++ b/unit-test/utilities/fm_test_utils.c
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <time.h>
-#include "fm_msg.h"
+#include "fm_app.h"
 
 /* UT includes */
 #include "uttest.h"

--- a/unit-test/utilities/fm_test_utils.h
+++ b/unit-test/utilities/fm_test_utils.h
@@ -25,7 +25,7 @@
 #include "common_types.h"
 
 #include "fm_platform_cfg.h"
-#include "fm_app.h"
+#include "fm_msg.h"
 #include "utstubs.h"
 
 typedef struct


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/FM/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Global data structures should not be defined in the public include files, they should be private to the local source directory.

Unit test is justified in accessing this file directly, so provisions are also made to permit this.

Fixes #75

**Testing performed**
Build and run all tests.  Sanity check on FM running in CFE.

**Expected behavior changes**
No impact to behavior.
Private struct that was in public_inc is now back in a private header.

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
