### PR TITLE
Fix #73, compression selectable at source file level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,14 @@
 project(CFS_FM C)
 
-# Uncomment the below include if decompress functionality is
-# enabled in FM
-# include_directories(${fs_lib_MISSION_DIR}/fsw/public_inc)
+# Type of data compression to link in.  Actual routines to implement compression
+# are expected to be in a separately loaded library.  Bindings are available for:
+#  FALSE or OFF: Do not include compression
+#  TRUE or ON: Use default compression for the platform (TBD)
+#  CFS_FS_LIB: historical unzip implementation from older versions of CFE FS (deprecated)
+#  ZLIB: Use inflate/deflate API from zlib (http://zlib.net) (not yet implemented)
+set(FM_INCLUDE_COMPRESSION FALSE CACHE STRING "Type of data compression/decompression features to include in FM")
+set(FM_DEPENDENCY_LIST)
+set(FM_OPTION_SRC_FILES)
 
 set(APP_SRC_FILES
   fsw/src/fm_cmd_utils.c
@@ -12,11 +18,38 @@ set(APP_SRC_FILES
   fsw/src/fm_tbl.c
 )
 
+# If compression features are enabled, choose the adapter based on the selected implementation
+if (FM_INCLUDE_COMPRESSION)
+
+  if (FM_INCLUDE_COMPRESSION STREQUAL ZLIB)
+    # Using a properly-maintained external implementation should be preferred
+    # This may be the default in a future release.
+    list(APPEND FM_OPTION_SRC_FILES fsw/src/fm_compression_zlib.c)
+  else()
+    # Older versions of FM used a decompression implemented in CFS FS, so this is
+    # what will be assumed if FM_INCLUDE_COMPRESSION is set to a simple
+    # boolean "ON" or "TRUE".  This code now resides in an external "FS_Lib".
+    list(APPEND FM_DEPENDENCY_LIST fs_lib)
+    list(APPEND FM_OPTION_SRC_FILES fsw/src/fm_compression_fslib.c)
+  endif()
+
+else()
+
+  # FM_INCLUDE_COMPRESSION set to "OFF" or "FALSE" - compression features are not enabled
+  list(APPEND FM_OPTION_SRC_FILES fsw/src/fm_compression_none.c)
+
+endif()
+
 # Create the app module
-add_cfe_app(fm ${APP_SRC_FILES})
+add_cfe_app(fm ${APP_SRC_FILES} ${FM_OPTION_SRC_FILES})
 
 # This permits direct access to public headers in the fsw/inc directory
 target_include_directories(fm PUBLIC fsw/inc)
+
+# Add dependencies based on the type of compression algoritm selected (if any)
+if (FM_DEPENDENCY_LIST)
+  add_cfe_app_dependency(fm ${FM_DEPENDENCY_LIST})
+endif()
 
 set(APP_TABLE_FILES
   fsw/tables/fm_monitor.c

--- a/docs/dox_src/cfs_fm.dox
+++ b/docs/dox_src/cfs_fm.dox
@@ -54,10 +54,10 @@
 
   This Doxygen-based User's Guide provides a complete reference for the
   cFS File Manager (FM) application.  The Guide is intended primarily for
-  users of the software (operations personnel, test engineers, and 
+  users of the software (operations personnel, test engineers, and
   maintenance personnel) who prefer a developer-focused document and direct
   references to the source code.  The "deployment guide" section is intended
-  for mission developers when deploying and configuring the FM application 
+  for mission developers when deploying and configuring the FM application
   software for a mission flight software build environment.
 
   \ref cfsfmversion
@@ -109,21 +109,21 @@
   \page cfsfmovr CFS File Manager Overview
 
   The CFS FM application provides onboard file system management services by processing ground commands
-  for copying, moving, and renaming files, decompressing files, creating directories, deleting files and 
-  directories, providing file and directory informational telemetry messages, and providing open file and 
-  directory listings.  The FM software context diagram is shown in Figure FM-1.  
-  
+  for copying, moving, and renaming files, decompressing files, creating directories, deleting files and
+  directories, providing file and directory informational telemetry messages, and providing open file and
+  directory listings.  The FM software context diagram is shown in Figure FM-1.
+
   \image html CFS_FM_Context.jpg "Figure FM-1"
   \image latex CFS_FM_Context.jpg "Figure FM-1"
 
-  The FM application interfaces with the Command Ingest (CI) application to receive ground commands.  
-  See page \ref cfsfmcmdspg for a detailed description of the FM ground commands.  FM utilizes the Operating 
-  System Abstraction Layer (OSAL) API library functions for interfacing with the onboard file systems when 
+  The FM application interfaces with the Command Ingest (CI) application to receive ground commands.
+  See page \ref cfsfmcmdspg for a detailed description of the FM ground commands.  FM utilizes the Operating
+  System Abstraction Layer (OSAL) API library functions for interfacing with the onboard file systems when
   processing ground commands.  The FM application receives messages from the Scheduler (SCH) Application
-  for periodic housekeeping requests.  Upon receipt of a housekeeping request, FM will send its 
+  for periodic housekeeping requests.  Upon receipt of a housekeeping request, FM will send its
   housekeeping telemetry packets on the Software Bus.  Housekeeping telemetry
-  packets are typically subscribed to 
-  by the Housekeeping (HK), Telemetry Output (TO), and Data Storage applications.  See page 
+  packets are typically subscribed to
+  by the Housekeeping (HK), Telemetry Output (TO), and Data Storage applications.  See page
   \ref cfsfmtlm for a detailed description of the contents of the FM housekeeping telemetry packet.
 **/
 
@@ -134,66 +134,66 @@
 
   <B> Power-On and Processor Resets </B>
 
-  Upon a Power-On or Processor reset the FM application initializes all telemetry within its housekeeping 
-  telemetry packet.  The Command and Command Error counters are set to zero, as well as, all other 
-  numerical data within the packet.  In addition to initializing telemetry, FM registers for cFE event 
-  services, creates its software bus message pipe, and subscribes to FM SB housekeeping requests and 
+  Upon a Power-On or Processor reset the FM application initializes all telemetry within its housekeeping
+  telemetry packet.  The Command and Command Error counters are set to zero, as well as, all other
+  numerical data within the packet.  In addition to initializing telemetry, FM registers for cFE event
+  services, creates its software bus message pipe, and subscribes to FM SB housekeeping requests and
   commands.
 
   <B> Normal Operation </B>
 
-  The CFS FM application is a command and telemetry driven application.  FM waits in a command loop 
-  infinitely until the software receives a scheduled housekeeping request, ground command, or stored 
-  command.  Command packets (including housekeeping requests) are processed as they are received.  The 
-  application sends an FM housekeeping telemetry message on the cFE Software Bus upon receipt of a scheduled 
-  housekeeping request produced by the SCH application.  This request is typically performed every 
+  The CFS FM application is a command and telemetry driven application.  FM waits in a command loop
+  infinitely until the software receives a scheduled housekeeping request, ground command, or stored
+  command.  Command packets (including housekeeping requests) are processed as they are received.  The
+  application sends an FM housekeeping telemetry message on the cFE Software Bus upon receipt of a scheduled
+  housekeeping request produced by the SCH application.  This request is typically performed every
   4-5 seconds and these housekeeping messages are usually sent to the ground
   (though this depends on the configuration of the rest of the system).
 
-  Various FM ground commands produce telemetry messages as a result of processing the command.  These 
-  telemetry messages include a directory listing telemetry message, file information telemetry message, 
-  and an open file listing telemetry message. See page \ref cfsfmcmdspg for a detailed description of the 
-  FM directory listing, file information, and open file listing ground commands.  See page \ref cfsfmtlm 
-  for a detailed description of the contents of the FM directory listing, file information, and open file 
+  Various FM ground commands produce telemetry messages as a result of processing the command.  These
+  telemetry messages include a directory listing telemetry message, file information telemetry message,
+  and an open file listing telemetry message. See page \ref cfsfmcmdspg for a detailed description of the
+  FM directory listing, file information, and open file listing ground commands.  See page \ref cfsfmtlm
+  for a detailed description of the contents of the FM directory listing, file information, and open file
   listing telemetry messages.
 
-  Other FM ground commands produce files as a result of processing the command.  These files include a 
-  decompression file, concatenation file, and a directory listing file.  See page \ref cfsfmcmdspg for a 
-  detailed description of the FM decompress file, concatenate files, and directory listing file ground 
-  commands. Note decompression capability is optionally supported via the FM_INCLUDE_DECOMPRESS platform
+  Other FM ground commands produce files as a result of processing the command.  These files include a
+  decompression file, concatenation file, and a directory listing file.  See page \ref cfsfmcmdspg for a
+  detailed description of the FM decompress file, concatenate files, and directory listing file ground
+  commands. Note decompression capability is optionally supported via the FM_INCLUDE_COMPRESSION platform
   configuration option.
-  
-  The decompression file is produced using the cFE API function CFE_FS_Decompress which uses code ported 
-  from the GNU zip sources.  The cFE API function CFE_FS_Decompress produces the decompressed output file.  
-  The output file is comparable to that of a file that has been unzipped using the system utility gunzip.  
-  A compressed file reduces the size of the file by encoding the file.  Compressed files may be used to 
-  reduce uplink time to the spacecraft.  Decompressing the file will restore the file from its encoded 
+
+  The decompression file is produced using the cFE API function CFE_FS_Decompress which uses code ported
+  from the GNU zip sources.  The cFE API function CFE_FS_Decompress produces the decompressed output file.
+  The output file is comparable to that of a file that has been unzipped using the system utility gunzip.
+  A compressed file reduces the size of the file by encoding the file.  Compressed files may be used to
+  reduce uplink time to the spacecraft.  Decompressing the file will restore the file from its encoded
   state to the original state of the file.
 
-  The concatenation file is a direct copy of the contents of the two command specified source files, 
-  with the contents of the first source file specified proceeding the contents of the second source 
-  file specified.  The contents of the second source file are written with no delineation characters 
+  The concatenation file is a direct copy of the contents of the two command specified source files,
+  with the contents of the first source file specified proceeding the contents of the second source
+  file specified.  The contents of the second source file are written with no delineation characters
   such as spaces or returns following the contents of the first source file.
 
-  The directory listing file is written as a binary file and contains a cFE file header at the top of 
-  the file contiguously followed by a directory listing status data structure containing an echo of the 
-  command specified directory name (#OS_MAX_PATH_LEN), directory size in bytes (uint32), total number of 
-  file contained in the directory (uint32), and the number of file names written in the directory listing 
-  file (uint32).  The directory listing is then written contiguously one entry at a time.  Each entry in 
-  the directory listing includes for each file in the directory, the name of the file(#OS_MAX_PATH_LEN), 
-  file size in bytes (uint32), and last modification time of the file (uint32).  File systems use specific 
-  time epochs for their time tagging of files.  Since spacecraft systems rarely use an epoch that matches 
-  a particular file system, a function is used to convert the file system time (in seconds) to spacecraft 
-  time (in seconds).  The conversion is controlled by a cFE configuration parameter which is set equal to 
-  the number of seconds between the spacecraft's epoch and the file system's epoch.  See #CFE_FS_Header_t 
-  for the cFE file header format.  See /FM_DirListFileStat_t for the format of the directory listing 
+  The directory listing file is written as a binary file and contains a cFE file header at the top of
+  the file contiguously followed by a directory listing status data structure containing an echo of the
+  command specified directory name (#OS_MAX_PATH_LEN), directory size in bytes (uint32), total number of
+  file contained in the directory (uint32), and the number of file names written in the directory listing
+  file (uint32).  The directory listing is then written contiguously one entry at a time.  Each entry in
+  the directory listing includes for each file in the directory, the name of the file(#OS_MAX_PATH_LEN),
+  file size in bytes (uint32), and last modification time of the file (uint32).  File systems use specific
+  time epochs for their time tagging of files.  Since spacecraft systems rarely use an epoch that matches
+  a particular file system, a function is used to convert the file system time (in seconds) to spacecraft
+  time (in seconds).  The conversion is controlled by a cFE configuration parameter which is set equal to
+  the number of seconds between the spacecraft's epoch and the file system's epoch.  See #CFE_FS_Header_t
+  for the cFE file header format.  See /FM_DirListFileStat_t for the format of the directory listing
   status structure.  See /FM_DirListFileData_t for the format of a directory listing entry.
 **/
 
 /**
   \page cfsfmdg  CFS File Manager Deployment Guide
-  
-  To integrate the FM application, follow the CFS App Integration Guide. 
+
+  To integrate the FM application, follow the CFS App Integration Guide.
   Also, be sure to set up the configuration parameters and message IDs for
   the platform
 **/

--- a/fsw/inc/fm_msgdefs.h
+++ b/fsw/inc/fm_msgdefs.h
@@ -413,7 +413,9 @@
  *       of command argument verification and being able to place the command on
  *       the child task interface queue.
  *
- *       This command is only valid if FM_INCLUDE_DECOMPRESS is defined.
+ *       This command will only have an effect if FM is compiled with a decompression
+ *       algorithm enabled.  If compression is not enabled, issuing this command
+ *       will generate an error event.
  *
  *  \par Command Packet Structure
  *       #FM_DecompressCmd_t

--- a/fsw/inc/fm_platform_cfg.h
+++ b/fsw/inc/fm_platform_cfg.h
@@ -444,19 +444,6 @@
  */
 #define FM_TABLE_VALIDATION_ERR (-1)
 
-/**
- * \brief Include Decompress
- *
- *  \par Description:
- *       If this setting is defined, FM will be built with the Decompress
- *       command.  Otherwise Decompress will not be built into the application.
- *       If this setting is defined, FM will depend on an external FS_Lib.
- *
- *  \par Limits:
- *       N/A
- */
-/* #define FM_INCLUDE_DECOMPRESS */
-
 /**\}*/
 
 #endif

--- a/fsw/src/fm_app.c
+++ b/fsw/src/fm_app.c
@@ -236,6 +236,8 @@ int32 FM_AppInit(void)
         }
     }
 
+    FM_CompressionService_Init();
+
     return Result;
 }
 
@@ -313,11 +315,11 @@ void FM_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
         case FM_DELETE_ALL_CC:
             Result = FM_DeleteAllFilesCmd(BufPtr);
             break;
-#ifdef FM_INCLUDE_DECOMPRESS
+
         case FM_DECOMPRESS_CC:
             Result = FM_DecompressFileCmd(BufPtr);
             break;
-#endif
+
         case FM_CONCAT_CC:
             Result = FM_ConcatFilesCmd(BufPtr);
             break;

--- a/fsw/src/fm_app.h
+++ b/fsw/src/fm_app.h
@@ -26,10 +26,7 @@
 
 #include "cfe.h"
 #include "fm_msg.h"
-
-#ifdef FM_INCLUDE_DECOMPRESS
-#include "cfs_fs_lib.h"
-#endif
+#include "fm_compression.h"
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -103,10 +100,18 @@ typedef struct
 
     FM_ChildQueueEntry_t ChildQueue[FM_CHILD_QUEUE_DEPTH]; /**< \brief Child task command queue */
 
-#ifdef FM_INCLUDE_DECOMPRESS
-    FS_LIB_Decompress_State_t DecompressState;
+    /**
+     * \brief State of the embedded decompression routine
+     * This depends on the decompression option and may be NULL
+     */
+    FM_Decompressor_State_t *DecompressorStatePtr;
 
-#endif
+    /**
+     * \brief State of the embedded compression routine
+     * This depends on the compression option and may be NULL
+     */
+    FM_Compressor_State_t *CompressorStatePtr;
+
 } FM_GlobalData_t;
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/fm_child.c
+++ b/fsw/src/fm_child.c
@@ -37,10 +37,6 @@
 
 #include <string.h>
 
-#ifdef FM_INCLUDE_DECOMPRESS
-#include "cfs_fs_lib.h"
-#endif
-
 /************************************************************************
 ** OSAL Compatibility for directory name access
 ** New OSAL version have an access macro to get the string.  If that
@@ -221,11 +217,11 @@ void FM_ChildProcess(void)
         case FM_DELETE_ALL_CC:
             FM_ChildDeleteAllCmd(CmdArgs);
             break;
-#ifdef FM_INCLUDE_DECOMPRESS
+
         case FM_DECOMPRESS_CC:
             FM_ChildDecompressCmd(CmdArgs);
             break;
-#endif
+
         case FM_CONCAT_CC:
             FM_ChildConcatCmd(CmdArgs);
             break;
@@ -589,8 +585,6 @@ void FM_ChildDeleteAllCmd(FM_ChildQueueEntry_t *CmdArgs)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifdef FM_INCLUDE_DECOMPRESS
-
 void FM_ChildDecompressCmd(const FM_ChildQueueEntry_t *CmdArgs)
 {
     const char *CmdText    = "Decompress File";
@@ -600,7 +594,7 @@ void FM_ChildDecompressCmd(const FM_ChildQueueEntry_t *CmdArgs)
     FM_GlobalData.ChildCurrentCC = CmdArgs->CommandCode;
 
     /* Decompress source file into target file */
-    CFE_Status = FS_LIB_Decompress(&FM_GlobalData.DecompressState, CmdArgs->Source1, CmdArgs->Target);
+    CFE_Status = FM_Decompress_Impl(FM_GlobalData.DecompressorStatePtr, CmdArgs->Source1, CmdArgs->Target);
 
     if (CFE_Status != CFE_SUCCESS)
     {
@@ -624,8 +618,6 @@ void FM_ChildDecompressCmd(const FM_ChildQueueEntry_t *CmdArgs)
     FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
     FM_GlobalData.ChildCurrentCC  = 0;
 }
-
-#endif
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */

--- a/fsw/src/fm_child.h
+++ b/fsw/src/fm_child.h
@@ -27,10 +27,6 @@
 #include "cfe.h"
 #include "fm_msg.h"
 
-#ifdef FM_INCLUDE_DECOMPRESS
-#include "cfs_fs_lib.h"
-#endif
-
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* FM child task global function prototypes                        */
@@ -196,8 +192,6 @@ void FM_ChildDeleteCmd(const FM_ChildQueueEntry_t *CmdArgs);
  */
 void FM_ChildDeleteAllCmd(FM_ChildQueueEntry_t *CmdArgs);
 
-#ifdef FM_INCLUDE_DECOMPRESS
-
 /**
  *  \brief Child Task Decompress File Command Handler
  *
@@ -214,8 +208,6 @@ void FM_ChildDeleteAllCmd(FM_ChildQueueEntry_t *CmdArgs);
  *  \sa #FM_ChildQueueEntry_t, #FM_DecompressCmd_t
  */
 void FM_ChildDecompressCmd(const FM_ChildQueueEntry_t *CmdArgs);
-
-#endif
 
 /**
  *  \brief Child Task Concatenate Files Command Handler

--- a/fsw/src/fm_cmds.c
+++ b/fsw/src/fm_cmds.c
@@ -390,7 +390,6 @@ bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 /* FM command handler -- Decompress File                           */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-#ifdef FM_INCLUDE_DECOMPRESS
 
 bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
@@ -438,8 +437,6 @@ bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr)
 
     return CommandResult;
 }
-
-#endif
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */

--- a/fsw/src/fm_cmds.h
+++ b/fsw/src/fm_cmds.h
@@ -177,8 +177,6 @@ bool FM_DeleteFileCmd(const CFE_SB_Buffer_t *BufPtr);
  */
 bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr);
 
-#ifdef FM_INCLUDE_DECOMPRESS
-
 /**
  *  \brief Decompress Files Command Handler Function
  *
@@ -205,8 +203,6 @@ bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr);
  *  \sa #FM_DECOMPRESS_CC, #FM_DecompressCmd_t
  */
 bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr);
-
-#endif
 
 /**
  *  \brief Concatenate Files Command Handler Function

--- a/fsw/src/fm_compression.h
+++ b/fsw/src/fm_compression.h
@@ -1,0 +1,91 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,918-1, and identified as “Core Flight
+ * Software System (cFS) File Manager Application Version 2.6.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *   FM internal data compression API.  These functions may be unimplemented,
+ *   or they may map to external/3rd party data compression libraries such
+ *   as zLib.  In the latter case, an adapter layer is used to map the FM
+ *   compression/decompression tasks to the library of choice.
+ */
+
+#ifndef FM_COMPRESSION_H
+#define FM_COMPRESSION_H
+
+#include <common_types.h>
+#include <fm_platform_cfg.h>
+
+/**
+ * @brief The state object for a compressor
+ *
+ * This is an abstract object at this level, the definition of this
+ * object depends on the selected implementation.
+ */
+typedef struct FM_Compressor_State FM_Compressor_State_t;
+
+/**
+ * @brief The state object for a compressor
+ *
+ * This is an abstract object at this level, the definition of this
+ * object depends on the selected implementation.
+ */
+typedef struct FM_Decompressor_State FM_Decompressor_State_t;
+
+/**
+ * @brief Initialize the compression/decompression service
+ *
+ * Called during FM init to prepare service(s).  This may be a no-op
+ * if compression/decompression services are not enabled.
+ *
+ * @returns Status code
+ * @retval #CFE_SUCCESS if successful
+ */
+int32 FM_CompressionService_Init(void);
+
+/**
+ * @brief Abstract file decompression routine
+ *
+ * Decompresses the file specified by SrcFileName and stores
+ * the uncompressed data in the file specified by DstFileName
+ *
+ * @param State the decompressor state object
+ * @param SrcFileName the compressed input file
+ * @param DstFileName the uncompressed output file
+ *
+ * @returns Status code
+ * @retval #CFE_SUCCESS if decompression was successful
+ */
+int32 FM_Decompress_Impl(FM_Decompressor_State_t *State, const char *SrcFileName, const char *DstFileName);
+
+/**
+ * @brief Abstract file compression routine
+ *
+ * Compresses the file specified by SrcFileName and stores
+ * the compressed data in the file specified by DstFileName
+ *
+ * @param State the compressor state object
+ * @param SrcFileName the uncompressed input file
+ * @param DstFileName the compressed output file
+ *
+ * @returns Status code
+ * @retval #CFE_SUCCESS if decompression was successful
+ */
+int32 FM_Compress_Impl(FM_Compressor_State_t *State, const char *SrcFileName, const char *DstFileName);
+
+#endif

--- a/fsw/src/fm_compression_fslib.c
+++ b/fsw/src/fm_compression_fslib.c
@@ -1,0 +1,69 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,918-1, and identified as “Core Flight
+ * Software System (cFS) File Manager Application Version 2.6.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *  File Manager (FM) decompression facility via CFS "FS_Lib"
+ *
+ * Calls into CFS FS Lib to decompress file(s)
+ * Compression is not implemented.
+ */
+
+#include <string.h>
+#include <common_types.h>
+#include <cfe_error.h>
+#include <cfs_fs_lib.h>
+
+#include "fm_app.h"
+#include "fm_compression.h"
+
+/**
+ * @brief The state object for a compressor
+ *
+ * This is a wrapper around the object defined in CFS FS Lib
+ */
+struct FM_Decompressor_State
+{
+    FS_LIB_Decompress_State_t LibState;
+};
+
+/**
+ * @brief Instance of the decompressor state object
+ *
+ * A single instance is OK because this is only invoked
+ * from a single thread.
+ */
+static FM_Decompressor_State_t FM_FSLIB_DecompressState;
+
+int32 FM_CompressionService_Init(void)
+{
+    memset(&FM_FSLIB_DecompressState, 0, sizeof(FM_FSLIB_DecompressState));
+    FM_GlobalData.DecompressorStatePtr = &FM_FSLIB_DecompressState;
+    return CFE_SUCCESS;
+}
+
+int32 FM_Decompress_Impl(FM_Decompressor_State_t *State, const char *SrcFileName, const char *DstFileName)
+{
+    return FS_LIB_Decompress(&State->LibState, SrcFileName, DstFileName);
+}
+
+int32 FM_Compress_Impl(FM_Compressor_State_t *State, const char *SrcFileName, const char *DstFileName)
+{
+    return CFE_STATUS_NOT_IMPLEMENTED;
+}

--- a/fsw/src/fm_compression_none.c
+++ b/fsw/src/fm_compression_none.c
@@ -1,0 +1,46 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,918-1, and identified as “Core Flight
+ * Software System (cFS) File Manager Application Version 2.6.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *  File Manager (FM) non-implemented compression API
+ *
+ * This returns "CFE_STATUS_NOT_IMPLEMENTED" for the internal compression API
+ * calls, and is used when compression features are not required.
+ */
+
+#include <common_types.h>
+#include <cfe_error.h>
+
+#include "fm_compression.h"
+
+int32 FM_CompressionService_Init(void)
+{
+    return CFE_SUCCESS;
+}
+
+int32 FM_Decompress_Impl(FM_Decompressor_State_t *State, const char *SrcFileName, const char *DstFileName)
+{
+    return CFE_STATUS_NOT_IMPLEMENTED;
+}
+
+int32 FM_Compress_Impl(FM_Compressor_State_t *State, const char *SrcFileName, const char *DstFileName)
+{
+    return CFE_STATUS_NOT_IMPLEMENTED;
+}

--- a/fsw/src/fm_compression_zlib.c
+++ b/fsw/src/fm_compression_zlib.c
@@ -1,0 +1,46 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,918-1, and identified as “Core Flight
+ * Software System (cFS) File Manager Application Version 2.6.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *  File Manager (FM) zLib compression API
+ *
+ * This invokes inflate/deflate routines in an external zLib library.
+ * The library must be provided separately.
+ */
+
+#include <common_types.h>
+#include <cfe_error.h>
+
+#include "fm_compression.h"
+
+int32 FM_CompressionService_Init(void)
+{
+    return CFE_SUCCESS;
+}
+
+int32 FM_Decompress_Impl(FM_Decompressor_State_t *State, const char *SrcFileName, const char *DstFileName)
+{
+    return CFE_STATUS_NOT_IMPLEMENTED;
+}
+
+int32 FM_Compress_Impl(FM_Compressor_State_t *State, const char *SrcFileName, const char *DstFileName)
+{
+    return CFE_STATUS_NOT_IMPLEMENTED;
+}

--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -13,6 +13,7 @@ add_cfe_coverage_stubs("fm_internal"
   stubs/fm_cmds_stubs.c
   stubs/fm_cmd_utils_stubs.c
   stubs/fm_cmd_utils_handlers.c
+  stubs/fm_compression_stubs.c
   stubs/fm_app_stubs.c
   stubs/fm_child_stubs.c
   stubs/fm_tbl_stubs.c

--- a/unit-test/fm_app_tests.c
+++ b/unit-test/fm_app_tests.c
@@ -527,7 +527,6 @@ void Test_FM_ProcessCmd_DeleteAllFilesCCReturn(void)
     UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
 }
 
-#ifdef FM_INCLUDE_DECOMPRESS
 void Test_FM_ProcessCmd_DecompressFileCCReturn(void)
 {
     /* Arrange */
@@ -545,7 +544,6 @@ void Test_FM_ProcessCmd_DecompressFileCCReturn(void)
     UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
     UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
 }
-#endif
 
 void Test_FM_ProcessCmd_ConcatFilesCCReturn(void)
 {
@@ -820,10 +818,10 @@ void add_FM_ProcessCmd_tests(void)
 
     UtTest_Add(Test_FM_ProcessCmd_DeleteAllFilesCCReturn, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_ProcessCmd_DeleteAllFilesCCReturn");
-#ifdef FM_INCLUDE_DECOMPRESS
+
     UtTest_Add(Test_FM_ProcessCmd_DecompressFileCCReturn, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_ProcessCmd_DecompressFileCCReturn");
-#endif
+
     UtTest_Add(Test_FM_ProcessCmd_ConcatFilesCCReturn, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_PRocessCmd_ConcatFilesCCReturn");
 

--- a/unit-test/fm_child_tests.c
+++ b/unit-test/fm_child_tests.c
@@ -39,9 +39,6 @@
  * UT Testing
  */
 #include "fm_test_utils.h"
-#ifdef FM_INCLUDE_DECOMPRESS
-#include "cfs_fs_lib.h"
-#endif
 
 /*
  * UT includes
@@ -250,13 +247,12 @@ void Test_FM_ChildProcess_FMDeleteAllCC(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_OS_ERR_EID);
 }
 
-#ifdef FM_INCLUDE_DECOMPRESS
 void Test_FM_ChildProcess_FMDecompressCC(void)
 {
     /* Arrange */
     FM_GlobalData.ChildQueue[0].CommandCode = FM_DECOMPRESS_CC;
 
-    UT_SetDefaultReturnValue(UT_KEY(FS_LIB_Decompress), !CFE_SUCCESS);
+    UT_SetDefaultReturnValue(UT_KEY(FM_Decompress_Impl), !CFE_SUCCESS);
 
     /* Act */
     UtAssert_VOIDCALL(FM_ChildProcess());
@@ -264,12 +260,11 @@ void Test_FM_ChildProcess_FMDecompressCC(void)
     /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, FM_GlobalData.ChildQueue[0].CommandCode);
 
-    UtAssert_STUB_COUNT(FS_LIB_Decompress, 1);
+    UtAssert_STUB_COUNT(FM_Decompress_Impl, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DECOM_CFE_ERR_EID);
 }
-#endif
 
 void Test_FM_ChildProcess_FMConcatCC(void)
 {
@@ -911,7 +906,7 @@ void Test_FM_ChildDeleteAllCmd_FilenameStateDefaultReturn(void)
 /* ****************
  * ChildDecompressCmd Tests
  * ***************/
-#ifdef FM_INCLUDE_DECOMPRESS
+
 void Test_FM_ChildDecompressCmd_FSDecompressSuccess(void)
 {
     /* Arrange */
@@ -925,7 +920,7 @@ void Test_FM_ChildDecompressCmd_FSDecompressSuccess(void)
     /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
-    UtAssert_STUB_COUNT(FS_LIB_Decompress, 1);
+    UtAssert_STUB_COUNT(FM_Decompress_Impl, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DECOM_CMD_EID);
@@ -937,7 +932,7 @@ void Test_FM_ChildDecompressCmd_FSDecompressNotSuccess(void)
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DECOMPRESS_CC};
 
     FM_GlobalData.ChildCurrentCC = 1;
-    UT_SetDefaultReturnValue(UT_KEY(FS_LIB_Decompress), !CFE_SUCCESS);
+    UT_SetDefaultReturnValue(UT_KEY(FM_Decompress_Impl), !CFE_SUCCESS);
 
     /* Act */
     UtAssert_VOIDCALL(FM_ChildDecompressCmd(&queue_entry));
@@ -945,12 +940,11 @@ void Test_FM_ChildDecompressCmd_FSDecompressNotSuccess(void)
     /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
 
-    UtAssert_STUB_COUNT(FS_LIB_Decompress, 1);
+    UtAssert_STUB_COUNT(FM_Decompress_Impl, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DECOM_CFE_ERR_EID);
 }
-#endif
 
 /* ****************
  * ChildConcatCmd Tests
@@ -2265,10 +2259,10 @@ void add_FM_ChildProcess_tests(void)
 
     UtTest_Add(Test_FM_ChildProcess_FMDeleteAllCC, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_ChildProcess_FMDeleteAllCC");
-#ifdef FM_INCLUDE_DECOMPRESS
+
     UtTest_Add(Test_FM_ChildProcess_FMDecompressCC, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_ChildProcess_FMDecompressCC");
-#endif
+
     UtTest_Add(Test_FM_ChildProcess_FMConcatCC, FM_Test_Setup, FM_Test_Teardown, "Test_FM_ChildProcess_FMConcatCC");
 
     UtTest_Add(Test_FM_ChildProcess_FMCreateDirCC, FM_Test_Setup, FM_Test_Teardown,
@@ -2369,7 +2363,7 @@ void add_FM_ChildDeleteAllCmd_tests(void)
     UtTest_Add(Test_FM_ChildDeleteAllCmd_FilenameStateDefaultReturn, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_ChildDeleteAllCmd_FilenameStateDefaultReturn");
 }
-#ifdef FM_INCLUDE_DECOMPRESS
+
 void add_FM_ChildDecompressCmd_tests(void)
 {
     UtTest_Add(Test_FM_ChildDecompressCmd_FSDecompressNotSuccess, FM_Test_Setup, FM_Test_Teardown,
@@ -2378,7 +2372,6 @@ void add_FM_ChildDecompressCmd_tests(void)
     UtTest_Add(Test_FM_ChildDecompressCmd_FSDecompressSuccess, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_ChildDecompressCmd_FSDecompressSuccess");
 }
-#endif
 
 void add_FM_ChildConcatCmd_tests(void)
 {
@@ -2603,9 +2596,7 @@ void UtTest_Setup(void)
     add_FM_ChildRenameCmd_tests();
     add_FM_ChildDeleteCmd_tests();
     add_FM_ChildDeleteAllCmd_tests();
-#ifdef FM_INCLUDE_DECOMPRESS
     add_FM_ChildDecompressCmd_tests();
-#endif
     add_FM_ChildConcatCmd_tests();
     add_FM_ChildFileInfoCmd_tests();
     add_FM_ChildCreateDirCmd_tests();

--- a/unit-test/fm_cmds_tests.c
+++ b/unit-test/fm_cmds_tests.c
@@ -892,7 +892,6 @@ void add_FM_DeleteAllFilesCmd_tests(void)
                "Test_FM_DeleteAllFilesCmd_NoChildTask");
 }
 
-#ifdef FM_INCLUDE_DECOMPRESS
 /****************************/
 /* Decompress File Test s   */
 /****************************/
@@ -1018,8 +1017,6 @@ void add_FM_DecompressFileCmd_tests(void)
     UtTest_Add(Test_FM_DecompressFileCmd_NoChildTask, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_DecompressFileCmd_NoChildTask");
 }
-
-#endif
 
 /****************************/
 /* Concat Files Tests       */
@@ -2292,11 +2289,7 @@ void UtTest_Setup(void)
     add_FM_RenameFileCmd_tests();
     add_FM_DeleteFileCmd_tests();
     add_FM_DeleteAllFilesCmd_tests();
-
-#ifdef FM_INCLUDE_DECOMPRESS
     add_FM_DecompressFileCmd_tests();
-#endif
-
     add_FM_ConcatFilesCmd_tests();
     add_FM_GetFileInfoCmd_tests();
     add_FM_GetOpenFilesCmd_tests();

--- a/unit-test/stubs/fm_cmds_stubs.c
+++ b/unit-test/stubs/fm_cmds_stubs.c
@@ -19,229 +19,297 @@
 
 /**
  * @file
- *  Provides functions for the execution of the FM ground commands
+ *
+ * Auto-Generated stub implementations for functions defined in fm_cmds header
  */
 
-#include "cfe.h"
-#include "fm_msg.h"
-#include "fm_msgdefs.h"
-#include "fm_msgids.h"
-#include "fm_events.h"
-#include "fm_app.h"
 #include "fm_cmds.h"
-#include "fm_cmd_utils.h"
-#include "fm_perfids.h"
-#include "fm_platform_cfg.h"
-#include "fm_version.h"
-#include "fm_verify.h"
-#include "fm_test_utils.h"
+#include "utgenstub.h"
 
-/************************************************************************
-** UT Includes
-*************************************************************************/
-#include "uttest.h"
-#include "utassert.h"
-#include "utstubs.h"
-
-#include <string.h>
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM command handler -- NOOP                                      */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-bool FM_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
-{
-    return UT_DEFAULT_IMPL(FM_NoopCmd) != 0;
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM command handler -- Reset Counters                            */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
-{
-    return UT_DEFAULT_IMPL(FM_ResetCountersCmd) != 0;
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM command handler -- Copy File                                 */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-bool FM_CopyFileCmd(const CFE_SB_Buffer_t *BufPtr)
-{
-    return UT_DEFAULT_IMPL(FM_CopyFileCmd) != 0;
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM command handler -- Move File                                 */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-bool FM_MoveFileCmd(const CFE_SB_Buffer_t *BufPtr)
-{
-    return UT_DEFAULT_IMPL(FM_MoveFileCmd) != 0;
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM command handler -- Rename File                               */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-bool FM_RenameFileCmd(const CFE_SB_Buffer_t *BufPtr)
-{
-    return UT_DEFAULT_IMPL(FM_RenameFileCmd) != 0;
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM command handler -- Delete File                               */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-bool FM_DeleteFileCmd(const CFE_SB_Buffer_t *BufPtr)
-{
-    return UT_DEFAULT_IMPL(FM_DeleteFileCmd) != 0;
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM command handler -- Delete All Files                          */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr)
-{
-    return UT_DEFAULT_IMPL(FM_DeleteAllFilesCmd) != 0;
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM command handler -- Decompress File                           */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-#ifdef FM_INCLUDE_DECOMPRESS
-
-bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr)
-{
-    return UT_DEFAULT_IMPL(FM_DecompressFileCmd) != 0;
-}
-
-#endif
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM command handler -- Concatenate Files                         */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_ConcatFilesCmd()
+ * ----------------------------------------------------
+ */
 bool FM_ConcatFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    return UT_DEFAULT_IMPL(FM_ConcatFilesCmd) != 0;
+    UT_GenStub_SetupReturnBuffer(FM_ConcatFilesCmd, bool);
+
+    UT_GenStub_AddParam(FM_ConcatFilesCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(FM_ConcatFilesCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_ConcatFilesCmd, bool);
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM command handler -- Get File Info                             */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-bool FM_GetFileInfoCmd(const CFE_SB_Buffer_t *BufPtr)
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_CopyFileCmd()
+ * ----------------------------------------------------
+ */
+bool FM_CopyFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    return UT_DEFAULT_IMPL(FM_GetFileInfoCmd) != 0;
+    UT_GenStub_SetupReturnBuffer(FM_CopyFileCmd, bool);
+
+    UT_GenStub_AddParam(FM_CopyFileCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(FM_CopyFileCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_CopyFileCmd, bool);
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM command handler -- Get List of Open Files                    */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr)
-{
-    return UT_DEFAULT_IMPL(FM_GetOpenFilesCmd) != 0;
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM command handler -- Create Directory                          */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_CreateDirectoryCmd()
+ * ----------------------------------------------------
+ */
 bool FM_CreateDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    return UT_DEFAULT_IMPL(FM_CreateDirectoryCmd);
+    UT_GenStub_SetupReturnBuffer(FM_CreateDirectoryCmd, bool);
+
+    UT_GenStub_AddParam(FM_CreateDirectoryCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(FM_CreateDirectoryCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_CreateDirectoryCmd, bool);
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM command handler -- Delete Directory                          */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_DecompressFileCmd()
+ * ----------------------------------------------------
+ */
+bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_SetupReturnBuffer(FM_DecompressFileCmd, bool);
 
+    UT_GenStub_AddParam(FM_DecompressFileCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(FM_DecompressFileCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_DecompressFileCmd, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_DeleteAllFilesCmd()
+ * ----------------------------------------------------
+ */
+bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_SetupReturnBuffer(FM_DeleteAllFilesCmd, bool);
+
+    UT_GenStub_AddParam(FM_DeleteAllFilesCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(FM_DeleteAllFilesCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_DeleteAllFilesCmd, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_DeleteDirectoryCmd()
+ * ----------------------------------------------------
+ */
 bool FM_DeleteDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    return UT_DEFAULT_IMPL(FM_DeleteDirectoryCmd) != 0;
+    UT_GenStub_SetupReturnBuffer(FM_DeleteDirectoryCmd, bool);
+
+    UT_GenStub_AddParam(FM_DeleteDirectoryCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(FM_DeleteDirectoryCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_DeleteDirectoryCmd, bool);
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM command handler -- Get List of Directory Entries (to file)   */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_DeleteFileCmd()
+ * ----------------------------------------------------
+ */
+bool FM_DeleteFileCmd(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_SetupReturnBuffer(FM_DeleteFileCmd, bool);
 
+    UT_GenStub_AddParam(FM_DeleteFileCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(FM_DeleteFileCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_DeleteFileCmd, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_GetDirListFileCmd()
+ * ----------------------------------------------------
+ */
 bool FM_GetDirListFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    return UT_DEFAULT_IMPL(FM_GetDirListFileCmd) != 0;
+    UT_GenStub_SetupReturnBuffer(FM_GetDirListFileCmd, bool);
+
+    UT_GenStub_AddParam(FM_GetDirListFileCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(FM_GetDirListFileCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_GetDirListFileCmd, bool);
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM command handler -- Get List of Directory Entries (to pkt)    */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_GetDirListPktCmd()
+ * ----------------------------------------------------
+ */
 bool FM_GetDirListPktCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    return UT_DEFAULT_IMPL(FM_GetDirListPktCmd) != 0;
+    UT_GenStub_SetupReturnBuffer(FM_GetDirListPktCmd, bool);
+
+    UT_GenStub_AddParam(FM_GetDirListPktCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(FM_GetDirListPktCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_GetDirListPktCmd, bool);
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM command handler -- Get File System Free Space                */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_GetFileInfoCmd()
+ * ----------------------------------------------------
+ */
+bool FM_GetFileInfoCmd(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_SetupReturnBuffer(FM_GetFileInfoCmd, bool);
 
+    UT_GenStub_AddParam(FM_GetFileInfoCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(FM_GetFileInfoCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_GetFileInfoCmd, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_GetOpenFilesCmd()
+ * ----------------------------------------------------
+ */
+bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_SetupReturnBuffer(FM_GetOpenFilesCmd, bool);
+
+    UT_GenStub_AddParam(FM_GetOpenFilesCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(FM_GetOpenFilesCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_GetOpenFilesCmd, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_MonitorFilesystemSpaceCmd()
+ * ----------------------------------------------------
+ */
 bool FM_MonitorFilesystemSpaceCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    return UT_DEFAULT_IMPL(FM_MonitorFilesystemSpaceCmd) != 0;
+    UT_GenStub_SetupReturnBuffer(FM_MonitorFilesystemSpaceCmd, bool);
+
+    UT_GenStub_AddParam(FM_MonitorFilesystemSpaceCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(FM_MonitorFilesystemSpaceCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_MonitorFilesystemSpaceCmd, bool);
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM command handler -- Set Table Entry Enable/Disable State      */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-bool FM_SetTableStateCmd(const CFE_SB_Buffer_t *BufPtr)
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_MoveFileCmd()
+ * ----------------------------------------------------
+ */
+bool FM_MoveFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    return UT_DEFAULT_IMPL(FM_SetTableStateCmd) != 0;
+    UT_GenStub_SetupReturnBuffer(FM_MoveFileCmd, bool);
+
+    UT_GenStub_AddParam(FM_MoveFileCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(FM_MoveFileCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_MoveFileCmd, bool);
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM command handler -- Set Permissions for a file                */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_NoopCmd()
+ * ----------------------------------------------------
+ */
+bool FM_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_SetupReturnBuffer(FM_NoopCmd, bool);
 
+    UT_GenStub_AddParam(FM_NoopCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(FM_NoopCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_NoopCmd, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_RenameFileCmd()
+ * ----------------------------------------------------
+ */
+bool FM_RenameFileCmd(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_SetupReturnBuffer(FM_RenameFileCmd, bool);
+
+    UT_GenStub_AddParam(FM_RenameFileCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(FM_RenameFileCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_RenameFileCmd, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_ResetCountersCmd()
+ * ----------------------------------------------------
+ */
+bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_SetupReturnBuffer(FM_ResetCountersCmd, bool);
+
+    UT_GenStub_AddParam(FM_ResetCountersCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(FM_ResetCountersCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_ResetCountersCmd, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_SetPermissionsCmd()
+ * ----------------------------------------------------
+ */
 bool FM_SetPermissionsCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    return UT_DEFAULT_IMPL(FM_SetPermissionsCmd) != 0;
+    UT_GenStub_SetupReturnBuffer(FM_SetPermissionsCmd, bool);
+
+    UT_GenStub_AddParam(FM_SetPermissionsCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(FM_SetPermissionsCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_SetPermissionsCmd, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_SetTableStateCmd()
+ * ----------------------------------------------------
+ */
+bool FM_SetTableStateCmd(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_SetupReturnBuffer(FM_SetTableStateCmd, bool);
+
+    UT_GenStub_AddParam(FM_SetTableStateCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(FM_SetTableStateCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_SetTableStateCmd, bool);
 }

--- a/unit-test/stubs/fm_compression_stubs.c
+++ b/unit-test/stubs/fm_compression_stubs.c
@@ -1,0 +1,77 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,918-1, and identified as “Core Flight
+ * Software System (cFS) File Manager Application Version 2.6.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *
+ * Auto-Generated stub implementations for functions defined in fm_compression header
+ */
+
+#include "fm_compression.h"
+#include "utgenstub.h"
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_Compress_Impl()
+ * ----------------------------------------------------
+ */
+int32 FM_Compress_Impl(FM_Compressor_State_t *State, const char *SrcFileName, const char *DstFileName)
+{
+    UT_GenStub_SetupReturnBuffer(FM_Compress_Impl, int32);
+
+    UT_GenStub_AddParam(FM_Compress_Impl, FM_Compressor_State_t *, State);
+    UT_GenStub_AddParam(FM_Compress_Impl, const char *, SrcFileName);
+    UT_GenStub_AddParam(FM_Compress_Impl, const char *, DstFileName);
+
+    UT_GenStub_Execute(FM_Compress_Impl, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_Compress_Impl, int32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_CompressionService_Init()
+ * ----------------------------------------------------
+ */
+int32 FM_CompressionService_Init(void)
+{
+    UT_GenStub_SetupReturnBuffer(FM_CompressionService_Init, int32);
+
+    UT_GenStub_Execute(FM_CompressionService_Init, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_CompressionService_Init, int32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for FM_Decompress_Impl()
+ * ----------------------------------------------------
+ */
+int32 FM_Decompress_Impl(FM_Decompressor_State_t *State, const char *SrcFileName, const char *DstFileName)
+{
+    UT_GenStub_SetupReturnBuffer(FM_Decompress_Impl, int32);
+
+    UT_GenStub_AddParam(FM_Decompress_Impl, FM_Decompressor_State_t *, State);
+    UT_GenStub_AddParam(FM_Decompress_Impl, const char *, SrcFileName);
+    UT_GenStub_AddParam(FM_Decompress_Impl, const char *, DstFileName);
+
+    UT_GenStub_Execute(FM_Decompress_Impl, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_Decompress_Impl, int32);
+}


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/FM/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Adds a cmake option for compression sub-component implementation.  This replaces the FM_INCLUDE_DECOMPRESS option in fm_platform_cfg.h.

Currently available options are:
 - fslib (should be equivalent to FM_INCLUDE_DECOMPRESS set)
 - none (should be equivalent to FM_INCLUDE_DECOMPRESS unset)
 - zlib (stub for future work)

This lays the groundwork to support compression in addition to decompression, using an external 3rd part library if desired.

Fixes #73

**Testing performed**
Build and run all tests

**Expected behavior changes**
Compression option no longer in header file - now in a CMake option with source selection.  Basically equivalent though.

**System(s) tested on**
Debian

**Additional context**
All conditional compilation (`#ifdef`) around compression has been removed.  This comprised a fair bit of code in FM that was not being tested in any workflow because compression is usually disabled.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
