### PR TITLE
Fix #66, remove static from table definition

### DIFF
--- a/fsw/tables/fm_monitor.c
+++ b/fsw/tables/fm_monitor.c
@@ -37,9 +37,8 @@
 /*
 ** FM file system free space table header
 */
-static CFE_TBL_FileDef_t CFE_TBL_FileDef
-    __attribute__((__used__)) = {"FM_MonitorTable", FM_APP_NAME "." FM_TABLE_CFE_NAME, FM_TABLE_DEF_DESC,
-                                 FM_TABLE_FILENAME, sizeof(FM_MonitorTable_t)};
+CFE_TBL_FileDef_t CFE_TBL_FileDef = {"FM_MonitorTable", FM_APP_NAME "." FM_TABLE_CFE_NAME, FM_TABLE_DEF_DESC,
+                                     FM_TABLE_FILENAME, sizeof(FM_MonitorTable_t)};
 
 /*
 ** FM file system monitor table data


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/FM/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
This is not needed, and it ends up also needing a compiler-specific attribute to avoid a warning.  Much simpler without it.

Fixes #66

**Testing performed**
Build and run all tests

**Expected behavior changes**
None

**System(s) tested on**
Debian

**Additional context**
FSB coding standards restrict use of compiler-specific attributes - should limit to standard ANSI/ISO C.  This makes it comply.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

