### PR TITLE
Fix #74, add payload submember for all cmd/tlm

### DIFF
--- a/fsw/inc/fm_msg.h
+++ b/fsw/inc/fm_msg.h
@@ -68,6 +68,20 @@ typedef struct
 } FM_ResetCmd_t;
 
 /**
+ * \brief Copy/Move File command payload structure
+ *
+ * Contains a source and target file name and an overwrite flag
+ *
+ * Used by #FM_COPY_CC, #FM_MOVE_CC
+ */
+typedef struct
+{
+    uint16 Overwrite;               /**< \brief Allow overwrite */
+    char   Source[OS_MAX_PATH_LEN]; /**< \brief Source filename */
+    char   Target[OS_MAX_PATH_LEN]; /**< \brief Target filename */
+} FM_OvwSourceTargetFilename_Payload_t;
+
+/**
  *  \brief Copy File command packet structure
  *
  *  For command details see #FM_COPY_CC
@@ -76,9 +90,7 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
-    uint16 Overwrite;               /**< \brief Allow overwrite */
-    char   Source[OS_MAX_PATH_LEN]; /**< \brief Source filename */
-    char   Target[OS_MAX_PATH_LEN]; /**< \brief Target filename */
+    FM_OvwSourceTargetFilename_Payload_t Payload; /**< \brief Command payload */
 } FM_CopyFileCmd_t;
 
 /**
@@ -90,10 +102,20 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
-    uint16 Overwrite;               /**< \brief Allow overwrite */
-    char   Source[OS_MAX_PATH_LEN]; /**< \brief Source filename */
-    char   Target[OS_MAX_PATH_LEN]; /**< \brief Target filename */
+    FM_OvwSourceTargetFilename_Payload_t Payload; /**< \brief Command payload */
+
 } FM_MoveFileCmd_t;
+
+/**
+ *  \brief Source and Target filename command payload structure
+ *
+ *  Used by #FM_RENAME_CC, #FM_DECOMPRESS_CC
+ */
+typedef struct
+{
+    char Source[OS_MAX_PATH_LEN]; /**< \brief Source filename */
+    char Target[OS_MAX_PATH_LEN]; /**< \brief Target filename */
+} FM_SourceTargetFileName_Payload_t;
 
 /**
  *  \brief Rename File command packet structure
@@ -104,9 +126,18 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
-    char Source[OS_MAX_PATH_LEN]; /**< \brief Source filename */
-    char Target[OS_MAX_PATH_LEN]; /**< \brief Target filename */
+    FM_SourceTargetFileName_Payload_t Payload; /**< \brief Command payload */
 } FM_RenameFileCmd_t;
+
+/**
+ *  \brief Single filename command payload structure
+ *
+ *  Used by #FM_DELETE_CC
+ */
+typedef struct
+{
+    char Filename[OS_MAX_PATH_LEN]; /**< \brief Delete filename */
+} FM_SingleFilename_Payload_t;
 
 /**
  *  \brief Delete File command packet structure
@@ -115,9 +146,20 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader;                 /**< \brief Command header */
-    char                    Filename[OS_MAX_PATH_LEN]; /**< \brief Delete filename */
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+
+    FM_SingleFilename_Payload_t Payload; /**< \brief Command Payload */
 } FM_DeleteFileCmd_t;
+
+/**
+ *  \brief Single directory command payload structure
+ *
+ *  Used by #FM_DELETE_ALL_CC, #FM_CREATE_DIR_CC, #FM_DELETE_DIR_CC
+ */
+typedef struct
+{
+    char Directory[OS_MAX_PATH_LEN]; /**< \brief Directory name */
+} FM_DirectoryName_Payload_t;
 
 /**
  *  \brief Delete All command packet structure
@@ -126,8 +168,9 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader;                  /**< \brief Command header */
-    char                    Directory[OS_MAX_PATH_LEN]; /**< \brief Directory name */
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+
+    FM_DirectoryName_Payload_t Payload; /**< \brief Command Payload */
 } FM_DeleteAllCmd_t;
 
 /**
@@ -137,10 +180,22 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader;               /**< \brief Command header */
-    char                    Source[OS_MAX_PATH_LEN]; /**< \brief Source filename */
-    char                    Target[OS_MAX_PATH_LEN]; /**< \brief Target filename */
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+
+    FM_SourceTargetFileName_Payload_t Payload; /**< \brief Command Payload */
 } FM_DecompressCmd_t;
+
+/**
+ * \brief Two source, one target filename command payload structure
+ *
+ * Used by #FM_CONCAT_CC
+ */
+typedef struct
+{
+    char Source1[OS_MAX_PATH_LEN]; /**< \brief Source 1 filename */
+    char Source2[OS_MAX_PATH_LEN]; /**< \brief Source 2 filename */
+    char Target[OS_MAX_PATH_LEN];  /**< \brief Target filename */
+} FM_TwoSourceOneTarget_Payload_t;
 
 /**
  *  \brief Concatenate Files command packet structure
@@ -151,10 +206,19 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
-    char Source1[OS_MAX_PATH_LEN]; /**< \brief Source 1 filename */
-    char Source2[OS_MAX_PATH_LEN]; /**< \brief Source 2 filename */
-    char Target[OS_MAX_PATH_LEN];  /**< \brief Target filename */
+    FM_TwoSourceOneTarget_Payload_t Payload; /**< \brief Command Payload */
 } FM_ConcatCmd_t;
+
+/**
+ *  \brief Filename and CRC command payload structure
+ *
+ *  Used by #FM_GET_FILE_INFO_CC
+ */
+typedef struct
+{
+    char   Filename[OS_MAX_PATH_LEN]; /**< \brief Filename */
+    uint32 FileInfoCRC;               /**< \brief File info CRC method */
+} FM_FilenameAndCRC_Payload_t;
 
 /**
  *  \brief Get File Info command packet structure
@@ -165,8 +229,7 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
-    char   Filename[OS_MAX_PATH_LEN]; /**< \brief Filename */
-    uint32 FileInfoCRC;               /**< \brief File info CRC method */
+    FM_FilenameAndCRC_Payload_t Payload; /**< \brief Command Payload */
 } FM_GetFileInfoCmd_t;
 
 /**
@@ -188,7 +251,7 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
-    char Directory[OS_MAX_PATH_LEN]; /**< \brief Directory name */
+    FM_DirectoryName_Payload_t Payload; /**< \brief Command Payload */
 } FM_CreateDirCmd_t;
 
 /**
@@ -200,8 +263,22 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
-    char Directory[OS_MAX_PATH_LEN]; /**< \brief Directory name */
+    FM_DirectoryName_Payload_t Payload; /**< \brief Command Payload */
 } FM_DeleteDirCmd_t;
+
+/**
+ *  \brief Get Directory and output to file command payload
+ *
+ * Contains a directory and output file name, with optional flags
+ * Used by #FM_GET_DIR_FILE_CC
+ */
+typedef struct
+{
+    char  Directory[OS_MAX_PATH_LEN]; /**< \brief Directory name */
+    char  Filename[OS_MAX_PATH_LEN];  /**< \brief Filename */
+    uint8 GetSizeTimeMode;            /**< \brief Option to query size, time, and mode of files (CPU intensive) */
+    uint8 Spare01[3];                 /**< \brief Padding to 32 bit boundary */
+} FM_GetDirectoryToFile_Payload_t;
 
 /**
  *  \brief Get DIR List to File command packet structure
@@ -212,11 +289,22 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
-    char  Directory[OS_MAX_PATH_LEN]; /**< \brief Directory name */
-    char  Filename[OS_MAX_PATH_LEN];  /**< \brief Filename */
-    uint8 GetSizeTimeMode;            /**< \brief Option to query size, time, and mode of files (CPU intensive) */
-    uint8 Spare01[3];                 /**< \brief Padding to 32 bit boundary */
+    FM_GetDirectoryToFile_Payload_t Payload; /**< \brief Command Payload */
 } FM_GetDirFileCmd_t;
+
+/**
+ *  \brief Get Directory and output to message command payload
+ *
+ * Contains a directory and position offset, with optional flags
+ * Used by #FM_GET_DIR_PKT_CC
+ */
+typedef struct
+{
+    char   Directory[OS_MAX_PATH_LEN]; /**< \brief Directory name */
+    uint32 DirListOffset;              /**< \brief Index of 1st dir entry to put in packet */
+    uint8  GetSizeTimeMode;            /**< \brief Option to query size, time, and mode of files (CPU intensive) */
+    uint8  Spare01[3];                 /**< \brief Padding to 32 bit boundary */
+} FM_GetDirectoryToPkt_Payload_t;
 
 /**
  *  \brief Get DIR List to Packet command packet structure
@@ -227,10 +315,7 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
-    char   Directory[OS_MAX_PATH_LEN]; /**< \brief Directory name */
-    uint32 DirListOffset;              /**< \brief Index of 1st dir entry to put in packet */
-    uint8  GetSizeTimeMode;            /**< \brief Option to query size, time, and mode of files (CPU intensive) */
-    uint8  Spare01[3];                 /**< \brief Padding to 32 bit boundary */
+    FM_GetDirectoryToPkt_Payload_t Payload; /**< \brief Command Payload */
 } FM_GetDirPktCmd_t;
 
 /**
@@ -244,6 +329,17 @@ typedef struct
 } FM_MonitorFilesystemSpaceCmd_t;
 
 /**
+ *  \brief Table Index and State command payload structure
+ *
+ *  Used by #FM_SET_TABLE_STATE_CC
+ */
+typedef struct
+{
+    uint32 TableEntryIndex; /**< \brief Table entry index */
+    uint32 TableEntryState; /**< \brief New table entry state */
+} FM_TableIndexAndState_Payload_t;
+
+/**
  *  \brief Set Table State command packet structure
  *
  *  For command details see #FM_SET_TABLE_STATE_CC
@@ -252,9 +348,19 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
-    uint32 TableEntryIndex; /**< \brief Table entry index */
-    uint32 TableEntryState; /**< \brief New table entry state */
+    FM_TableIndexAndState_Payload_t Payload; /**< \brief Command Payload */
 } FM_SetTableStateCmd_t;
+
+/**
+ *  \brief File name and mode command payload structure
+ *
+ *  Used by #FM_SET_FILE_PERM_CC
+ */
+typedef struct
+{
+    char   FileName[OS_MAX_PATH_LEN]; /**< \brief File name of the permissions to set */
+    uint32 Mode;                      /**< \brief Permissions, passed directly to OS_chmod */
+} FM_FilenameAndMode_Payload_t;
 
 /**
  *  \brief Set Permissions for a file
@@ -265,8 +371,7 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
-    char   FileName[OS_MAX_PATH_LEN]; /**< \brief File name of the permissions to set */
-    uint32 Mode;                      /**< \brief Permissions, passed directly to OS_chmod */
+    FM_FilenameAndMode_Payload_t Payload;
 } FM_SetPermCmd_t;
 
 /**\}*/
@@ -294,17 +399,25 @@ typedef struct
 } FM_DirListEntry_t;
 
 /**
+ *  \brief Get Directory Listing telemetry payload
+ */
+typedef struct
+{
+    char              DirName[OS_MAX_PATH_LEN];          /**< \brief Directory Name */
+    uint32            TotalFiles;                        /**< \brief Number of files in the directory */
+    uint32            PacketFiles;                       /**< \brief Number of files in this packet */
+    uint32            FirstFile;                         /**< \brief Index into directory files of first packet file */
+    FM_DirListEntry_t FileList[FM_DIR_LIST_PKT_ENTRIES]; /**< \brief Directory listing file data */
+} FM_DirListPkt_Payload_t;
+
+/**
  *  \brief Get Directory Listing telemetry packet
  */
 typedef struct
 {
     CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief Telemetry Header */
 
-    char              DirName[OS_MAX_PATH_LEN];          /**< \brief Directory Name */
-    uint32            TotalFiles;                        /**< \brief Number of files in the directory */
-    uint32            PacketFiles;                       /**< \brief Number of files in this packet */
-    uint32            FirstFile;                         /**< \brief Index into directory files of first packet file */
-    FM_DirListEntry_t FileList[FM_DIR_LIST_PKT_ENTRIES]; /**< \brief Directory listing file data */
+    FM_DirListPkt_Payload_t Payload; /**< \brief Telemetry Payload */
 } FM_DirListPkt_t;
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -330,12 +443,10 @@ typedef struct
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /**
- *  \brief Get File Info telemetry packet
+ *  \brief Get File Info telemetry payload
  */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief Telemetry Header */
-
     uint8  FileStatus;                /**< \brief Status indicating whether the file is open or closed */
     uint8  CRC_Computed;              /**< \brief Flag indicating whether a CRC was computed or not */
     uint8  Spare[2];                  /**< \brief Structure padding */
@@ -344,6 +455,16 @@ typedef struct
     uint32 LastModifiedTime;          /**< \brief Last Modification Time of File */
     uint32 Mode;                      /**< \brief Mode of the file (Permissions) */
     char   Filename[OS_MAX_PATH_LEN]; /**< \brief Name of File */
+} FM_FileInfoPkt_Payload_t;
+
+/**
+ *  \brief Get File Info telemetry packet
+ */
+typedef struct
+{
+    CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief Telemetry Header */
+
+    FM_FileInfoPkt_Payload_t Payload; /**< \brief Telemetry Payload */
 } FM_FileInfoPkt_t;
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -362,14 +483,22 @@ typedef struct
 } FM_OpenFilesEntry_t;
 
 /**
+ *  \brief Get Open Files telemetry payload
+ */
+typedef struct
+{
+    uint32              NumOpenFiles;                         /**< \brief Number of files opened via cFE */
+    FM_OpenFilesEntry_t OpenFilesList[OS_MAX_NUM_OPEN_FILES]; /**< \brief List of files opened via cFE */
+} FM_OpenFilesPkt_Payload_t;
+
+/**
  *  \brief Get Open Files telemetry packet
  */
 typedef struct
 {
     CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief Telemetry Header */
 
-    uint32              NumOpenFiles;                         /**< \brief Number of files opened via cFE */
-    FM_OpenFilesEntry_t OpenFilesList[OS_MAX_NUM_OPEN_FILES]; /**< \brief List of files opened via cFE */
+    FM_OpenFilesPkt_Payload_t Payload; /**< \brief Telemetry Payload */
 } FM_OpenFilesPkt_t;
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -390,13 +519,21 @@ typedef struct
 } FM_MonitorReportEntry_t;
 
 /**
+ *  \brief Monitor filesystem telemetry payload
+ */
+typedef struct
+{
+    FM_MonitorReportEntry_t FileSys[FM_TABLE_ENTRY_COUNT]; /**< \brief Array of file system free space entries */
+} FM_MonitorReportPkt_Payload_t;
+
+/**
  *  \brief Monitor filesystem telemetry packet
  */
 typedef struct
 {
     CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief Telemetry Header */
 
-    FM_MonitorReportEntry_t FileSys[FM_TABLE_ENTRY_COUNT]; /**< \brief Array of file system free space entries */
+    FM_MonitorReportPkt_Payload_t Payload; /**< \brief Telemetry Payload */
 } FM_MonitorReportPkt_t;
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -406,12 +543,10 @@ typedef struct
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /**
- * \brief Housekeeping telemetry packet
+ * \brief Housekeeping telemetry payload
  */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief Telemetry Header */
-
     uint8 CommandCounter;    /**< \brief Application command counter */
     uint8 CommandErrCounter; /**< \brief Application command error counter */
     uint8 Spare;             /**< \brief Placeholder for unused command warning counter */
@@ -426,6 +561,16 @@ typedef struct
 
     uint8 ChildCurrentCC;  /**< \brief Command code currently executing */
     uint8 ChildPreviousCC; /**< \brief Command code previously executed */
+} FM_HousekeepingPkt_Payload_t;
+
+/**
+ * \brief Housekeeping telemetry packet
+ */
+typedef struct
+{
+    CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief Telemetry Header */
+
+    FM_HousekeepingPkt_Payload_t Payload; /**< \brief Telemetry Payload */
 } FM_HousekeepingPkt_t;
 
 /**\}*/

--- a/fsw/inc/fm_msgdefs.h
+++ b/fsw/inc/fm_msgdefs.h
@@ -45,13 +45,13 @@
  *
  *  \par Command Success Verification
  *       - Informational event #FM_NOOP_CMD_EID will be sent
- *       - #FM_HousekeepingPkt_t.CommandCounter will increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment
  *
  *  \par Command Error Conditions
  *       - Invalid command packet length
  *
  *  \par Command Failure Verification
- *       - #FM_HousekeepingPkt_t.CommandErrCounter will increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandErrCounter will increment
  *       - Error event #FM_NOOP_PKT_ERR_EID will be sent
  *
  *  \par Criticality
@@ -64,11 +64,11 @@
  *
  *  \par Description
  *       This command resets the following housekeeping telemetry:
- *       - #FM_HousekeepingPkt_t.CommandCounter
- *       - #FM_HousekeepingPkt_t.CommandErrCounter
- *       - #FM_HousekeepingPkt_t.ChildCmdCounter
- *       - #FM_HousekeepingPkt_t.ChildCmdErrCounter
- *       - #FM_HousekeepingPkt_t.ChildCmdWarnCounter
+ *       - #FM_HousekeepingPkt_Payload_t.CommandCounter
+ *       - #FM_HousekeepingPkt_Payload_t.CommandErrCounter
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdErrCounter
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdWarnCounter
  *
  *  \par Command Packet Structure
  *       #FM_ResetCmd_t
@@ -81,7 +81,7 @@
  *       - Invalid command packet length
  *
  *  \par Command Failure Verification
- *       - #FM_HousekeepingPkt_t.CommandErrCounter will increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandErrCounter will increment
  *       - Error event #FM_RESET_PKT_ERR_EID will be sent
  *
  *  \par Criticality
@@ -113,8 +113,8 @@
  *       #FM_CopyFileCmd_t
  *
  *  \par Command Success Verification
- *       - #FM_HousekeepingPkt_t.CommandCounter will increment after validation
- *       - #FM_HousekeepingPkt_t.ChildCmdCounter will increment after completion
+ *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
  *       - Debug event #FM_COPY_CMD_EID will be sent
  *
  *  \par Command Error Conditions
@@ -131,8 +131,8 @@
  *       - Failure of OS copy function
  *
  *  \par Command Failure Verification
- *       - #FM_HousekeepingPkt_t.CommandErrCounter may increment
- *       - #FM_HousekeepingPkt_t.ChildCmdErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdErrCounter may increment
  *       - Error event #FM_COPY_PKT_ERR_EID may be sent
  *       - Error event #FM_COPY_OVR_ERR_EID may be sent
  *       - Error event #FM_COPY_SRC_INVALID_ERR_EID may be sent
@@ -185,8 +185,8 @@
  *       #FM_MoveFileCmd_t
  *
  *  \par Command Success Verification
- *       - #FM_HousekeepingPkt_t.CommandCounter will increment after validation
- *       - #FM_HousekeepingPkt_t.ChildCmdCounter will increment after completion
+ *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
  *       - Debug event #FM_MOVE_CMD_EID will be sent
  *
  *  \par Command Error Conditions
@@ -201,8 +201,8 @@
  *       - Failure of OS move function
  *
  *  \par Command Failure Verification
- *       - #FM_HousekeepingPkt_t.CommandErrCounter may increment
- *       - #FM_HousekeepingPkt_t.ChildCmdErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdErrCounter may increment
  *       - Error event #FM_MOVE_PKT_ERR_EID may be sent
  *       - Error event #FM_MOVE_OVR_ERR_EID may be sent
  *       - Error event #FM_MOVE_SRC_INVALID_ERR_EID may be sent
@@ -247,8 +247,8 @@
  *       #FM_RenameFileCmd_t
  *
  *  \par Command Success Verification
- *       - #FM_HousekeepingPkt_t.CommandCounter will increment after validation
- *       - #FM_HousekeepingPkt_t.ChildCmdCounter will increment after completion
+ *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
  *       - Debug event #FM_RENAME_CMD_EID will be sent
  *
  *  \par Command Error Conditions
@@ -262,8 +262,8 @@
  *       - Failure of OS rename function
  *
  *  \par Command Failure Verification
- *       - #FM_HousekeepingPkt_t.CommandErrCounter may increment
- *       - #FM_HousekeepingPkt_t.ChildCmdErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdErrCounter may increment
  *       - Error event #FM_RENAME_PKT_ERR_EID may be sent
  *       - Error event #FM_RENAME_SRC_INVALID_ERR_EID may be sent
  *       - Error event #FM_RENAME_SRC_DNE_ERR_EID may be sent
@@ -301,8 +301,8 @@
  *       #FM_DeleteFileCmd_t
  *
  *  \par Command Success Verification
- *       - #FM_HousekeepingPkt_t.CommandCounter will increment after validation
- *       - #FM_HousekeepingPkt_t.ChildCmdCounter will increment after completion
+ *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
  *       - Debug event #FM_DELETE_CMD_EID will be sent
  *
  *  \par Command Error Conditions
@@ -314,8 +314,8 @@
  *       - Failure of OS delete function
  *
  *  \par Command Failure Verification
- *       - #FM_HousekeepingPkt_t.CommandErrCounter will increment
- *       - #FM_HousekeepingPkt_t.ChildCmdErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandErrCounter will increment
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdErrCounter may increment
  *       - Error event #FM_DELETE_PKT_ERR_EID may be sent
  *       - Error event #FM_DELETE_SRC_INVALID_ERR_EID may be sent
  *       - Error event #FM_DELETE_SRC_DNE_ERR_EID may be sent
@@ -354,8 +354,8 @@
  *       #FM_DeleteAllCmd_t
  *
  *  \par Command Success Verification
- *       - #FM_HousekeepingPkt_t.CommandCounter will increment after validation
- *       - #FM_HousekeepingPkt_t.ChildCmdCounter will increment after completion
+ *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
  *       - Debug event #FM_DELETE_ALL_CMD_EID will be sent
  *
  *  \par Command Warning Conditions
@@ -363,7 +363,7 @@
  *       - Directory entry is an open file
  *
  *  \par Command Warning Verification
- *       - #FM_HousekeepingPkt_t.ChildCmdWarnCounter will increment
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdWarnCounter will increment
  *       - Informational event #FM_DELETE_ALL_FILES_ND_WARNING_EID may be sent
  *       - Informational event #FM_DELETE_ALL_SKIP_WARNING_EID may be sent
  *
@@ -375,8 +375,8 @@
  *       - Failure of OS delete function
  *
  *  \par Command Failure Verification
- *       - #FM_HousekeepingPkt_t.CommandErrCounter may increment
- *       - #FM_HousekeepingPkt_t.ChildCmdErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdErrCounter may increment
  *       - Error event #FM_DELETE_ALL_PKT_ERR_EID may be sent
  *       - Error event #FM_DELETE_ALL_SRC_INVALID_ERR_EID may be sent
  *       - Error event #FM_DELETE_ALL_SRC_DNE_ERR_EID may be sent
@@ -421,8 +421,8 @@
  *       #FM_DecompressCmd_t
  *
  *  \par Command Success Verification
- *       - #FM_HousekeepingPkt_t.CommandCounter will increment after validation
- *       - #FM_HousekeepingPkt_t.ChildCmdCounter will increment after completion
+ *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
  *       - Debug event #FM_DECOM_CMD_EID will be sent
  *
  *  \par Command Error Conditions
@@ -434,8 +434,8 @@
  *       - Failure of CFE_FS_Decompress function
  *
  *  \par Command Failure Verification
- *       - #FM_HousekeepingPkt_t.CommandErrCounter may increment
- *       - #FM_HousekeepingPkt_t.ChildCmdErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdErrCounter may increment
  *       - Error event #FM_DECOM_PKT_ERR_EID may be sent
  *       - Error event #FM_DECOM_SRC_INVALID_ERR_EID may be sent
  *       - Error event #FM_DECOM_SRC_DNE_ERR_EID may be sent
@@ -477,8 +477,8 @@
  *       #FM_ConcatCmd_t
  *
  *  \par Command Success Verification
- *       - #FM_HousekeepingPkt_t.CommandCounter will increment after validation
- *       - #FM_HousekeepingPkt_t.ChildCmdCounter will increment after completion
+ *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
  *       - Debug event #FM_CONCAT_CMD_EID will be sent
  *
  *  \par Command Error Conditions
@@ -490,8 +490,8 @@
  *       - Failure of OS function (copy, open, read, write, etc.)
  *
  *  \par Command Failure Verification
- *       - #FM_HousekeepingPkt_t.CommandErrCounter may increment
- *       - #FM_HousekeepingPkt_t.ChildCmdErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdErrCounter may increment
  *       - Error event #FM_CONCAT_PKT_ERR_EID may be sent
  *       - Error event #FM_CONCAT_OSCPY_ERR_EID may be sent
  *       - Error event #FM_CONCAT_OPEN_SRC2_ERR_EID may be sent
@@ -545,8 +545,8 @@
  *       #FM_GetFileInfoCmd_t
  *
  *  \par Command Success Verification
- *       - #FM_HousekeepingPkt_t.CommandCounter will increment after validation
- *       - #FM_HousekeepingPkt_t.ChildCmdCounter will increment after completion
+ *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
  *       - Debug event #FM_GET_FILE_INFO_CMD_EID will be sent
  *
  *  \par Command Warning Conditions
@@ -555,7 +555,7 @@
  *       - CRC cannot be calculated because file cannot be read
  *
  *  \par Command Warning Verification
- *       - #FM_HousekeepingPkt_t.ChildCmdWarnCounter will increment
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdWarnCounter will increment
  *       - Informational event #FM_GET_FILE_INFO_STATE_WARNING_EID may be sent
  *       - Informational event #FM_GET_FILE_INFO_TYPE_WARNING_EID may be sent
  *       - Informational event #FM_GET_FILE_INFO_READ_WARNING_EID may be sent
@@ -566,8 +566,8 @@
  *       - Failure of OS_stat function
  *
  *  \par Command Failure Verification
- *       - #FM_HousekeepingPkt_t.CommandErrCounter may increment
- *       - #FM_HousekeepingPkt_t.ChildCmdErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdErrCounter may increment
  *       - Error event #FM_GET_FILE_INFO_OPEN_ERR_EID may be sent
  *       - Error event #FM_GET_FILE_INFO_PKT_ERR_EID may be sent
  *       - Error event #FM_GET_FILE_INFO_SRC_ERR_EID may be sent
@@ -596,14 +596,14 @@
  *       #FM_GetOpenFilesCmd_t
  *
  *  \par Command Success Verification
- *       - #FM_HousekeepingPkt_t.CommandCounter will increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment
  *       - Debug event #FM_GET_OPEN_FILES_CMD_EID will be sent
  *
  *  \par Command Error Conditions
  *       - Invalid command packet length
  *
  *  \par Command Failure Verification
- *       - #FM_HousekeepingPkt_t.CommandErrCounter will increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandErrCounter will increment
  *       - Error event #FM_GET_OPEN_FILES_PKT_ERR_EID will be sent
  *
  *  \par Criticality
@@ -631,8 +631,8 @@
  *       #FM_CreateDirCmd_t
  *
  *  \par Command Success Verification
- *       - #FM_HousekeepingPkt_t.CommandCounter will increment after validation
- *       - #FM_HousekeepingPkt_t.ChildCmdCounter will increment after completion
+ *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
  *       - Debug event #FM_CREATE_DIR_CMD_EID will be sent
  *
  *  \par Command Error Conditions
@@ -642,8 +642,8 @@
  *       - Failure of OS_mkdir function
  *
  *  \par Command Failure Verification
- *       - #FM_HousekeepingPkt_t.CommandErrCounter will increment
- *       - #FM_HousekeepingPkt_t.ChildCmdErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandErrCounter will increment
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdErrCounter may increment
  *       - Error event #FM_CREATE_DIR_PKT_ERR_EID may be sent
  *       - Error event #FM_CREATE_DIR_SRC_INVALID_ERR_EID may be sent
  *       - Error event #FM_CREATE_DIR_SRC_DNE_ERR_EID may be sent
@@ -679,8 +679,8 @@
  *       #FM_DeleteDirCmd_t
  *
  *  \par Command Success Verification
- *       - #FM_HousekeepingPkt_t.CommandCounter will increment after validation
- *       - #FM_HousekeepingPkt_t.ChildCmdCounter will increment after completion
+ *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
  *       - Debug event #FM_DELETE_DIR_CMD_EID will be sent
  *
  *  \par Command Error Conditions
@@ -691,8 +691,8 @@
  *       - Failure of OS function (OS_opendir, OS_rmdir)
  *
  *  \par Command Failure Verification
- *       - #FM_HousekeepingPkt_t.CommandErrCounter will increment
- *       - #FM_HousekeepingPkt_t.ChildCmdErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandErrCounter will increment
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdErrCounter may increment
  *       - Error event #FM_DELETE_DIR_PKT_ERR_EID may be sent
  *       - Error event #FM_DELETE_DIR_EMPTY_ERR_EID may be sent
  *       - Error event #FM_DELETE_OPENDIR_OS_ERR_EID may be sent
@@ -734,15 +734,15 @@
  *       #FM_GetDirFileCmd_t
  *
  *  \par Command Success Verification
- *       - #FM_HousekeepingPkt_t.CommandCounter will increment after validation
- *       - #FM_HousekeepingPkt_t.ChildCmdCounter will increment after completion
+ *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
  *       - Debug event #FM_GET_DIR_FILE_CMD_EID will be sent
  *
  *  \par Command Warning Conditions
  *       - Combined directory and entry name is too long
  *
  *  \par Command Warning Verification
- *       - #FM_HousekeepingPkt_t.ChildCmdWarnCounter will increment
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdWarnCounter will increment
  *       - Informational event #FM_GET_DIR_FILE_WARNING_EID may be sent
  *
  *  \par Command Error Conditions
@@ -756,8 +756,8 @@
  *       - Failure of OS function (OS_opendir, OS_creat, OS_write)
  *
  *  \par Command Failure Verification
- *       - #FM_HousekeepingPkt_t.CommandErrCounter may increment
- *       - #FM_HousekeepingPkt_t.ChildCmdErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdErrCounter may increment
  *       - Error event #FM_GET_DIR_FILE_PKT_ERR_EID may be sent
  *       - Error event #FM_GET_DIR_FILE_OSOPENDIR_ERR_EID may be sent
  *       - Error event #FM_GET_DIR_FILE_WRBLANK_ERR_EID may be sent
@@ -816,8 +816,8 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #FM_HousekeepingPkt_t.CommandCounter will increment after validation
- *       - #FM_HousekeepingPkt_t.ChildCmdCounter will increment after completion
+ *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
  *       - The #FM_DirListPkt_t telemetry packet will be sent
  *       - The #FM_GET_DIR_PKT_CMD_EID debug event will be sent
  *
@@ -825,7 +825,7 @@
  *       - Combined directory and entry name is too long
  *
  *  \par Command Warning Verification
- *       - #FM_HousekeepingPkt_t.ChildCmdWarnCounter will increment
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdWarnCounter will increment
  *       - Informational event #FM_GET_DIR_PKT_WARNING_EID may be sent
  *
  *  \par Error Conditions
@@ -837,8 +837,8 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #FM_HousekeepingPkt_t.CommandErrCounter may increment
- *       - #FM_HousekeepingPkt_t.ChildCmdErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdErrCounter may increment
  *       - Error event #FM_GET_DIR_PKT_PKT_ERR_EID may be sent
  *       - Error event #FM_GET_DIR_PKT_OS_ERR_EID may be sent
  *       - Error event #FM_GET_DIR_PKT_SRC_INVALID_ERR_EID may be sent
@@ -868,7 +868,7 @@
  *       #FM_MonitorFilesystemSpaceCmd_t
  *
  *  \par Evidence of success may be found in the following telemetry:
- *       - #FM_HousekeepingPkt_t.CommandCounter will increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment
  *       - Debug event #FM_MONITOR_FILESYSTEM_SPACE_CMD_EID will be sent
  *       - Telemetry packet #FM_MonitorReportPkt_t will be sent
  *
@@ -877,7 +877,7 @@
  *       - Free space table is not loaded
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #FM_HousekeepingPkt_t.CommandErrCounter will increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandErrCounter will increment
  *       - Error event #FM_GET_FREE_SPACE_PKT_ERR_EID may be sent
  *       - Error event #FM_GET_FREE_SPACE_TBL_ERR_EID may be sent
  *
@@ -899,7 +899,7 @@
  *       #FM_SetTableStateCmd_t
  *
  *  \par Evidence of success may be found in the following telemetry:
- *       - #FM_HousekeepingPkt_t.CommandCounter will increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment
  *       - Informational event #FM_SET_TABLE_STATE_CMD_EID will be sent
  *
  *  \par Error Conditions
@@ -910,7 +910,7 @@
  *       - Invalid current table entry state, entry is unused
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #FM_HousekeepingPkt_t.CommandErrCounter will increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandErrCounter will increment
  *       - Error event #FM_SET_TABLE_STATE_PKT_ERR_EID may be sent
  *       - Error event #FM_SET_TABLE_STATE_TBL_ERR_EID may be sent
  *       - Error event #FM_SET_TABLE_STATE_ARG_IDX_ERR_EID may be sent
@@ -946,8 +946,8 @@
  *       #FM_SetPermCmd_t
  *
  *  \par Command Success Verification
- *       - #FM_HousekeepingPkt_t.CommandCounter will increment after validation
- *       - #FM_HousekeepingPkt_t.ChildCmdCounter will increment after completion
+ *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
  *       - Debug event #FM_SET_PERM_CMD_EID will be sent
  *
  *  \par Error Conditions
@@ -955,8 +955,8 @@
  *       - Error from call to OS_chmod
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #FM_HousekeepingPkt_t.CommandErrCounter may increment
- *       - #FM_HousekeepingPkt_t.ChildCmdErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.CommandErrCounter may increment
+ *       - #FM_HousekeepingPkt_Payload_t.ChildCmdErrCounter may increment
  *       - Error event #FM_SET_PERM_ERR_EID may be sent
  *       - Error event #FM_SET_PERM_OS_ERR_EID may be sent
  *

--- a/fsw/src/fm_app.c
+++ b/fsw/src/fm_app.c
@@ -389,8 +389,9 @@ void FM_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void FM_ReportHK(const CFE_MSG_CommandHeader_t *Msg)
 {
-    const char *CmdText = "HK Request";
-    bool        Result  = true;
+    const char *                  CmdText = "HK Request";
+    bool                          Result  = true;
+    FM_HousekeepingPkt_Payload_t *PayloadPtr;
 
     /* Verify command packet length */
     Result = FM_IsValidCmdPktLength(&Msg->Msg, sizeof(FM_HousekeepingCmd_t), FM_HK_REQ_ERR_EID, CmdText);
@@ -405,22 +406,24 @@ void FM_ReportHK(const CFE_MSG_CommandHeader_t *Msg)
         CFE_MSG_Init(&FM_GlobalData.HousekeepingPkt.TlmHeader.Msg, CFE_SB_ValueToMsgId(FM_HK_TLM_MID),
                      sizeof(FM_HousekeepingPkt_t));
 
-        /* Report application command counters */
-        FM_GlobalData.HousekeepingPkt.CommandCounter    = FM_GlobalData.CommandCounter;
-        FM_GlobalData.HousekeepingPkt.CommandErrCounter = FM_GlobalData.CommandErrCounter;
+        PayloadPtr = &FM_GlobalData.HousekeepingPkt.Payload;
 
-        FM_GlobalData.HousekeepingPkt.NumOpenFiles = FM_GetOpenFilesData(NULL);
+        /* Report application command counters */
+        PayloadPtr->CommandCounter    = FM_GlobalData.CommandCounter;
+        PayloadPtr->CommandErrCounter = FM_GlobalData.CommandErrCounter;
+
+        PayloadPtr->NumOpenFiles = FM_GetOpenFilesData(NULL);
 
         /* Report child task command counters */
-        FM_GlobalData.HousekeepingPkt.ChildCmdCounter     = FM_GlobalData.ChildCmdCounter;
-        FM_GlobalData.HousekeepingPkt.ChildCmdErrCounter  = FM_GlobalData.ChildCmdErrCounter;
-        FM_GlobalData.HousekeepingPkt.ChildCmdWarnCounter = FM_GlobalData.ChildCmdWarnCounter;
+        PayloadPtr->ChildCmdCounter     = FM_GlobalData.ChildCmdCounter;
+        PayloadPtr->ChildCmdErrCounter  = FM_GlobalData.ChildCmdErrCounter;
+        PayloadPtr->ChildCmdWarnCounter = FM_GlobalData.ChildCmdWarnCounter;
 
-        FM_GlobalData.HousekeepingPkt.ChildQueueCount = FM_GlobalData.ChildQueueCount;
+        PayloadPtr->ChildQueueCount = FM_GlobalData.ChildQueueCount;
 
         /* Report current and previous commands executed by the child task */
-        FM_GlobalData.HousekeepingPkt.ChildCurrentCC  = FM_GlobalData.ChildCurrentCC;
-        FM_GlobalData.HousekeepingPkt.ChildPreviousCC = FM_GlobalData.ChildPreviousCC;
+        PayloadPtr->ChildCurrentCC  = FM_GlobalData.ChildCurrentCC;
+        PayloadPtr->ChildPreviousCC = FM_GlobalData.ChildPreviousCC;
 
         CFE_SB_TimeStampMsg(&FM_GlobalData.HousekeepingPkt.TlmHeader.Msg);
         CFE_SB_TransmitMsg(&FM_GlobalData.HousekeepingPkt.TlmHeader.Msg, true);

--- a/fsw/src/fm_cmds.c
+++ b/fsw/src/fm_cmds.c
@@ -39,6 +39,14 @@
 
 #include <string.h>
 
+/**
+ * \brief Internal Macro to access the internal payload structure of a message
+ *
+ * This is done as a macro so it can be applied consistently to all
+ * message processing functions, based on the way FM defines its messages.
+ */
+#define FM_GET_CMD_PAYLOAD(ptr, type) (&((const type *)(ptr))->Payload)
+
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* FM command handler -- NOOP                                      */
@@ -102,10 +110,11 @@ bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_CopyFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    FM_CopyFileCmd_t *    CmdPtr        = (FM_CopyFileCmd_t *)BufPtr;
     FM_ChildQueueEntry_t *CmdArgs       = NULL;
     const char *          CmdText       = "Copy File";
     bool                  CommandResult = false;
+
+    const FM_OvwSourceTargetFilename_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_CopyFileCmd_t);
 
     /* Verify command packet length */
     CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_CopyFileCmd_t), FM_COPY_PKT_ERR_EID, CmdText);
@@ -169,10 +178,11 @@ bool FM_CopyFileCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_MoveFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    FM_MoveFileCmd_t *    CmdPtr        = (FM_MoveFileCmd_t *)BufPtr;
     FM_ChildQueueEntry_t *CmdArgs       = NULL;
     const char *          CmdText       = "Move File";
     bool                  CommandResult = false;
+
+    const FM_OvwSourceTargetFilename_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_MoveFileCmd_t);
 
     /* Verify command packet length */
     CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_MoveFileCmd_t), FM_MOVE_PKT_ERR_EID, CmdText);
@@ -237,10 +247,11 @@ bool FM_MoveFileCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_RenameFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    FM_RenameFileCmd_t *  CmdPtr        = (FM_RenameFileCmd_t *)BufPtr;
     FM_ChildQueueEntry_t *CmdArgs       = NULL;
     const char *          CmdText       = "Rename File";
     bool                  CommandResult = false;
+
+    const FM_SourceTargetFileName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_RenameFileCmd_t);
 
     /* Verify command packet length */
     CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_RenameFileCmd_t), FM_RENAME_PKT_ERR_EID, CmdText);
@@ -292,10 +303,11 @@ bool FM_RenameFileCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_DeleteFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    FM_DeleteFileCmd_t *  CmdPtr        = (FM_DeleteFileCmd_t *)BufPtr;
     FM_ChildQueueEntry_t *CmdArgs       = NULL;
     const char *          CmdText       = "Delete File";
     bool                  CommandResult = false;
+
+    const FM_SingleFilename_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_DeleteFileCmd_t);
 
     /* Verify command packet length */
     CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DeleteFileCmd_t), FM_DELETE_PKT_ERR_EID, CmdText);
@@ -338,11 +350,12 @@ bool FM_DeleteFileCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    FM_DeleteAllCmd_t *   CmdPtr                      = (FM_DeleteAllCmd_t *)BufPtr;
     const char *          CmdText                     = "Delete All Files";
     char                  DirWithSep[OS_MAX_PATH_LEN] = "\0";
     FM_ChildQueueEntry_t *CmdArgs                     = NULL;
     bool                  CommandResult               = false;
+
+    const FM_DirectoryName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_DeleteAllCmd_t);
 
     /* Verify message length */
     CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DeleteAllCmd_t), FM_DELETE_ALL_PKT_ERR_EID, CmdText);
@@ -393,10 +406,11 @@ bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    FM_DecompressCmd_t *  CmdPtr        = (FM_DecompressCmd_t *)BufPtr;
     const char *          CmdText       = "Decompress File";
     FM_ChildQueueEntry_t *CmdArgs       = NULL;
     bool                  CommandResult = false;
+
+    const FM_SourceTargetFileName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_DecompressCmd_t);
 
     /* Verify command packet length */
     CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DecompressCmd_t), FM_DECOM_PKT_ERR_EID, CmdText);
@@ -446,10 +460,11 @@ bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_ConcatFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    FM_ConcatCmd_t *      CmdPtr        = (FM_ConcatCmd_t *)BufPtr;
     const char *          CmdText       = "Concat Files";
     FM_ChildQueueEntry_t *CmdArgs       = NULL;
     bool                  CommandResult = false;
+
+    const FM_TwoSourceOneTarget_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_ConcatCmd_t);
 
     /* Verify command packet length */
     CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_ConcatCmd_t), FM_CONCAT_PKT_ERR_EID, CmdText);
@@ -507,11 +522,12 @@ bool FM_ConcatFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_GetFileInfoCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    FM_GetFileInfoCmd_t * CmdPtr        = (FM_GetFileInfoCmd_t *)BufPtr;
     const char *          CmdText       = "Get File Info";
     FM_ChildQueueEntry_t *CmdArgs       = NULL;
     bool                  CommandResult = false;
     uint32                FilenameState = FM_NAME_IS_INVALID;
+
+    const FM_FilenameAndCRC_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_GetFileInfoCmd_t);
 
     /* Verify command packet length */
     CommandResult =
@@ -572,6 +588,8 @@ bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr)
     bool        CommandResult = false;
     uint32      NumOpenFiles  = 0;
 
+    FM_OpenFilesPkt_Payload_t *ReportPtr = &FM_GlobalData.OpenFilesPkt.Payload;
+
     /* Verify command packet length */
     CommandResult =
         FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_GetOpenFilesCmd_t), FM_GET_OPEN_FILES_PKT_ERR_EID, CmdText);
@@ -582,8 +600,9 @@ bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr)
                      sizeof(FM_OpenFilesPkt_t));
 
         /* Get list of open files and count */
-        NumOpenFiles                            = FM_GetOpenFilesData(FM_GlobalData.OpenFilesPkt.OpenFilesList);
-        FM_GlobalData.OpenFilesPkt.NumOpenFiles = NumOpenFiles;
+        NumOpenFiles = FM_GetOpenFilesData(ReportPtr->OpenFilesList);
+
+        ReportPtr->NumOpenFiles = NumOpenFiles;
 
         /* Timestamp and send open files telemetry packet */
         CFE_SB_TimeStampMsg(&FM_GlobalData.OpenFilesPkt.TlmHeader.Msg);
@@ -604,10 +623,11 @@ bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_CreateDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    FM_CreateDirCmd_t *   CmdPtr        = (FM_CreateDirCmd_t *)BufPtr;
     FM_ChildQueueEntry_t *CmdArgs       = NULL;
     const char *          CmdText       = "Create Directory";
     bool                  CommandResult = false;
+
+    const FM_DirectoryName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_CreateDirCmd_t);
 
     /* Verify command packet length */
     CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_CreateDirCmd_t), FM_CREATE_DIR_PKT_ERR_EID, CmdText);
@@ -650,10 +670,11 @@ bool FM_CreateDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_DeleteDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    FM_DeleteDirCmd_t *   CmdPtr        = (FM_DeleteDirCmd_t *)BufPtr;
     FM_ChildQueueEntry_t *CmdArgs       = NULL;
     const char *          CmdText       = "Delete Directory";
     bool                  CommandResult = false;
+
+    const FM_DirectoryName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_DeleteDirCmd_t);
 
     /* Verify command packet length */
     CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DeleteDirCmd_t), FM_DELETE_DIR_PKT_ERR_EID, CmdText);
@@ -696,12 +717,13 @@ bool FM_DeleteDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_GetDirListFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    FM_GetDirFileCmd_t *  CmdPtr                      = (FM_GetDirFileCmd_t *)BufPtr;
     const char *          CmdText                     = "Directory List to File";
     char                  DirWithSep[OS_MAX_PATH_LEN] = "\0";
     char                  Filename[OS_MAX_PATH_LEN]   = "\0";
     FM_ChildQueueEntry_t *CmdArgs                     = NULL;
     bool                  CommandResult               = false;
+
+    const FM_GetDirectoryToFile_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_GetDirFileCmd_t);
 
     /* Verify command packet length */
     CommandResult =
@@ -775,11 +797,12 @@ bool FM_GetDirListFileCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_GetDirListPktCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    FM_GetDirPktCmd_t *   CmdPtr                      = (FM_GetDirPktCmd_t *)BufPtr;
     const char *          CmdText                     = "Directory List to Packet";
     char                  DirWithSep[OS_MAX_PATH_LEN] = "\0";
     FM_ChildQueueEntry_t *CmdArgs                     = NULL;
     bool                  CommandResult               = false;
+
+    const FM_GetDirectoryToPkt_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_GetDirPktCmd_t);
 
     /* Verify command packet length */
     CommandResult =
@@ -862,7 +885,7 @@ bool FM_MonitorFilesystemSpaceCmd(const CFE_SB_Buffer_t *BufPtr)
 
             /* Process enabled file system table entries */
             MonitorPtr = FM_GlobalData.MonitorTablePtr->Entries;
-            ReportPtr  = FM_GlobalData.MonitorReportPkt.FileSys;
+            ReportPtr  = FM_GlobalData.MonitorReportPkt.Payload.FileSys;
             for (i = 0; i < FM_TABLE_ENTRY_COUNT; i++)
             {
                 if (MonitorPtr->Type != FM_MonitorTableEntry_Type_UNUSED)
@@ -927,9 +950,10 @@ bool FM_MonitorFilesystemSpaceCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_SetTableStateCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    FM_SetTableStateCmd_t *CmdPtr        = (FM_SetTableStateCmd_t *)BufPtr;
-    const char *           CmdText       = "Set Table State";
-    bool                   CommandResult = false;
+    const char *CmdText       = "Set Table State";
+    bool        CommandResult = false;
+
+    const FM_TableIndexAndState_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_SetTableStateCmd_t);
 
     /* Verify command packet length */
     CommandResult =
@@ -997,11 +1021,12 @@ bool FM_SetTableStateCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_SetPermissionsCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    FM_SetPermCmd_t *     CmdPtr        = (FM_SetPermCmd_t *)BufPtr;
     FM_ChildQueueEntry_t *CmdArgs       = NULL;
     const char *          CmdText       = "Set Permissions";
     bool                  CommandResult = false;
     bool                  FilenameState = FM_NAME_IS_INVALID;
+
+    const FM_FilenameAndMode_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_SetPermCmd_t);
 
     /* Verify command packet length */
     CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_SetPermCmd_t), FM_SET_PERM_ERR_EID, CmdText);

--- a/unit-test/fm_app_tests.c
+++ b/unit-test/fm_app_tests.c
@@ -349,6 +349,8 @@ void Test_FM_AppInit_TableInitSuccess(void)
  * *******************************/
 void Test_FM_ReportHK_ReturnPktLengthTrue(void)
 {
+    FM_HousekeepingPkt_Payload_t *ReportPtr;
+
     /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_GetOpenFilesData), 0);
@@ -374,15 +376,17 @@ void Test_FM_ReportHK_ReturnPktLengthTrue(void)
     UtAssert_STUB_COUNT(FM_GetOpenFilesData, 1);
     UtAssert_STUB_COUNT(CFE_SB_TimeStampMsg, 1);
     UtAssert_STUB_COUNT(CFE_SB_TransmitMsg, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.CommandCounter, FM_GlobalData.CommandCounter);
-    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.CommandErrCounter, FM_GlobalData.CommandErrCounter);
-    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.NumOpenFiles, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.ChildCmdCounter, FM_GlobalData.ChildCmdCounter);
-    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.ChildCmdErrCounter, FM_GlobalData.ChildCmdErrCounter);
-    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.ChildCmdWarnCounter, FM_GlobalData.ChildCmdWarnCounter);
-    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.ChildQueueCount, FM_GlobalData.ChildQueueCount);
-    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.ChildCurrentCC, FM_GlobalData.ChildCurrentCC);
-    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.ChildPreviousCC, FM_GlobalData.ChildPreviousCC);
+
+    ReportPtr = &FM_GlobalData.HousekeepingPkt.Payload;
+    UtAssert_INT32_EQ(ReportPtr->CommandCounter, FM_GlobalData.CommandCounter);
+    UtAssert_INT32_EQ(ReportPtr->CommandErrCounter, FM_GlobalData.CommandErrCounter);
+    UtAssert_INT32_EQ(ReportPtr->NumOpenFiles, 0);
+    UtAssert_INT32_EQ(ReportPtr->ChildCmdCounter, FM_GlobalData.ChildCmdCounter);
+    UtAssert_INT32_EQ(ReportPtr->ChildCmdErrCounter, FM_GlobalData.ChildCmdErrCounter);
+    UtAssert_INT32_EQ(ReportPtr->ChildCmdWarnCounter, FM_GlobalData.ChildCmdWarnCounter);
+    UtAssert_INT32_EQ(ReportPtr->ChildQueueCount, FM_GlobalData.ChildQueueCount);
+    UtAssert_INT32_EQ(ReportPtr->ChildCurrentCC, FM_GlobalData.ChildCurrentCC);
+    UtAssert_INT32_EQ(ReportPtr->ChildPreviousCC, FM_GlobalData.ChildPreviousCC);
 }
 
 void Test_FM_ReportHK_ReturnPktLengthFalse(void)

--- a/unit-test/fm_child_tests.c
+++ b/unit-test/fm_child_tests.c
@@ -1598,6 +1598,8 @@ void Test_FM_ChildDirListPktCmd_OSDirOpenNotSuccess(void)
 
 void Test_FM_ChildDirListPktCmd_OSDirReadNotSuccess(void)
 {
+    FM_DirListPkt_Payload_t *ReportPtr;
+
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_GET_DIR_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
@@ -1615,11 +1617,15 @@ void Test_FM_ChildDirListPktCmd_OSDirReadNotSuccess(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_PKT_CMD_EID);
-    UtAssert_UINT32_EQ(FM_GlobalData.DirListPkt.PacketFiles, 0);
+
+    ReportPtr = &FM_GlobalData.DirListPkt.Payload;
+    UtAssert_UINT32_EQ(ReportPtr->PacketFiles, 0);
 }
 
 void Test_FM_ChildDirListPktCmd_DirEntryNameThisDirectory(void)
 {
+    FM_DirListPkt_Payload_t *ReportPtr;
+
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_GET_DIR_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
@@ -1639,11 +1645,15 @@ void Test_FM_ChildDirListPktCmd_DirEntryNameThisDirectory(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_PKT_CMD_EID);
-    UtAssert_UINT32_EQ(FM_GlobalData.DirListPkt.PacketFiles, 0);
+
+    ReportPtr = &FM_GlobalData.DirListPkt.Payload;
+    UtAssert_UINT32_EQ(ReportPtr->PacketFiles, 0);
 }
 
 void Test_FM_ChildDirListPktCmd_DirEntryNameParentDirectory(void)
 {
+    FM_DirListPkt_Payload_t *ReportPtr;
+
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_GET_DIR_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
@@ -1663,11 +1673,15 @@ void Test_FM_ChildDirListPktCmd_DirEntryNameParentDirectory(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_PKT_CMD_EID);
-    UtAssert_UINT32_EQ(FM_GlobalData.DirListPkt.PacketFiles, 0);
+
+    ReportPtr = &FM_GlobalData.DirListPkt.Payload;
+    UtAssert_UINT32_EQ(ReportPtr->PacketFiles, 0);
 }
 
 void Test_FM_ChildDirListPktCmd_DirListOffsetNotExceeded(void)
 {
+    FM_DirListPkt_Payload_t *ReportPtr;
+
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_GET_DIR_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2", .DirListOffset = 1};
@@ -1688,13 +1702,16 @@ void Test_FM_ChildDirListPktCmd_DirListOffsetNotExceeded(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_PKT_CMD_EID);
 
-    UtAssert_UINT32_EQ(FM_GlobalData.DirListPkt.FirstFile, 1);
-    UtAssert_UINT32_EQ(FM_GlobalData.DirListPkt.TotalFiles, 1);
-    UtAssert_UINT32_EQ(FM_GlobalData.DirListPkt.PacketFiles, 0);
+    ReportPtr = &FM_GlobalData.DirListPkt.Payload;
+    UtAssert_UINT32_EQ(ReportPtr->FirstFile, 1);
+    UtAssert_UINT32_EQ(ReportPtr->TotalFiles, 1);
+    UtAssert_UINT32_EQ(ReportPtr->PacketFiles, 0);
 }
 
 void Test_FM_ChildDirListPktCmd_DirListOffsetExceeded(void)
 {
+    FM_DirListPkt_Payload_t *ReportPtr;
+
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
         .CommandCode = FM_GET_DIR_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
@@ -1719,13 +1736,16 @@ void Test_FM_ChildDirListPktCmd_DirListOffsetExceeded(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_PKT_CMD_EID);
 
-    UtAssert_UINT32_EQ(FM_GlobalData.DirListPkt.FirstFile, 0);
-    UtAssert_UINT32_EQ(FM_GlobalData.DirListPkt.TotalFiles, sizeof(direntry) / sizeof(direntry[0]));
-    UtAssert_UINT32_EQ(FM_GlobalData.DirListPkt.PacketFiles, FM_DIR_LIST_PKT_ENTRIES);
+    ReportPtr = &FM_GlobalData.DirListPkt.Payload;
+    UtAssert_UINT32_EQ(ReportPtr->FirstFile, 0);
+    UtAssert_UINT32_EQ(ReportPtr->TotalFiles, sizeof(direntry) / sizeof(direntry[0]));
+    UtAssert_UINT32_EQ(ReportPtr->PacketFiles, FM_DIR_LIST_PKT_ENTRIES);
 }
 
 void Test_FM_ChildDirListPktCmd_PathAndEntryLengthGreaterMaxPathLength(void)
 {
+    FM_DirListPkt_Payload_t *ReportPtr;
+
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_ALL_CC,
                                         .Source1     = "dummy_source1",
@@ -1747,9 +1767,10 @@ void Test_FM_ChildDirListPktCmd_PathAndEntryLengthGreaterMaxPathLength(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_PKT_WARNING_EID);
 
-    UtAssert_UINT32_EQ(FM_GlobalData.DirListPkt.FirstFile, 0);
-    UtAssert_UINT32_EQ(FM_GlobalData.DirListPkt.TotalFiles, 1);
-    UtAssert_UINT32_EQ(FM_GlobalData.DirListPkt.PacketFiles, 0);
+    ReportPtr = &FM_GlobalData.DirListPkt.Payload;
+    UtAssert_UINT32_EQ(ReportPtr->FirstFile, 0);
+    UtAssert_UINT32_EQ(ReportPtr->TotalFiles, 1);
+    UtAssert_UINT32_EQ(ReportPtr->PacketFiles, 0);
 }
 
 /* ****************

--- a/unit-test/fm_cmds_tests.c
+++ b/unit-test/fm_cmds_tests.c
@@ -188,8 +188,12 @@ void add_FM_ResetCountersCmd_tests(void)
 
 void Test_FM_CopyFileCmd_Success(void)
 {
-    strncpy(UT_CmdBuf.CopyFileCmd.Source, "src1", sizeof(UT_CmdBuf.CopyFileCmd.Source) - 1);
-    strncpy(UT_CmdBuf.CopyFileCmd.Target, "tgt", sizeof(UT_CmdBuf.CopyFileCmd.Target) - 1);
+    FM_OvwSourceTargetFilename_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.CopyFileCmd.Payload;
+
+    strncpy(CmdPtr->Source, "src1", sizeof(CmdPtr->Source) - 1);
+    strncpy(CmdPtr->Target, "tgt", sizeof(CmdPtr->Target) - 1);
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
@@ -305,7 +309,11 @@ void Test_FM_CopyFileCmd_NoOverwriteTargetExists(void)
 
 void Test_FM_CopyFileCmd_OverwriteFileOpen(void)
 {
-    UT_CmdBuf.CopyFileCmd.Overwrite         = 1;
+    FM_OvwSourceTargetFilename_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.CopyFileCmd.Payload;
+
+    CmdPtr->Overwrite                       = 1;
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
@@ -491,7 +499,11 @@ void Test_FM_MoveFileCmd_NoOverwriteTargetExists(void)
 
 void Test_FM_MoveFileCmd_OverwriteFileOpen(void)
 {
-    UT_CmdBuf.MoveFileCmd.Overwrite         = 1;
+    FM_OvwSourceTargetFilename_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.MoveFileCmd.Payload;
+
+    CmdPtr->Overwrite                       = 1;
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
@@ -562,8 +574,12 @@ void add_FM_MoveFileCmd_tests(void)
 
 void Test_FM_RenameFileCmd_Success(void)
 {
-    strncpy(UT_CmdBuf.RenameFileCmd.Source, "src1", sizeof(UT_CmdBuf.RenameFileCmd.Source) - 1);
-    strncpy(UT_CmdBuf.RenameFileCmd.Target, "tgt", sizeof(UT_CmdBuf.RenameFileCmd.Target) - 1);
+    FM_SourceTargetFileName_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.RenameFileCmd.Payload;
+
+    strncpy(CmdPtr->Source, "src1", sizeof(CmdPtr->Source) - 1);
+    strncpy(CmdPtr->Target, "tgt", sizeof(CmdPtr->Target) - 1);
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -797,7 +813,11 @@ void add_FM_DeleteFileCmd_tests(void)
 
 void Test_FM_DeleteAllFilesCmd_Success(void)
 {
-    strncpy(UT_CmdBuf.DeleteAllCmd.Directory, "dir", sizeof(UT_CmdBuf.DeleteAllCmd.Directory) - 1);
+    FM_DirectoryName_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.DeleteAllCmd.Payload;
+
+    strncpy(CmdPtr->Directory, "dir", sizeof(CmdPtr->Directory) - 1);
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -859,7 +879,11 @@ void Test_FM_DeleteAllFilesCmd_DirNoExist(void)
 
 void Test_FM_DeleteAllFilesCmd_NoChildTask(void)
 {
-    strncpy(UT_CmdBuf.DeleteAllCmd.Directory, "dir", sizeof(UT_CmdBuf.DeleteAllCmd.Directory) - 1);
+    FM_DirectoryName_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.DeleteAllCmd.Payload;
+
+    strncpy(CmdPtr->Directory, "dir", sizeof(CmdPtr->Directory) - 1);
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
@@ -1024,9 +1048,13 @@ void add_FM_DecompressFileCmd_tests(void)
 
 void Test_FM_ConcatFilesCmd_Success(void)
 {
-    strncpy(UT_CmdBuf.ConcatCmd.Source1, "src1", sizeof(UT_CmdBuf.ConcatCmd.Source1) - 1);
-    strncpy(UT_CmdBuf.ConcatCmd.Source2, "src2", sizeof(UT_CmdBuf.ConcatCmd.Source2) - 1);
-    strncpy(UT_CmdBuf.ConcatCmd.Target, "tgt", sizeof(UT_CmdBuf.ConcatCmd.Target) - 1);
+    FM_TwoSourceOneTarget_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.ConcatCmd.Payload;
+
+    strncpy(CmdPtr->Source1, "src1", sizeof(CmdPtr->Source1) - 1);
+    strncpy(CmdPtr->Source2, "src2", sizeof(CmdPtr->Source2) - 1);
+    strncpy(CmdPtr->Target, "tgt", sizeof(CmdPtr->Target) - 1);
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -1173,7 +1201,11 @@ void add_FM_ConcatFilesCmd_tests(void)
 
 void Test_FM_GetFileInfoCmd_Success(void)
 {
-    strncpy(UT_CmdBuf.GetFileInfoCmd.Filename, "file", sizeof(UT_CmdBuf.GetFileInfoCmd.Filename) - 1);
+    FM_FilenameAndCRC_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.GetFileInfoCmd.Payload;
+
+    strncpy(CmdPtr->Filename, "file", sizeof(CmdPtr->Filename) - 1);
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -1323,7 +1355,11 @@ void add_FM_GetOpenFilesCmd_tests(void)
 
 void Test_FM_CreateDirectoryCmd_Success(void)
 {
-    strncpy(UT_CmdBuf.CreateDirCmd.Directory, "dir", sizeof(UT_CmdBuf.CreateDirCmd.Directory) - 1);
+    FM_DirectoryName_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.CreateDirCmd.Payload;
+
+    strncpy(CmdPtr->Directory, "dir", sizeof(CmdPtr->Directory) - 1);
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
@@ -1423,7 +1459,11 @@ void add_FM_CreateDirectoryCmd_tests(void)
 
 void Test_FM_DeleteDirectoryCmd_Success(void)
 {
-    strncpy(UT_CmdBuf.DeleteDirCmd.Directory, "dir", sizeof(UT_CmdBuf.DeleteDirCmd.Directory) - 1);
+    FM_DirectoryName_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.DeleteDirCmd.Payload;
+
+    strncpy(CmdPtr->Directory, "dir", sizeof(CmdPtr->Directory) - 1);
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
@@ -1523,8 +1563,12 @@ void add_FM_DeleteDirectoryCmd_tests(void)
 
 void Test_FM_GetDirListFileCmd_Success(void)
 {
-    strncpy(UT_CmdBuf.GetDirFileCmd.Filename, "file", sizeof(UT_CmdBuf.GetDirFileCmd.Filename) - 1);
-    strncpy(UT_CmdBuf.GetDirFileCmd.Directory, "dir", sizeof(UT_CmdBuf.GetDirFileCmd.Directory) - 1);
+    FM_GetDirectoryToFile_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.GetDirFileCmd.Payload;
+
+    strncpy(CmdPtr->Filename, "file", sizeof(CmdPtr->Filename) - 1);
+    strncpy(CmdPtr->Directory, "dir", sizeof(CmdPtr->Directory) - 1);
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
@@ -1546,8 +1590,12 @@ void Test_FM_GetDirListFileCmd_Success(void)
 
 void Test_FM_GetDirListFileCmd_SuccessDefaultPath(void)
 {
-    strncpy(UT_CmdBuf.GetDirFileCmd.Directory, "dir", sizeof(UT_CmdBuf.GetDirFileCmd.Directory) - 1);
-    UT_CmdBuf.GetDirFileCmd.Filename[0]     = '\0';
+    FM_GetDirectoryToFile_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.GetDirFileCmd.Payload;
+
+    strncpy(CmdPtr->Directory, "dir", sizeof(CmdPtr->Directory) - 1);
+    CmdPtr->Filename[0]                     = '\0';
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
@@ -1611,8 +1659,12 @@ void Test_FM_GetDirListFileCmd_SourceNotExist(void)
 
 void Test_FM_GetDirListFileCmd_TargetFileOpen(void)
 {
-    strncpy(UT_CmdBuf.GetDirFileCmd.Filename, "file", sizeof(UT_CmdBuf.GetDirFileCmd.Filename) - 1);
-    strncpy(UT_CmdBuf.GetDirFileCmd.Directory, "dir", sizeof(UT_CmdBuf.GetDirFileCmd.Directory) - 1);
+    FM_GetDirectoryToFile_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.GetDirFileCmd.Payload;
+
+    strncpy(CmdPtr->Filename, "file", sizeof(CmdPtr->Filename) - 1);
+    strncpy(CmdPtr->Directory, "dir", sizeof(CmdPtr->Directory) - 1);
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -1635,8 +1687,12 @@ void Test_FM_GetDirListFileCmd_TargetFileOpen(void)
 
 void Test_FM_GetDirListFileCmd_NoChildTask(void)
 {
-    strncpy(UT_CmdBuf.GetDirFileCmd.Filename, "file", sizeof(UT_CmdBuf.GetDirFileCmd.Filename) - 1);
-    strncpy(UT_CmdBuf.GetDirFileCmd.Directory, "dir", sizeof(UT_CmdBuf.GetDirFileCmd.Directory) - 1);
+    FM_GetDirectoryToFile_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.GetDirFileCmd.Payload;
+
+    strncpy(CmdPtr->Filename, "file", sizeof(CmdPtr->Filename) - 1);
+    strncpy(CmdPtr->Directory, "dir", sizeof(CmdPtr->Directory) - 1);
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -1683,7 +1739,11 @@ void add_FM_GetDirListFileCmd_tests(void)
 
 void Test_FM_GetDirListPktCmd_Success(void)
 {
-    strncpy(UT_CmdBuf.GetDirPktCmd.Directory, "dir", sizeof(UT_CmdBuf.GetDirPktCmd.Directory) - 1);
+    FM_GetDirectoryToPkt_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.GetDirPktCmd.Payload;
+
+    strncpy(CmdPtr->Directory, "dir", sizeof(CmdPtr->Directory) - 1);
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -1793,8 +1853,11 @@ void UT_Handler_MonitorSpace(void *UserObj, UT_EntryKey_t FuncKey, const UT_Stub
 
 void Test_FM_MonitorFilesystemSpaceCmd_Success(void)
 {
+    FM_MonitorReportPkt_Payload_t *ReportPtr;
+
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "%%s command");
 
     FM_MonitorTable_t DummyTable;
@@ -1836,12 +1899,14 @@ void Test_FM_MonitorFilesystemSpaceCmd_Success(void)
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(call_count_CFE_SB_TransmitMsg, 1);
-    UtAssert_UINT32_EQ(FM_GlobalData.MonitorReportPkt.FileSys[0].Bytes, 2000);
-    UtAssert_UINT32_EQ(FM_GlobalData.MonitorReportPkt.FileSys[0].Blocks, 20);
-    UtAssert_UINT32_EQ(FM_GlobalData.MonitorReportPkt.FileSys[1].Bytes, 1000);
-    UtAssert_UINT32_EQ(FM_GlobalData.MonitorReportPkt.FileSys[1].Blocks, 10);
-    UtAssert_UINT32_EQ(FM_GlobalData.MonitorReportPkt.FileSys[2].Bytes, 0);
-    UtAssert_UINT32_EQ(FM_GlobalData.MonitorReportPkt.FileSys[2].Blocks, 0);
+
+    ReportPtr = &FM_GlobalData.MonitorReportPkt.Payload;
+    UtAssert_UINT32_EQ(ReportPtr->FileSys[0].Bytes, 2000);
+    UtAssert_UINT32_EQ(ReportPtr->FileSys[0].Blocks, 20);
+    UtAssert_UINT32_EQ(ReportPtr->FileSys[1].Bytes, 1000);
+    UtAssert_UINT32_EQ(ReportPtr->FileSys[1].Blocks, 10);
+    UtAssert_UINT32_EQ(ReportPtr->FileSys[2].Bytes, 0);
+    UtAssert_UINT32_EQ(ReportPtr->FileSys[2].Blocks, 0);
 }
 
 void Test_FM_MonitorFilesystemSpaceCmd_BadLength(void)
@@ -1887,9 +1952,12 @@ void Test_FM_MonitorFilesystemSpaceCmd_NullFreeSpaceTable(void)
 
 void Test_FM_MonitorFilesystemSpaceCmd_ImplCallFails(void)
 {
+    FM_MonitorReportPkt_Payload_t *ReportPtr;
+
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     char  ExpectedEventString2[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Could not get file system free space for %%s. Returned 0x%%08X");
     snprintf(ExpectedEventString2, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "%%s command");
@@ -1922,15 +1990,19 @@ void Test_FM_MonitorFilesystemSpaceCmd_ImplCallFails(void)
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(call_count_CFE_SB_TransmitMsg, 1);
-    UtAssert_ZERO(FM_GlobalData.MonitorReportPkt.FileSys[0].Blocks);
-    UtAssert_ZERO(FM_GlobalData.MonitorReportPkt.FileSys[0].Bytes);
+    ReportPtr = &FM_GlobalData.MonitorReportPkt.Payload;
+    UtAssert_ZERO(ReportPtr->FileSys[0].Blocks);
+    UtAssert_ZERO(ReportPtr->FileSys[0].Bytes);
 }
 
 void Test_FM_MonitorFilesystemSpaceCmd_NotImpl(void)
 {
+    FM_MonitorReportPkt_Payload_t *ReportPtr;
+
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     char  ExpectedEventString2[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Could not get file system free space for %%s. Returned 0x%%08X");
     snprintf(ExpectedEventString2, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "%%s command");
@@ -1962,8 +2034,9 @@ void Test_FM_MonitorFilesystemSpaceCmd_NotImpl(void)
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(call_count_CFE_SB_TransmitMsg, 1);
-    UtAssert_ZERO(FM_GlobalData.MonitorReportPkt.FileSys[0].Blocks);
-    UtAssert_ZERO(FM_GlobalData.MonitorReportPkt.FileSys[0].Bytes);
+    ReportPtr = &FM_GlobalData.MonitorReportPkt.Payload;
+    UtAssert_ZERO(ReportPtr->FileSys[0].Blocks);
+    UtAssert_ZERO(ReportPtr->FileSys[0].Bytes);
 }
 
 void add_FM_MonitorFilesystemSpaceCmd_tests(void)
@@ -1990,8 +2063,12 @@ void add_FM_MonitorFilesystemSpaceCmd_tests(void)
 
 void Test_FM_SetTableStateCmd_Success(void)
 {
-    UT_CmdBuf.SetTableStateCmd.TableEntryState = FM_TABLE_ENTRY_ENABLED;
-    UT_CmdBuf.SetTableStateCmd.TableEntryIndex = 0;
+    FM_TableIndexAndState_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.SetTableStateCmd.Payload;
+
+    CmdPtr->TableEntryState = FM_TABLE_ENTRY_ENABLED;
+    CmdPtr->TableEntryIndex = 0;
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -2023,8 +2100,12 @@ void Test_FM_SetTableStateCmd_Success(void)
 
 void Test_FM_SetTableStateCmd_BadLength(void)
 {
-    UT_CmdBuf.SetTableStateCmd.TableEntryState = FM_TABLE_ENTRY_ENABLED;
-    UT_CmdBuf.SetTableStateCmd.TableEntryIndex = 0;
+    FM_TableIndexAndState_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.SetTableStateCmd.Payload;
+
+    CmdPtr->TableEntryState = FM_TABLE_ENTRY_ENABLED;
+    CmdPtr->TableEntryIndex = 0;
 
     UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
 
@@ -2040,8 +2121,12 @@ void Test_FM_SetTableStateCmd_BadLength(void)
 
 void Test_FM_SetTableStateCmd_NullFreeSpaceTable(void)
 {
-    UT_CmdBuf.SetTableStateCmd.TableEntryState = FM_TABLE_ENTRY_ENABLED;
-    UT_CmdBuf.SetTableStateCmd.TableEntryIndex = 0;
+    FM_TableIndexAndState_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.SetTableStateCmd.Payload;
+
+    CmdPtr->TableEntryState = FM_TABLE_ENTRY_ENABLED;
+    CmdPtr->TableEntryIndex = 0;
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -2071,8 +2156,12 @@ void Test_FM_SetTableStateCmd_NullFreeSpaceTable(void)
 
 void Test_FM_SetTableStateCmd_TableEntryIndexTooLarge(void)
 {
-    UT_CmdBuf.SetTableStateCmd.TableEntryState = FM_TABLE_ENTRY_ENABLED;
-    UT_CmdBuf.SetTableStateCmd.TableEntryIndex = FM_TABLE_ENTRY_COUNT;
+    FM_TableIndexAndState_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.SetTableStateCmd.Payload;
+
+    CmdPtr->TableEntryState = FM_TABLE_ENTRY_ENABLED;
+    CmdPtr->TableEntryIndex = FM_TABLE_ENTRY_COUNT;
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -2106,8 +2195,12 @@ void Test_FM_SetTableStateCmd_TableEntryIndexTooLarge(void)
 
 void Test_FM_SetTableStateCmd_BadNewState(void)
 {
-    UT_CmdBuf.SetTableStateCmd.TableEntryState = 55;
-    UT_CmdBuf.SetTableStateCmd.TableEntryIndex = 0;
+    FM_TableIndexAndState_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.SetTableStateCmd.Payload;
+
+    CmdPtr->TableEntryState = 55;
+    CmdPtr->TableEntryIndex = 0;
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -2141,8 +2234,12 @@ void Test_FM_SetTableStateCmd_BadNewState(void)
 
 void Test_FM_SetTableStateCmd_BadCurrentState(void)
 {
-    UT_CmdBuf.SetTableStateCmd.TableEntryState = FM_TABLE_ENTRY_DISABLED;
-    UT_CmdBuf.SetTableStateCmd.TableEntryIndex = 0;
+    FM_TableIndexAndState_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.SetTableStateCmd.Payload;
+
+    CmdPtr->TableEntryState = FM_TABLE_ENTRY_DISABLED;
+    CmdPtr->TableEntryIndex = 0;
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -2197,7 +2294,11 @@ void add_FM_SetTableStateCmd_tests(void)
 
 void Test_FM_SetPermissionsCmd_Success(void)
 {
-    strncpy(UT_CmdBuf.SetPermCmd.FileName, "file", sizeof(UT_CmdBuf.SetPermCmd.FileName) - 1);
+    FM_FilenameAndMode_Payload_t *CmdPtr;
+
+    CmdPtr = &UT_CmdBuf.SetPermCmd.Payload;
+
+    strncpy(CmdPtr->FileName, "file", sizeof(CmdPtr->FileName) - 1);
     UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyNameValid), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/FM/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Adds a "Payload" submember to all cmd/tlm structs.  The message content is found in this sub-structure.  This matches the patterns currently implemented in CFE.

Fixes #74

**Testing performed**
Build and run all tests

**Expected behavior changes**
None expected.  This _may_ affect the padding in some circumstances, but should not change anything if the headers were properly aligned to begin with.

**System(s) tested on**
Debian

**Additional context**
This pattern of using a payload sub-structure matches CFE and keeps things more consistent.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
