### PR TITLE
Fix #87, Change EVS_Register failure from SendEvent to WriteToSysLog

### DIFF
--- a/fsw/src/fm_app.c
+++ b/fsw/src/fm_app.c
@@ -177,8 +177,7 @@ int32 FM_AppInit(void)
 
     if (Result != CFE_SUCCESS)
     {
-        CFE_EVS_SendEvent(FM_STARTUP_EVENTS_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "%s register for event services: result = 0x%08X", ErrText, (unsigned int)Result);
+        CFE_ES_WriteToSysLog("FM App: Error registering for Event Services, RC = 0x%08X\n", (unsigned int)Result);
     }
     else
     {

--- a/unit-test/fm_app_tests.c
+++ b/unit-test/fm_app_tests.c
@@ -71,12 +71,11 @@ void Test_FM_AppMain_AppInitNotSuccess(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_ES_RunLoop, 1);
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_STUB_COUNT(CFE_ES_WriteToSysLog, 2);
     UtAssert_STUB_COUNT(CFE_ES_ExitApp, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_STARTUP_EVENTS_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_EXIT_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_EXIT_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
 }
 
 void Test_FM_AppMain_SBReceiveBufferDefaultOption(void)
@@ -242,9 +241,6 @@ void Test_FM_AppInit_EVSRegisterNotSuccess(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_Register, 1);
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_STARTUP_EVENTS_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 }
 
 void Test_FM_AppInit_CreatePipeFail(void)

--- a/unit-test/fm_child_tests.c
+++ b/unit-test/fm_child_tests.c
@@ -1683,9 +1683,11 @@ void Test_FM_ChildDirListPktCmd_DirListOffsetNotExceeded(void)
     FM_DirListPkt_Payload_t *ReportPtr;
 
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_GET_DIR_LIST_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2", .DirListOffset = 1};
-    os_dirent_t direntry = {.FileName = "filename"};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode   = FM_GET_DIR_LIST_PKT_CC,
+                                        .Source1       = "dummy_source1",
+                                        .Source2       = "dummy_source2",
+                                        .DirListOffset = 1};
+    os_dirent_t          direntry    = {.FileName = "filename"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #87
`CFE_EVS_SendEvent` replaced by `CFE_ES_WriteToSysLog` on failure of `CFE_EVS_Register`.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.
Coverage maintained at 100%:
```
  lines......: 100.0% (1443 of 1443 lines)
  functions..: 100.0% (72 of 72 functions)
  branches...: 100.0% (525 of 525 branches)
```

**Expected behavior changes**
Failure can be successfully recorded somewhere even without the EVS now.

**Contributor Info**
Avi Weiss @thnkslprpt