### PR TITLE
Fix #15, use CFE_MSG_PTR macro

### DIFF
--- a/fsw/inc/fm_msg.h
+++ b/fsw/inc/fm_msg.h
@@ -44,8 +44,8 @@
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
-} FM_HousekeepingCmd_t;
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} FM_SendHkCmd_t;
 
 /**
  *  \brief No-Operation command packet structure
@@ -54,25 +54,25 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 } FM_NoopCmd_t;
 
 /**
  *  \brief Reset Counters command packet structure
  *
- *  For command details see #FM_RESET_CC
+ *  For command details see #FM_RESET_COUNTERS_CC
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
-} FM_ResetCmd_t;
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} FM_ResetCountersCmd_t;
 
 /**
  * \brief Copy/Move File command payload structure
  *
  * Contains a source and target file name and an overwrite flag
  *
- * Used by #FM_COPY_CC, #FM_MOVE_CC
+ * Used by #FM_COPY_FILE_CC, #FM_MOVE_FILE_CC
  */
 typedef struct
 {
@@ -84,11 +84,11 @@ typedef struct
 /**
  *  \brief Copy File command packet structure
  *
- *  For command details see #FM_COPY_CC
+ *  For command details see #FM_COPY_FILE_CC
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 
     FM_OvwSourceTargetFilename_Payload_t Payload; /**< \brief Command payload */
 } FM_CopyFileCmd_t;
@@ -96,11 +96,11 @@ typedef struct
 /**
  *  \brief Move File command packet structure
  *
- *  For command details see #FM_MOVE_CC
+ *  For command details see #FM_MOVE_FILE_CC
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 
     FM_OvwSourceTargetFilename_Payload_t Payload; /**< \brief Command payload */
 
@@ -109,7 +109,7 @@ typedef struct
 /**
  *  \brief Source and Target filename command payload structure
  *
- *  Used by #FM_RENAME_CC, #FM_DECOMPRESS_CC
+ *  Used by #FM_RENAME_FILE_CC, #FM_DECOMPRESS_FILE_CC
  */
 typedef struct
 {
@@ -120,11 +120,11 @@ typedef struct
 /**
  *  \brief Rename File command packet structure
  *
- *  For command details see #FM_RENAME_CC
+ *  For command details see #FM_RENAME_FILE_CC
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 
     FM_SourceTargetFileName_Payload_t Payload; /**< \brief Command payload */
 } FM_RenameFileCmd_t;
@@ -132,7 +132,7 @@ typedef struct
 /**
  *  \brief Single filename command payload structure
  *
- *  Used by #FM_DELETE_CC
+ *  Used by #FM_DELETE_FILE_CC
  */
 typedef struct
 {
@@ -142,11 +142,11 @@ typedef struct
 /**
  *  \brief Delete File command packet structure
  *
- *  For command details see #FM_DELETE_CC
+ *  For command details see #FM_DELETE_FILE_CC
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 
     FM_SingleFilename_Payload_t Payload; /**< \brief Command Payload */
 } FM_DeleteFileCmd_t;
@@ -154,7 +154,7 @@ typedef struct
 /**
  *  \brief Single directory command payload structure
  *
- *  Used by #FM_DELETE_ALL_CC, #FM_CREATE_DIR_CC, #FM_DELETE_DIR_CC
+ *  Used by #FM_DELETE_ALL_FILES_CC, #FM_CREATE_DIRECTORY_CC, #FM_DELETE_DIRECTORY_CC
  */
 typedef struct
 {
@@ -164,31 +164,31 @@ typedef struct
 /**
  *  \brief Delete All command packet structure
  *
- *  For command details see #FM_DELETE_ALL_CC
+ *  For command details see #FM_DELETE_ALL_FILES_CC
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 
     FM_DirectoryName_Payload_t Payload; /**< \brief Command Payload */
-} FM_DeleteAllCmd_t;
+} FM_DeleteAllFilesCmd_t;
 
 /**
  *  \brief Decompress File command packet structure
  *
- *  For command details see #FM_DECOMPRESS_CC
+ *  For command details see #FM_DECOMPRESS_FILE_CC
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 
     FM_SourceTargetFileName_Payload_t Payload; /**< \brief Command Payload */
-} FM_DecompressCmd_t;
+} FM_DecompressFileCmd_t;
 
 /**
  * \brief Two source, one target filename command payload structure
  *
- * Used by #FM_CONCAT_CC
+ * Used by #FM_CONCAT_FILES_CC
  */
 typedef struct
 {
@@ -200,14 +200,14 @@ typedef struct
 /**
  *  \brief Concatenate Files command packet structure
  *
- *  For command details see #FM_CONCAT_CC
+ *  For command details see #FM_CONCAT_FILES_CC
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 
     FM_TwoSourceOneTarget_Payload_t Payload; /**< \brief Command Payload */
-} FM_ConcatCmd_t;
+} FM_ConcatFilesCmd_t;
 
 /**
  *  \brief Filename and CRC command payload structure
@@ -227,7 +227,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 
     FM_FilenameAndCRC_Payload_t Payload; /**< \brief Command Payload */
 } FM_GetFileInfoCmd_t;
@@ -239,38 +239,38 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 } FM_GetOpenFilesCmd_t;
 
 /**
  *  \brief Create Directory command packet structure
  *
- *  For command details see #FM_CREATE_DIR_CC
+ *  For command details see #FM_CREATE_DIRECTORY_CC
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 
     FM_DirectoryName_Payload_t Payload; /**< \brief Command Payload */
-} FM_CreateDirCmd_t;
+} FM_CreateDirectoryCmd_t;
 
 /**
  *  \brief Delete Directory command packet structure
  *
- *  For command details see #FM_DELETE_DIR_CC
+ *  For command details see #FM_DELETE_DIRECTORY_CC
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 
     FM_DirectoryName_Payload_t Payload; /**< \brief Command Payload */
-} FM_DeleteDirCmd_t;
+} FM_DeleteDirectoryCmd_t;
 
 /**
  *  \brief Get Directory and output to file command payload
  *
  * Contains a directory and output file name, with optional flags
- * Used by #FM_GET_DIR_FILE_CC
+ * Used by #FM_GET_DIR_LIST_FILE_CC
  */
 typedef struct
 {
@@ -283,20 +283,20 @@ typedef struct
 /**
  *  \brief Get DIR List to File command packet structure
  *
- *  For command details see #FM_GET_DIR_FILE_CC
+ *  For command details see #FM_GET_DIR_LIST_FILE_CC
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 
     FM_GetDirectoryToFile_Payload_t Payload; /**< \brief Command Payload */
-} FM_GetDirFileCmd_t;
+} FM_GetDirListFileCmd_t;
 
 /**
  *  \brief Get Directory and output to message command payload
  *
  * Contains a directory and position offset, with optional flags
- * Used by #FM_GET_DIR_PKT_CC
+ * Used by #FM_GET_DIR_LIST_PKT_CC
  */
 typedef struct
 {
@@ -309,14 +309,14 @@ typedef struct
 /**
  *  \brief Get DIR List to Packet command packet structure
  *
- *  For command details see #FM_GET_DIR_PKT_CC
+ *  For command details see #FM_GET_DIR_LIST_PKT_CC
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 
     FM_GetDirectoryToPkt_Payload_t Payload; /**< \brief Command Payload */
-} FM_GetDirPktCmd_t;
+} FM_GetDirListPktCmd_t;
 
 /**
  *  \brief Get Free Space command packet structure
@@ -325,7 +325,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 } FM_MonitorFilesystemSpaceCmd_t;
 
 /**
@@ -346,7 +346,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 
     FM_TableIndexAndState_Payload_t Payload; /**< \brief Command Payload */
 } FM_SetTableStateCmd_t;
@@ -354,7 +354,7 @@ typedef struct
 /**
  *  \brief File name and mode command payload structure
  *
- *  Used by #FM_SET_FILE_PERM_CC
+ *  Used by #FM_SET_PERMISSIONS_CC
  */
 typedef struct
 {
@@ -365,14 +365,14 @@ typedef struct
 /**
  *  \brief Set Permissions for a file
  *
- *  For command details see #FM_SET_FILE_PERM_CC
+ *  For command details see #FM_SET_PERMISSIONS_CC
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 
     FM_FilenameAndMode_Payload_t Payload;
-} FM_SetPermCmd_t;
+} FM_SetPermissionsCmd_t;
 
 /**\}*/
 
@@ -415,7 +415,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief Telemetry Header */
+    CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief Telemetry Header */
 
     FM_DirListPkt_Payload_t Payload; /**< \brief Telemetry Payload */
 } FM_DirListPkt_t;
@@ -462,7 +462,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief Telemetry Header */
+    CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief Telemetry Header */
 
     FM_FileInfoPkt_Payload_t Payload; /**< \brief Telemetry Payload */
 } FM_FileInfoPkt_t;
@@ -496,7 +496,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief Telemetry Header */
+    CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief Telemetry Header */
 
     FM_OpenFilesPkt_Payload_t Payload; /**< \brief Telemetry Payload */
 } FM_OpenFilesPkt_t;
@@ -531,7 +531,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief Telemetry Header */
+    CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief Telemetry Header */
 
     FM_MonitorReportPkt_Payload_t Payload; /**< \brief Telemetry Payload */
 } FM_MonitorReportPkt_t;
@@ -568,7 +568,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief Telemetry Header */
+    CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief Telemetry Header */
 
     FM_HousekeepingPkt_Payload_t Payload; /**< \brief Telemetry Payload */
 } FM_HousekeepingPkt_t;

--- a/fsw/inc/fm_msgdefs.h
+++ b/fsw/inc/fm_msgdefs.h
@@ -71,7 +71,7 @@
  *       - #FM_HousekeepingPkt_Payload_t.ChildCmdWarnCounter
  *
  *  \par Command Packet Structure
- *       #FM_ResetCmd_t
+ *       #FM_ResetCountersCmd_t
  *
  *  \par Command Success Verification
  *       - Command counters will be set to zero (see description)
@@ -88,7 +88,7 @@
  *       - There are no critical issues related to this command.
  *
  */
-#define FM_RESET_CC 1
+#define FM_RESET_COUNTERS_CC 1
 
 /**
  * \brief Copy File
@@ -151,9 +151,9 @@
  *       critical tasks.  Also, copying very large files may
  *       consume more CPU resource than anticipated.
  *
- *  \sa #FM_MOVE_CC, #FM_RENAME_CC
+ *  \sa #FM_MOVE_FILE_CC, #FM_RENAME_FILE_CC
  */
-#define FM_COPY_CC 2
+#define FM_COPY_FILE_CC 2
 
 /**
  * \brief Move File
@@ -219,9 +219,9 @@
  *  \par Criticality
  *       - There are no critical issues related to this command.
  *
- *  \sa #FM_COPY_CC, #FM_RENAME_CC
+ *  \sa #FM_COPY_FILE_CC, #FM_RENAME_FILE_CC
  */
-#define FM_MOVE_CC 3
+#define FM_MOVE_FILE_CC 3
 
 /**
  * \brief Rename File
@@ -279,9 +279,9 @@
  *  \par Criticality
  *       - There are no critical issues related to this command.
  *
- *  \sa #FM_COPY_CC, #FM_MOVE_CC
+ *  \sa #FM_COPY_FILE_CC, #FM_MOVE_FILE_CC
  */
-#define FM_RENAME_CC 4
+#define FM_RENAME_FILE_CC 4
 
 /**
  * \brief Delete File
@@ -330,9 +330,9 @@
  *       The FM application does not provide a method to restore deleted
  *       files.  Critical data may be lost when deleting files.
  *
- *  \sa #FM_DELETE_ALL_CC, #FM_DELETE_DIR_CC
+ *  \sa #FM_DELETE_ALL_FILES_CC, #FM_DELETE_DIRECTORY_CC
  */
-#define FM_DELETE_CC 5
+#define FM_DELETE_FILE_CC 5
 
 /**
  * \brief Delete All Files
@@ -351,7 +351,7 @@
  *       the child task interface queue.
  *
  *  \par Command Packet Structure
- *       #FM_DeleteAllCmd_t
+ *       #FM_DeleteAllFilesCmd_t
  *
  *  \par Command Success Verification
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
@@ -392,9 +392,9 @@
  *       deleting a very large number of files may consume more CPU resource
  *       than anticipated.
  *
- *  \sa #FM_DELETE_CC, #FM_DELETE_DIR_CC
+ *  \sa #FM_DELETE_FILE_CC, #FM_DELETE_DIRECTORY_CC
  */
-#define FM_DELETE_ALL_CC 7
+#define FM_DELETE_ALL_FILES_CC 7
 
 /**
  * \brief Decompress File
@@ -418,7 +418,7 @@
  *       will generate an error event.
  *
  *  \par Command Packet Structure
- *       #FM_DecompressCmd_t
+ *       #FM_DecompressFileCmd_t
  *
  *  \par Command Success Verification
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
@@ -453,7 +453,7 @@
  *       Decompressing a very large file may consume more CPU resource than
  *       anticipated.
  */
-#define FM_DECOMPRESS_CC 8
+#define FM_DECOMPRESS_FILE_CC 8
 
 /**
  * \brief Concatenate Files
@@ -474,7 +474,7 @@
  *       the child task interface queue.
  *
  *  \par Command Packet Structure
- *       #FM_ConcatCmd_t
+ *       #FM_ConcatFilesCmd_t
  *
  *  \par Command Success Verification
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
@@ -517,9 +517,9 @@
  *       Concatenating very large files may consume more CPU resource
  *       than anticipated.
  *
- *  \sa #FM_COPY_CC
+ *  \sa #FM_COPY_FILE_CC
  */
-#define FM_CONCAT_CC 9
+#define FM_CONCAT_FILES_CC 9
 
 /**
  * \brief Get File Information
@@ -579,7 +579,7 @@
  *       Calculating the CRC for a very large file may consume more CPU resource than
  *       anticipated.
  *
- *  \sa #FM_GET_OPEN_FILES_CC, #FM_GET_DIR_FILE_CC, #FM_GET_DIR_PKT_CC
+ *  \sa #FM_GET_OPEN_FILES_CC, #FM_GET_DIR_LIST_FILE_CC, #FM_GET_DIR_LIST_PKT_CC
  */
 #define FM_GET_FILE_INFO_CC 10
 
@@ -609,7 +609,7 @@
  *  \par Criticality
  *       - There are no critical issues related to this command.
  *
- *  \sa #FM_GET_FILE_INFO_CC, #FM_GET_DIR_FILE_CC, #FM_GET_DIR_PKT_CC
+ *  \sa #FM_GET_FILE_INFO_CC, #FM_GET_DIR_LIST_FILE_CC, #FM_GET_DIR_LIST_PKT_CC
  */
 #define FM_GET_OPEN_FILES_CC 11
 
@@ -628,7 +628,7 @@
  *       the child task interface queue.
  *
  *  \par Command Packet Structure
- *       #FM_CreateDirCmd_t
+ *       #FM_CreateDirectoryCmd_t
  *
  *  \par Command Success Verification
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
@@ -656,9 +656,9 @@
  *  \par Criticality
  *       - There are no critical issues related to this command.
  *
- *  \sa #FM_DELETE_DIR_CC
+ *  \sa #FM_DELETE_DIRECTORY_CC
  */
-#define FM_CREATE_DIR_CC 12
+#define FM_CREATE_DIRECTORY_CC 12
 
 /**
  * \brief Remove Directory
@@ -676,7 +676,7 @@
  *       the child task interface queue.
  *
  *  \par Command Packet Structure
- *       #FM_DeleteDirCmd_t
+ *       #FM_DeleteDirectoryCmd_t
  *
  *  \par Command Success Verification
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
@@ -708,9 +708,9 @@
  *       The unexpected loss of a directory may affect a critical
  *       tasks ability to store data.
  *
- *  \sa #FM_CREATE_DIR_CC
+ *  \sa #FM_CREATE_DIRECTORY_CC
  */
-#define FM_DELETE_DIR_CC 13
+#define FM_DELETE_DIRECTORY_CC 13
 
 /**
  * \brief Get Directory Listing to a File
@@ -731,7 +731,7 @@
  *       the child task interface queue.
  *
  *  \par Command Packet Structure
- *       #FM_GetDirFileCmd_t
+ *       #FM_GetDirListFileCmd_t
  *
  *  \par Command Success Verification
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
@@ -778,9 +778,9 @@
  *       Reading a directory that contains thousands of files may consume more CPU
  *       resource than anticipated.
  *
- *  \sa #FM_GET_DIR_PKT_CC
+ *  \sa #FM_GET_DIR_LIST_PKT_CC
  */
-#define FM_GET_DIR_FILE_CC 14
+#define FM_GET_DIR_LIST_FILE_CC 14
 
 /**
  * \brief Get Directory Listing to a Packet
@@ -811,7 +811,7 @@
  *       the child task interface queue.
  *
  *  \par Command Packet Structure
- *       #FM_GetDirPktCmd_t
+ *       #FM_GetDirListPktCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -852,9 +852,9 @@
  *       Reading a directory that contains thousands of files may consume more CPU
  *       resource than anticipated.
  *
- *  \sa #FM_GET_DIR_FILE_CC
+ *  \sa #FM_GET_DIR_LIST_FILE_CC
  */
-#define FM_GET_DIR_PKT_CC 15
+#define FM_GET_DIR_LIST_PKT_CC 15
 
 /**
  * \brief Monitor Filesystem Space
@@ -943,7 +943,7 @@
  *       the child task interface queue.
  *
  *  \par Command Packet Structure
- *       #FM_SetPermCmd_t
+ *       #FM_SetPermissionsCmd_t
  *
  *  \par Command Success Verification
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
@@ -963,7 +963,7 @@
  *  \par Criticality
  *       - There are no critical issues related to this command.
  */
-#define FM_SET_FILE_PERM_CC 19
+#define FM_SET_PERMISSIONS_CC 19
 
 /**\}*/
 

--- a/fsw/src/fm_app.c
+++ b/fsw/src/fm_app.c
@@ -257,7 +257,7 @@ void FM_ProcessPkt(const CFE_SB_Buffer_t *BufPtr)
     {
         /* Housekeeping request */
         case FM_SEND_HK_MID:
-            FM_ReportHK((CFE_MSG_CommandHeader_t *)BufPtr);
+            FM_SendHkCmd(BufPtr);
             break;
 
         /* FM ground commands */
@@ -292,35 +292,35 @@ void FM_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
             Result = FM_NoopCmd(BufPtr);
             break;
 
-        case FM_RESET_CC:
+        case FM_RESET_COUNTERS_CC:
             Result = FM_ResetCountersCmd(BufPtr);
             break;
 
-        case FM_COPY_CC:
+        case FM_COPY_FILE_CC:
             Result = FM_CopyFileCmd(BufPtr);
             break;
 
-        case FM_MOVE_CC:
+        case FM_MOVE_FILE_CC:
             Result = FM_MoveFileCmd(BufPtr);
             break;
 
-        case FM_RENAME_CC:
+        case FM_RENAME_FILE_CC:
             Result = FM_RenameFileCmd(BufPtr);
             break;
 
-        case FM_DELETE_CC:
+        case FM_DELETE_FILE_CC:
             Result = FM_DeleteFileCmd(BufPtr);
             break;
 
-        case FM_DELETE_ALL_CC:
+        case FM_DELETE_ALL_FILES_CC:
             Result = FM_DeleteAllFilesCmd(BufPtr);
             break;
 
-        case FM_DECOMPRESS_CC:
+        case FM_DECOMPRESS_FILE_CC:
             Result = FM_DecompressFileCmd(BufPtr);
             break;
 
-        case FM_CONCAT_CC:
+        case FM_CONCAT_FILES_CC:
             Result = FM_ConcatFilesCmd(BufPtr);
             break;
 
@@ -332,19 +332,19 @@ void FM_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
             Result = FM_GetOpenFilesCmd(BufPtr);
             break;
 
-        case FM_CREATE_DIR_CC:
+        case FM_CREATE_DIRECTORY_CC:
             Result = FM_CreateDirectoryCmd(BufPtr);
             break;
 
-        case FM_DELETE_DIR_CC:
+        case FM_DELETE_DIRECTORY_CC:
             Result = FM_DeleteDirectoryCmd(BufPtr);
             break;
 
-        case FM_GET_DIR_FILE_CC:
+        case FM_GET_DIR_LIST_FILE_CC:
             Result = FM_GetDirListFileCmd(BufPtr);
             break;
 
-        case FM_GET_DIR_PKT_CC:
+        case FM_GET_DIR_LIST_PKT_CC:
             Result = FM_GetDirListPktCmd(BufPtr);
             break;
 
@@ -356,7 +356,7 @@ void FM_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
             Result = FM_SetTableStateCmd(BufPtr);
             break;
 
-        case FM_SET_FILE_PERM_CC:
+        case FM_SET_PERMISSIONS_CC:
             Result = FM_SetPermissionsCmd(BufPtr);
             break;
 
@@ -370,7 +370,7 @@ void FM_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
     if (Result == true)
     {
         /* Increment command success counter */
-        if (CommandCode != FM_RESET_CC)
+        if (CommandCode != FM_RESET_COUNTERS_CC)
         {
             FM_GlobalData.CommandCounter++;
         }
@@ -387,14 +387,14 @@ void FM_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
 /* FM application -- housekeeping request packet processor         */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void FM_ReportHK(const CFE_MSG_CommandHeader_t *Msg)
+void FM_SendHkCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     const char *                  CmdText = "HK Request";
     bool                          Result  = true;
     FM_HousekeepingPkt_Payload_t *PayloadPtr;
 
     /* Verify command packet length */
-    Result = FM_IsValidCmdPktLength(&Msg->Msg, sizeof(FM_HousekeepingCmd_t), FM_HK_REQ_ERR_EID, CmdText);
+    Result = FM_IsValidCmdPktLength(CFE_MSG_PTR(*BufPtr), sizeof(FM_SendHkCmd_t), FM_HK_REQ_ERR_EID, CmdText);
 
     if (Result == true)
     {
@@ -403,7 +403,7 @@ void FM_ReportHK(const CFE_MSG_CommandHeader_t *Msg)
         FM_AcquireTablePointers();
 
         /* Initialize housekeeping telemetry message */
-        CFE_MSG_Init(&FM_GlobalData.HousekeepingPkt.TlmHeader.Msg, CFE_SB_ValueToMsgId(FM_HK_TLM_MID),
+        CFE_MSG_Init(CFE_MSG_PTR(FM_GlobalData.HousekeepingPkt.TelemetryHeader), CFE_SB_ValueToMsgId(FM_HK_TLM_MID),
                      sizeof(FM_HousekeepingPkt_t));
 
         PayloadPtr = &FM_GlobalData.HousekeepingPkt.Payload;
@@ -425,7 +425,7 @@ void FM_ReportHK(const CFE_MSG_CommandHeader_t *Msg)
         PayloadPtr->ChildCurrentCC  = FM_GlobalData.ChildCurrentCC;
         PayloadPtr->ChildPreviousCC = FM_GlobalData.ChildPreviousCC;
 
-        CFE_SB_TimeStampMsg(&FM_GlobalData.HousekeepingPkt.TlmHeader.Msg);
-        CFE_SB_TransmitMsg(&FM_GlobalData.HousekeepingPkt.TlmHeader.Msg, true);
+        CFE_SB_TimeStampMsg(CFE_MSG_PTR(FM_GlobalData.HousekeepingPkt.TelemetryHeader));
+        CFE_SB_TransmitMsg(CFE_MSG_PTR(FM_GlobalData.HousekeepingPkt.TelemetryHeader), true);
     }
 }

--- a/fsw/src/fm_app.h
+++ b/fsw/src/fm_app.h
@@ -172,7 +172,7 @@ int32 FM_AppInit(void);
  *
  *  \param [in] MessagePtr Pointer to Software Bus message buffer.
  *
- *  \sa #FM_ReportHK, #FM_ProcessCmd
+ *  \sa #FM_SendHkCmd, #FM_ProcessCmd
  */
 void FM_ProcessPkt(const CFE_SB_Buffer_t *MessagePtr);
 
@@ -202,11 +202,11 @@ void FM_ProcessCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \par Assumptions, External Events, and Notes: None
  *
- *  \param [in]  Msg Pointer to Software Bus command packet.
+ *  \param [in]  BufPtr Pointer to Software Bus command packet.
  *
- *  \sa #FM_HousekeepingCmd_t, #FM_HousekeepingPkt_t
+ *  \sa #FM_SendHkCmd_t, #FM_HousekeepingPkt_t
  */
-void FM_ReportHK(const CFE_MSG_CommandHeader_t *Msg);
+void FM_SendHkCmd(const CFE_SB_Buffer_t *BufPtr);
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */

--- a/fsw/src/fm_child.c
+++ b/fsw/src/fm_child.c
@@ -198,55 +198,55 @@ void FM_ChildProcess(void)
     /* Invoke the command specific handler */
     switch (CmdArgs->CommandCode)
     {
-        case FM_COPY_CC:
+        case FM_COPY_FILE_CC:
             FM_ChildCopyCmd(CmdArgs);
             break;
 
-        case FM_MOVE_CC:
+        case FM_MOVE_FILE_CC:
             FM_ChildMoveCmd(CmdArgs);
             break;
 
-        case FM_RENAME_CC:
+        case FM_RENAME_FILE_CC:
             FM_ChildRenameCmd(CmdArgs);
             break;
 
-        case FM_DELETE_CC:
+        case FM_DELETE_FILE_CC:
             FM_ChildDeleteCmd(CmdArgs);
             break;
 
-        case FM_DELETE_ALL_CC:
-            FM_ChildDeleteAllCmd(CmdArgs);
+        case FM_DELETE_ALL_FILES_CC:
+            FM_ChildDeleteAllFilesCmd(CmdArgs);
             break;
 
-        case FM_DECOMPRESS_CC:
-            FM_ChildDecompressCmd(CmdArgs);
+        case FM_DECOMPRESS_FILE_CC:
+            FM_ChildDecompressFileCmd(CmdArgs);
             break;
 
-        case FM_CONCAT_CC:
-            FM_ChildConcatCmd(CmdArgs);
+        case FM_CONCAT_FILES_CC:
+            FM_ChildConcatFilesCmd(CmdArgs);
             break;
 
-        case FM_CREATE_DIR_CC:
-            FM_ChildCreateDirCmd(CmdArgs);
+        case FM_CREATE_DIRECTORY_CC:
+            FM_ChildCreateDirectoryCmd(CmdArgs);
             break;
 
-        case FM_DELETE_DIR_CC:
-            FM_ChildDeleteDirCmd(CmdArgs);
+        case FM_DELETE_DIRECTORY_CC:
+            FM_ChildDeleteDirectoryCmd(CmdArgs);
             break;
 
         case FM_GET_FILE_INFO_CC:
             FM_ChildFileInfoCmd(CmdArgs);
             break;
 
-        case FM_GET_DIR_FILE_CC:
+        case FM_GET_DIR_LIST_FILE_CC:
             FM_ChildDirListFileCmd(CmdArgs);
             break;
 
-        case FM_GET_DIR_PKT_CC:
+        case FM_GET_DIR_LIST_PKT_CC:
             FM_ChildDirListPktCmd(CmdArgs);
             break;
 
-        case FM_SET_FILE_PERM_CC:
+        case FM_SET_PERMISSIONS_CC:
             FM_ChildSetPermissionsCmd(CmdArgs);
             break;
 
@@ -434,7 +434,7 @@ void FM_ChildDeleteCmd(const FM_ChildQueueEntry_t *CmdArgs)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-void FM_ChildDeleteAllCmd(FM_ChildQueueEntry_t *CmdArgs)
+void FM_ChildDeleteAllFilesCmd(FM_ChildQueueEntry_t *CmdArgs)
 {
     const char *CmdText = "Delete All Files";
     osal_id_t   DirId   = OS_OBJECT_ID_UNDEFINED;
@@ -450,7 +450,7 @@ void FM_ChildDeleteAllCmd(FM_ChildQueueEntry_t *CmdArgs)
     /*
     ** Command argument useage for this command:
     **
-    **  CmdArgs->CommandCode = FM_DELETE_ALL_CC
+    **  CmdArgs->CommandCode = FM_DELETE_ALL_FILES_CC
     **  CmdArgs->Source1     = directory name
     **  CmdArgs->Source2     = directory name plus separator
     */
@@ -585,7 +585,7 @@ void FM_ChildDeleteAllCmd(FM_ChildQueueEntry_t *CmdArgs)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-void FM_ChildDecompressCmd(const FM_ChildQueueEntry_t *CmdArgs)
+void FM_ChildDecompressFileCmd(const FM_ChildQueueEntry_t *CmdArgs)
 {
     const char *CmdText    = "Decompress File";
     int32       CFE_Status = CFE_SUCCESS;
@@ -625,7 +625,7 @@ void FM_ChildDecompressCmd(const FM_ChildQueueEntry_t *CmdArgs)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-void FM_ChildConcatCmd(const FM_ChildQueueEntry_t *CmdArgs)
+void FM_ChildConcatFilesCmd(const FM_ChildQueueEntry_t *CmdArgs)
 {
     const char *CmdText        = "Concat Files";
     bool        ConcatResult   = false;
@@ -817,7 +817,7 @@ void FM_ChildFileInfoCmd(FM_ChildQueueEntry_t *CmdArgs)
     /*
     ** Command argument useage for this command:
     **
-    **  CmdArgs->CommandCode   = FM_GET_DIR_FILE_CC
+    **  CmdArgs->CommandCode   = FM_GET_DIR_LIST_FILE_CC
     **  CmdArgs->Source1       = name of directory or file
     **  CmdArgs->FileInfoState = state of directory or file
     **  CmdArgs->FileInfoSize  = file size, else zero
@@ -825,7 +825,7 @@ void FM_ChildFileInfoCmd(FM_ChildQueueEntry_t *CmdArgs)
     */
 
     /* Initialize file info packet (set all data to zero) */
-    CFE_MSG_Init(&FM_GlobalData.FileInfoPkt.TlmHeader.Msg, CFE_SB_ValueToMsgId(FM_FILE_INFO_TLM_MID),
+    CFE_MSG_Init(CFE_MSG_PTR(FM_GlobalData.FileInfoPkt.TelemetryHeader), CFE_SB_ValueToMsgId(FM_FILE_INFO_TLM_MID),
                  sizeof(FM_FileInfoPkt_t));
 
     ReportPtr = &FM_GlobalData.FileInfoPkt.Payload;
@@ -941,8 +941,8 @@ void FM_ChildFileInfoCmd(FM_ChildQueueEntry_t *CmdArgs)
     }
 
     /* Timestamp and send file info telemetry packet */
-    CFE_SB_TimeStampMsg(&FM_GlobalData.FileInfoPkt.TlmHeader.Msg);
-    CFE_SB_TransmitMsg(&FM_GlobalData.FileInfoPkt.TlmHeader.Msg, true);
+    CFE_SB_TimeStampMsg(CFE_MSG_PTR(FM_GlobalData.FileInfoPkt.TelemetryHeader));
+    CFE_SB_TransmitMsg(CFE_MSG_PTR(FM_GlobalData.FileInfoPkt.TelemetryHeader), true);
 
     FM_GlobalData.ChildCmdCounter++;
 
@@ -961,7 +961,7 @@ void FM_ChildFileInfoCmd(FM_ChildQueueEntry_t *CmdArgs)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-void FM_ChildCreateDirCmd(const FM_ChildQueueEntry_t *CmdArgs)
+void FM_ChildCreateDirectoryCmd(const FM_ChildQueueEntry_t *CmdArgs)
 {
     const char *CmdText   = "Create Directory";
     int32       OS_Status = OS_SUCCESS;
@@ -1000,7 +1000,7 @@ void FM_ChildCreateDirCmd(const FM_ChildQueueEntry_t *CmdArgs)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-void FM_ChildDeleteDirCmd(const FM_ChildQueueEntry_t *CmdArgs)
+void FM_ChildDeleteDirectoryCmd(const FM_ChildQueueEntry_t *CmdArgs)
 {
     const char *CmdText      = "Delete Directory";
     bool        RemoveTheDir = true;
@@ -1092,7 +1092,7 @@ void FM_ChildDirListFileCmd(const FM_ChildQueueEntry_t *CmdArgs)
     /*
     ** Command argument useage for this command:
     **
-    **  CmdArgs->CommandCode = FM_GET_DIR_FILE_CC
+    **  CmdArgs->CommandCode = FM_GET_DIR_LIST_FILE_CC
     **  CmdArgs->Source1     = directory name
     **  CmdArgs->Source2     = directory name plus separator
     **  CmdArgs->Target      = output filename
@@ -1162,7 +1162,7 @@ void FM_ChildDirListPktCmd(const FM_ChildQueueEntry_t *CmdArgs)
     /*
     ** Command argument useage for this command:
     **
-    **  CmdArgs->CommandCode   = FM_GET_DIR_PKT_CC
+    **  CmdArgs->CommandCode   = FM_GET_DIR_LIST_PKT_CC
     **  CmdArgs->Source1       = directory name
     **  CmdArgs->Source2       = directory name plus separator
     **  CmdArgs->DirListOffset = index of 1st reported dir entry
@@ -1183,7 +1183,7 @@ void FM_ChildDirListPktCmd(const FM_ChildQueueEntry_t *CmdArgs)
     else
     {
         /* Initialize the directory list telemetry packet */
-        CFE_MSG_Init(&FM_GlobalData.DirListPkt.TlmHeader.Msg, CFE_SB_ValueToMsgId(FM_DIR_LIST_TLM_MID),
+        CFE_MSG_Init(CFE_MSG_PTR(FM_GlobalData.DirListPkt.TelemetryHeader), CFE_SB_ValueToMsgId(FM_DIR_LIST_TLM_MID),
                      sizeof(FM_DirListPkt_t));
 
         ReportPtr = &FM_GlobalData.DirListPkt.Payload;
@@ -1253,8 +1253,8 @@ void FM_ChildDirListPktCmd(const FM_ChildQueueEntry_t *CmdArgs)
         OS_DirectoryClose(DirId);
 
         /* Timestamp and send directory listing telemetry packet */
-        CFE_SB_TimeStampMsg(&FM_GlobalData.DirListPkt.TlmHeader.Msg);
-        CFE_SB_TransmitMsg(&FM_GlobalData.DirListPkt.TlmHeader.Msg, true);
+        CFE_SB_TimeStampMsg(CFE_MSG_PTR(FM_GlobalData.DirListPkt.TelemetryHeader));
+        CFE_SB_TransmitMsg(CFE_MSG_PTR(FM_GlobalData.DirListPkt.TelemetryHeader), true);
 
         /* Send command completion event (info) */
         CFE_EVS_SendEvent(FM_GET_DIR_PKT_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: offset = %d, dir = %s", CmdText,

--- a/fsw/src/fm_child.h
+++ b/fsw/src/fm_child.h
@@ -188,9 +188,9 @@ void FM_ChildDeleteCmd(const FM_ChildQueueEntry_t *CmdArgs);
  *  \param [in] CmdArgs A pointer to an entry in the child task handshake command
  *       queue which contains the arguments necessary to process this command.
  *
- *  \sa #FM_ChildQueueEntry_t, #FM_DeleteAllCmd_t
+ *  \sa #FM_ChildQueueEntry_t, #FM_DeleteAllFilesCmd_t
  */
-void FM_ChildDeleteAllCmd(FM_ChildQueueEntry_t *CmdArgs);
+void FM_ChildDeleteAllFilesCmd(FM_ChildQueueEntry_t *CmdArgs);
 
 /**
  *  \brief Child Task Decompress File Command Handler
@@ -205,9 +205,9 @@ void FM_ChildDeleteAllCmd(FM_ChildQueueEntry_t *CmdArgs);
  *  \param [in] CmdArgs A pointer to an entry in the child task handshake command
  *       queue which contains the arguments necessary to process this command.
  *
- *  \sa #FM_ChildQueueEntry_t, #FM_DecompressCmd_t
+ *  \sa #FM_ChildQueueEntry_t, #FM_DecompressFileCmd_t
  */
-void FM_ChildDecompressCmd(const FM_ChildQueueEntry_t *CmdArgs);
+void FM_ChildDecompressFileCmd(const FM_ChildQueueEntry_t *CmdArgs);
 
 /**
  *  \brief Child Task Concatenate Files Command Handler
@@ -222,9 +222,9 @@ void FM_ChildDecompressCmd(const FM_ChildQueueEntry_t *CmdArgs);
  *  \param [in] CmdArgs A pointer to an entry in the child task handshake command
  *       queue which contains the arguments necessary to process this command.
  *
- *  \sa #FM_ChildQueueEntry_t, #FM_ConcatCmd_t
+ *  \sa #FM_ChildQueueEntry_t, #FM_ConcatFilesCmd_t
  */
-void FM_ChildConcatCmd(const FM_ChildQueueEntry_t *CmdArgs);
+void FM_ChildConcatFilesCmd(const FM_ChildQueueEntry_t *CmdArgs);
 
 /**
  *  \brief Child Task Get File Info Command Handler
@@ -256,9 +256,9 @@ void FM_ChildFileInfoCmd(FM_ChildQueueEntry_t *CmdArgs);
  *  \param [in] CmdArgs A pointer to an entry in the child task handshake command
  *       queue which contains the arguments necessary to process this command.
  *
- *  \sa #FM_ChildQueueEntry_t, #FM_CreateDirCmd_t
+ *  \sa #FM_ChildQueueEntry_t, #FM_CreateDirectoryCmd_t
  */
-void FM_ChildCreateDirCmd(const FM_ChildQueueEntry_t *CmdArgs);
+void FM_ChildCreateDirectoryCmd(const FM_ChildQueueEntry_t *CmdArgs);
 
 /**
  *  \brief Child Task Delete Directory Command Handler
@@ -273,9 +273,9 @@ void FM_ChildCreateDirCmd(const FM_ChildQueueEntry_t *CmdArgs);
  *  \param [in] CmdArgs A pointer to an entry in the child task handshake command
  *       queue which contains the arguments necessary to process this command.
  *
- *  \sa #FM_ChildQueueEntry_t, #FM_DeleteDirCmd_t
+ *  \sa #FM_ChildQueueEntry_t, #FM_DeleteDirectoryCmd_t
  */
-void FM_ChildDeleteDirCmd(const FM_ChildQueueEntry_t *CmdArgs);
+void FM_ChildDeleteDirectoryCmd(const FM_ChildQueueEntry_t *CmdArgs);
 
 /**
  *  \brief Child Task Get Dir List to File Command Handler
@@ -290,7 +290,7 @@ void FM_ChildDeleteDirCmd(const FM_ChildQueueEntry_t *CmdArgs);
  *  \param [in] CmdArgs A pointer to an entry in the child task handshake command
  *       queue which contains the arguments necessary to process this command.
  *
- *  \sa #FM_ChildQueueEntry_t, #FM_GetDirFileCmd_t
+ *  \sa #FM_ChildQueueEntry_t, #FM_GetDirListFileCmd_t
  */
 void FM_ChildDirListFileCmd(const FM_ChildQueueEntry_t *CmdArgs);
 
@@ -307,7 +307,7 @@ void FM_ChildDirListFileCmd(const FM_ChildQueueEntry_t *CmdArgs);
  *  \param [in] CmdArgs A pointer to an entry in the child task handshake command
  *       queue which contains the arguments necessary to process this command.
  *
- *  \sa #FM_ChildQueueEntry_t, #FM_GetDirPktCmd_t
+ *  \sa #FM_ChildQueueEntry_t, #FM_GetDirListPktCmd_t
  */
 void FM_ChildDirListPktCmd(const FM_ChildQueueEntry_t *CmdArgs);
 
@@ -324,7 +324,7 @@ void FM_ChildDirListPktCmd(const FM_ChildQueueEntry_t *CmdArgs);
  *  \param [in] CmdArgs A pointer to an entry in the child task handshake command
  *       queue which contains the arguments necessary to process this command.
  *
- *  \sa #FM_ChildQueueEntry_t, #FM_SetPermCmd_t
+ *  \sa #FM_ChildQueueEntry_t, #FM_SetPermissionsCmd_t
  */
 void FM_ChildSetPermissionsCmd(const FM_ChildQueueEntry_t *CmdArgs);
 

--- a/fsw/src/fm_cmd_utils.h
+++ b/fsw/src/fm_cmd_utils.h
@@ -90,7 +90,7 @@ bool FM_IsValidCmdPktLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLeng
  *  \retval true  Overwrite argument valid
  *  \retval false Overwrite argument invalid
  *
- *  \sa #FM_COPY_CC, #FM_MOVE_CC
+ *  \sa #FM_COPY_FILE_CC, #FM_MOVE_FILE_CC
  */
 bool FM_VerifyOverwrite(uint16 Overwrite, uint32 EventID, const char *CmdText);
 

--- a/fsw/src/fm_cmds.c
+++ b/fsw/src/fm_cmds.c
@@ -83,7 +83,7 @@ bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
     bool        CommandResult = false;
 
     /* Verify message length */
-    CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_ResetCmd_t), FM_RESET_PKT_ERR_EID, CmdText);
+    CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_ResetCountersCmd_t), FM_RESET_PKT_ERR_EID, CmdText);
 
     /* Reset command counters */
     if (CommandResult == true)
@@ -156,7 +156,7 @@ bool FM_CopyFileCmd(const CFE_SB_Buffer_t *BufPtr)
         CmdArgs = &FM_GlobalData.ChildQueue[FM_GlobalData.ChildWriteIndex];
 
         /* Set handshake queue command args */
-        CmdArgs->CommandCode = FM_COPY_CC;
+        CmdArgs->CommandCode = FM_COPY_FILE_CC;
         strncpy(CmdArgs->Source1, CmdPtr->Source, OS_MAX_PATH_LEN - 1);
         CmdArgs->Source1[OS_MAX_PATH_LEN - 1] = '\0';
 
@@ -224,7 +224,7 @@ bool FM_MoveFileCmd(const CFE_SB_Buffer_t *BufPtr)
         CmdArgs = &FM_GlobalData.ChildQueue[FM_GlobalData.ChildWriteIndex];
 
         /* Set handshake queue command args */
-        CmdArgs->CommandCode = FM_MOVE_CC;
+        CmdArgs->CommandCode = FM_MOVE_FILE_CC;
 
         strncpy(CmdArgs->Source1, CmdPtr->Source, OS_MAX_PATH_LEN - 1);
         CmdArgs->Source1[OS_MAX_PATH_LEN - 1] = '\0';
@@ -280,7 +280,7 @@ bool FM_RenameFileCmd(const CFE_SB_Buffer_t *BufPtr)
         CmdArgs = &FM_GlobalData.ChildQueue[FM_GlobalData.ChildWriteIndex];
 
         /* Set handshake queue command args */
-        CmdArgs->CommandCode = FM_RENAME_CC;
+        CmdArgs->CommandCode = FM_RENAME_FILE_CC;
 
         strncpy(CmdArgs->Source1, CmdPtr->Source, OS_MAX_PATH_LEN - 1);
         CmdArgs->Source1[OS_MAX_PATH_LEN - 1] = '\0';
@@ -355,10 +355,11 @@ bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr)
     FM_ChildQueueEntry_t *CmdArgs                     = NULL;
     bool                  CommandResult               = false;
 
-    const FM_DirectoryName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_DeleteAllCmd_t);
+    const FM_DirectoryName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_DeleteAllFilesCmd_t);
 
     /* Verify message length */
-    CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DeleteAllCmd_t), FM_DELETE_ALL_PKT_ERR_EID, CmdText);
+    CommandResult =
+        FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DeleteAllFilesCmd_t), FM_DELETE_ALL_PKT_ERR_EID, CmdText);
 
     /* Verify that the directory exists */
     if (CommandResult == true)
@@ -384,7 +385,7 @@ bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr)
         CmdArgs = &FM_GlobalData.ChildQueue[FM_GlobalData.ChildWriteIndex];
 
         /* Set handshake queue command args */
-        CmdArgs->CommandCode = FM_DELETE_ALL_CC;
+        CmdArgs->CommandCode = FM_DELETE_ALL_FILES_CC;
         strncpy(CmdArgs->Source1, CmdPtr->Directory, OS_MAX_PATH_LEN - 1);
         CmdArgs->Source1[OS_MAX_PATH_LEN - 1] = '\0';
 
@@ -410,10 +411,10 @@ bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr)
     FM_ChildQueueEntry_t *CmdArgs       = NULL;
     bool                  CommandResult = false;
 
-    const FM_SourceTargetFileName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_DecompressCmd_t);
+    const FM_SourceTargetFileName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_DecompressFileCmd_t);
 
     /* Verify command packet length */
-    CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DecompressCmd_t), FM_DECOM_PKT_ERR_EID, CmdText);
+    CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DecompressFileCmd_t), FM_DECOM_PKT_ERR_EID, CmdText);
 
     /* Verify that source file exists, is not a directory and is not open */
     if (CommandResult == true)
@@ -439,7 +440,7 @@ bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr)
         CmdArgs = &FM_GlobalData.ChildQueue[FM_GlobalData.ChildWriteIndex];
 
         /* Set handshake queue command args */
-        CmdArgs->CommandCode = FM_DECOMPRESS_CC;
+        CmdArgs->CommandCode = FM_DECOMPRESS_FILE_CC;
         strncpy(CmdArgs->Source1, CmdPtr->Source, OS_MAX_PATH_LEN - 1);
         CmdArgs->Source1[OS_MAX_PATH_LEN - 1] = '\0';
         strncpy(CmdArgs->Target, CmdPtr->Target, OS_MAX_PATH_LEN - 1);
@@ -464,10 +465,10 @@ bool FM_ConcatFilesCmd(const CFE_SB_Buffer_t *BufPtr)
     FM_ChildQueueEntry_t *CmdArgs       = NULL;
     bool                  CommandResult = false;
 
-    const FM_TwoSourceOneTarget_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_ConcatCmd_t);
+    const FM_TwoSourceOneTarget_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_ConcatFilesCmd_t);
 
     /* Verify command packet length */
-    CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_ConcatCmd_t), FM_CONCAT_PKT_ERR_EID, CmdText);
+    CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_ConcatFilesCmd_t), FM_CONCAT_PKT_ERR_EID, CmdText);
 
     /* Verify that source file #1 exists, is not a directory and is not open */
     if (CommandResult == true)
@@ -499,7 +500,7 @@ bool FM_ConcatFilesCmd(const CFE_SB_Buffer_t *BufPtr)
         CmdArgs = &FM_GlobalData.ChildQueue[FM_GlobalData.ChildWriteIndex];
 
         /* Set handshake queue command args */
-        CmdArgs->CommandCode = FM_CONCAT_CC;
+        CmdArgs->CommandCode = FM_CONCAT_FILES_CC;
         strncpy(CmdArgs->Source1, CmdPtr->Source1, OS_MAX_PATH_LEN - 1);
         CmdArgs->Source1[OS_MAX_PATH_LEN - 1] = '\0';
         strncpy(CmdArgs->Source2, CmdPtr->Source2, OS_MAX_PATH_LEN - 1);
@@ -596,8 +597,8 @@ bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr)
     if (CommandResult == true)
     {
         /* Initialize open files telemetry packet */
-        CFE_MSG_Init(&FM_GlobalData.OpenFilesPkt.TlmHeader.Msg, CFE_SB_ValueToMsgId(FM_OPEN_FILES_TLM_MID),
-                     sizeof(FM_OpenFilesPkt_t));
+        CFE_MSG_Init(CFE_MSG_PTR(FM_GlobalData.OpenFilesPkt.TelemetryHeader),
+                     CFE_SB_ValueToMsgId(FM_OPEN_FILES_TLM_MID), sizeof(FM_OpenFilesPkt_t));
 
         /* Get list of open files and count */
         NumOpenFiles = FM_GetOpenFilesData(ReportPtr->OpenFilesList);
@@ -605,8 +606,8 @@ bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr)
         ReportPtr->NumOpenFiles = NumOpenFiles;
 
         /* Timestamp and send open files telemetry packet */
-        CFE_SB_TimeStampMsg(&FM_GlobalData.OpenFilesPkt.TlmHeader.Msg);
-        CFE_SB_TransmitMsg(&FM_GlobalData.OpenFilesPkt.TlmHeader.Msg, true);
+        CFE_SB_TimeStampMsg(CFE_MSG_PTR(FM_GlobalData.OpenFilesPkt.TelemetryHeader));
+        CFE_SB_TransmitMsg(CFE_MSG_PTR(FM_GlobalData.OpenFilesPkt.TelemetryHeader), true);
 
         /* Send command completion event (debug) */
         CFE_EVS_SendEvent(FM_GET_OPEN_FILES_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command", CmdText);
@@ -627,10 +628,11 @@ bool FM_CreateDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
     const char *          CmdText       = "Create Directory";
     bool                  CommandResult = false;
 
-    const FM_DirectoryName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_CreateDirCmd_t);
+    const FM_DirectoryName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_CreateDirectoryCmd_t);
 
     /* Verify command packet length */
-    CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_CreateDirCmd_t), FM_CREATE_DIR_PKT_ERR_EID, CmdText);
+    CommandResult =
+        FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_CreateDirectoryCmd_t), FM_CREATE_DIR_PKT_ERR_EID, CmdText);
 
     /* Verify that the directory name is not already in use */
     if (CommandResult == true)
@@ -651,7 +653,7 @@ bool FM_CreateDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
         CmdArgs = &FM_GlobalData.ChildQueue[FM_GlobalData.ChildWriteIndex];
 
         /* Set handshake queue command args */
-        CmdArgs->CommandCode = FM_CREATE_DIR_CC;
+        CmdArgs->CommandCode = FM_CREATE_DIRECTORY_CC;
         strncpy(CmdArgs->Source1, CmdPtr->Directory, OS_MAX_PATH_LEN - 1);
         CmdArgs->Source1[OS_MAX_PATH_LEN - 1] = '\0';
 
@@ -674,10 +676,11 @@ bool FM_DeleteDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
     const char *          CmdText       = "Delete Directory";
     bool                  CommandResult = false;
 
-    const FM_DirectoryName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_DeleteDirCmd_t);
+    const FM_DirectoryName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_DeleteDirectoryCmd_t);
 
     /* Verify command packet length */
-    CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DeleteDirCmd_t), FM_DELETE_DIR_PKT_ERR_EID, CmdText);
+    CommandResult =
+        FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DeleteDirectoryCmd_t), FM_DELETE_DIR_PKT_ERR_EID, CmdText);
 
     /* Verify that the directory exists */
     if (CommandResult == true)
@@ -698,7 +701,7 @@ bool FM_DeleteDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
         CmdArgs = &FM_GlobalData.ChildQueue[FM_GlobalData.ChildWriteIndex];
 
         /* Set handshake queue command args */
-        CmdArgs->CommandCode = FM_DELETE_DIR_CC;
+        CmdArgs->CommandCode = FM_DELETE_DIRECTORY_CC;
         strncpy(CmdArgs->Source1, CmdPtr->Directory, OS_MAX_PATH_LEN - 1);
         CmdArgs->Source1[OS_MAX_PATH_LEN - 1] = '\0';
 
@@ -723,11 +726,11 @@ bool FM_GetDirListFileCmd(const CFE_SB_Buffer_t *BufPtr)
     FM_ChildQueueEntry_t *CmdArgs                     = NULL;
     bool                  CommandResult               = false;
 
-    const FM_GetDirectoryToFile_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_GetDirFileCmd_t);
+    const FM_GetDirectoryToFile_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_GetDirListFileCmd_t);
 
     /* Verify command packet length */
     CommandResult =
-        FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_GetDirFileCmd_t), FM_GET_DIR_FILE_PKT_ERR_EID, CmdText);
+        FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_GetDirListFileCmd_t), FM_GET_DIR_FILE_PKT_ERR_EID, CmdText);
 
     /* Verify that source directory exists */
     if (CommandResult == true)
@@ -771,7 +774,7 @@ bool FM_GetDirListFileCmd(const CFE_SB_Buffer_t *BufPtr)
         FM_AppendPathSep(DirWithSep, OS_MAX_PATH_LEN);
 
         /* Set handshake queue command args */
-        CmdArgs->CommandCode     = FM_GET_DIR_FILE_CC;
+        CmdArgs->CommandCode     = FM_GET_DIR_LIST_FILE_CC;
         CmdArgs->GetSizeTimeMode = CmdPtr->GetSizeTimeMode;
         strncpy(CmdArgs->Source1, CmdPtr->Directory, OS_MAX_PATH_LEN - 1);
         CmdArgs->Source1[OS_MAX_PATH_LEN - 1] = '\0';
@@ -802,11 +805,11 @@ bool FM_GetDirListPktCmd(const CFE_SB_Buffer_t *BufPtr)
     FM_ChildQueueEntry_t *CmdArgs                     = NULL;
     bool                  CommandResult               = false;
 
-    const FM_GetDirectoryToPkt_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_GetDirPktCmd_t);
+    const FM_GetDirectoryToPkt_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_GetDirListPktCmd_t);
 
     /* Verify command packet length */
     CommandResult =
-        FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_GetDirPktCmd_t), FM_GET_DIR_PKT_PKT_ERR_EID, CmdText);
+        FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_GetDirListPktCmd_t), FM_GET_DIR_PKT_PKT_ERR_EID, CmdText);
 
     /* Verify that source directory exists */
     if (CommandResult == true)
@@ -832,7 +835,7 @@ bool FM_GetDirListPktCmd(const CFE_SB_Buffer_t *BufPtr)
         FM_AppendPathSep(DirWithSep, OS_MAX_PATH_LEN);
 
         /* Set handshake queue command args */
-        CmdArgs->CommandCode     = FM_GET_DIR_PKT_CC;
+        CmdArgs->CommandCode     = FM_GET_DIR_LIST_PKT_CC;
         CmdArgs->GetSizeTimeMode = CmdPtr->GetSizeTimeMode;
         strncpy(CmdArgs->Source1, CmdPtr->Directory, OS_MAX_PATH_LEN - 1);
         CmdArgs->Source1[OS_MAX_PATH_LEN - 1] = '\0';
@@ -880,8 +883,8 @@ bool FM_MonitorFilesystemSpaceCmd(const CFE_SB_Buffer_t *BufPtr)
         else
         {
             /* Initialize the file system free space telemetry packet */
-            CFE_MSG_Init(&FM_GlobalData.MonitorReportPkt.TlmHeader.Msg, CFE_SB_ValueToMsgId(FM_FREE_SPACE_TLM_MID),
-                         sizeof(FM_MonitorReportPkt_t));
+            CFE_MSG_Init(CFE_MSG_PTR(FM_GlobalData.MonitorReportPkt.TelemetryHeader),
+                         CFE_SB_ValueToMsgId(FM_FREE_SPACE_TLM_MID), sizeof(FM_MonitorReportPkt_t));
 
             /* Process enabled file system table entries */
             MonitorPtr = FM_GlobalData.MonitorTablePtr->Entries;
@@ -931,8 +934,8 @@ bool FM_MonitorFilesystemSpaceCmd(const CFE_SB_Buffer_t *BufPtr)
             }
 
             /* Timestamp and send file system free space telemetry packet */
-            CFE_SB_TimeStampMsg(&FM_GlobalData.MonitorReportPkt.TlmHeader.Msg);
-            CFE_SB_TransmitMsg(&FM_GlobalData.MonitorReportPkt.TlmHeader.Msg, true);
+            CFE_SB_TimeStampMsg(CFE_MSG_PTR(FM_GlobalData.MonitorReportPkt.TelemetryHeader));
+            CFE_SB_TransmitMsg(CFE_MSG_PTR(FM_GlobalData.MonitorReportPkt.TelemetryHeader), true);
 
             /* Send command completion event (debug) */
             CFE_EVS_SendEvent(FM_MONITOR_FILESYSTEM_SPACE_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command", CmdText);
@@ -1026,10 +1029,10 @@ bool FM_SetPermissionsCmd(const CFE_SB_Buffer_t *BufPtr)
     bool                  CommandResult = false;
     bool                  FilenameState = FM_NAME_IS_INVALID;
 
-    const FM_FilenameAndMode_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_SetPermCmd_t);
+    const FM_FilenameAndMode_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_SetPermissionsCmd_t);
 
     /* Verify command packet length */
-    CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_SetPermCmd_t), FM_SET_PERM_ERR_EID, CmdText);
+    CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_SetPermissionsCmd_t), FM_SET_PERM_ERR_EID, CmdText);
 
     if (CommandResult == true)
     {
@@ -1052,7 +1055,7 @@ bool FM_SetPermissionsCmd(const CFE_SB_Buffer_t *BufPtr)
     {
         CmdArgs = &FM_GlobalData.ChildQueue[FM_GlobalData.ChildWriteIndex];
         /* Set handshake queue command args */
-        CmdArgs->CommandCode = FM_SET_FILE_PERM_CC;
+        CmdArgs->CommandCode = FM_SET_PERMISSIONS_CC;
         strncpy(CmdArgs->Source1, CmdPtr->FileName, OS_MAX_PATH_LEN - 1);
         CmdArgs->Source1[OS_MAX_PATH_LEN - 1] = '\0';
         CmdArgs->Mode                         = CmdPtr->Mode;

--- a/fsw/src/fm_cmds.h
+++ b/fsw/src/fm_cmds.h
@@ -65,7 +65,7 @@ bool FM_NoopCmd(const CFE_SB_Buffer_t *BufPtr);
  *  \retval true  Command successful
  *  \retval false Command not successful
  *
- *  \sa #FM_RESET_CC, #FM_ResetCmd_t
+ *  \sa #FM_RESET_COUNTERS_CC, #FM_ResetCountersCmd_t
  */
 bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr);
 
@@ -91,7 +91,7 @@ bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr);
  *  \retval true  Command successful
  *  \retval false Command not successful
  *
- *  \sa #FM_COPY_CC, #FM_CopyFileCmd_t
+ *  \sa #FM_COPY_FILE_CC, #FM_CopyFileCmd_t
  */
 bool FM_CopyFileCmd(const CFE_SB_Buffer_t *BufPtr);
 
@@ -110,7 +110,7 @@ bool FM_CopyFileCmd(const CFE_SB_Buffer_t *BufPtr);
  *  \retval true  Command successful
  *  \retval false Command not successful
  *
- *  \sa #FM_MOVE_CC, #FM_MoveFileCmd_t
+ *  \sa #FM_MOVE_FILE_CC, #FM_MoveFileCmd_t
  */
 bool FM_MoveFileCmd(const CFE_SB_Buffer_t *BufPtr);
 
@@ -129,7 +129,7 @@ bool FM_MoveFileCmd(const CFE_SB_Buffer_t *BufPtr);
  *  \retval true  Command successful
  *  \retval false Command not successful
  *
- *  \sa #FM_RENAME_CC, #FM_RenameFileCmd_t
+ *  \sa #FM_RENAME_FILE_CC, #FM_RenameFileCmd_t
  */
 bool FM_RenameFileCmd(const CFE_SB_Buffer_t *BufPtr);
 
@@ -147,7 +147,7 @@ bool FM_RenameFileCmd(const CFE_SB_Buffer_t *BufPtr);
  *  \retval true  Command successful
  *  \retval false Command not successful
  *
- *  \sa #FM_DELETE_CC, #FM_DeleteFileCmd_t
+ *  \sa #FM_DELETE_FILE_CC, #FM_DeleteFileCmd_t
  */
 bool FM_DeleteFileCmd(const CFE_SB_Buffer_t *BufPtr);
 
@@ -173,7 +173,7 @@ bool FM_DeleteFileCmd(const CFE_SB_Buffer_t *BufPtr);
  *  \retval true  Command successful
  *  \retval false Command not successful
  *
- *  \sa #FM_DELETE_ALL_CC, #FM_DeleteAllCmd_t
+ *  \sa #FM_DELETE_ALL_FILES_CC, #FM_DeleteAllFilesCmd_t
  */
 bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr);
 
@@ -200,7 +200,7 @@ bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr);
  *  \retval true  Command successful
  *  \retval false Command not successful
  *
- *  \sa #FM_DECOMPRESS_CC, #FM_DecompressCmd_t
+ *  \sa #FM_DECOMPRESS_FILE_CC, #FM_DecompressFileCmd_t
  */
 bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr);
 
@@ -228,7 +228,7 @@ bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr);
  *  \retval true  Command successful
  *  \retval false Command not successful
  *
- *  \sa #FM_CONCAT_CC, #FM_ConcatCmd_t
+ *  \sa #FM_CONCAT_FILES_CC, #FM_ConcatFilesCmd_t
  */
 bool FM_ConcatFilesCmd(const CFE_SB_Buffer_t *BufPtr);
 
@@ -292,7 +292,7 @@ bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr);
  *  \retval true  Command successful
  *  \retval false Command not successful
  *
- *  \sa #FM_CREATE_DIR_CC, #FM_CreateDirCmd_t
+ *  \sa #FM_CREATE_DIRECTORY_CC, #FM_CreateDirectoryCmd_t
  */
 bool FM_CreateDirectoryCmd(const CFE_SB_Buffer_t *BufPtr);
 
@@ -310,7 +310,7 @@ bool FM_CreateDirectoryCmd(const CFE_SB_Buffer_t *BufPtr);
  *  \retval true  Command successful
  *  \retval false Command not successful
  *
- *  \sa #FM_DELETE_DIR_CC, #FM_DeleteDirCmd_t
+ *  \sa #FM_DELETE_DIRECTORY_CC, #FM_DeleteDirectoryCmd_t
  */
 bool FM_DeleteDirectoryCmd(const CFE_SB_Buffer_t *BufPtr);
 
@@ -336,7 +336,7 @@ bool FM_DeleteDirectoryCmd(const CFE_SB_Buffer_t *BufPtr);
  *  \retval true  Command successful
  *  \retval false Command not successful
  *
- *  \sa #FM_GET_DIR_FILE_CC, #FM_GetDirFileCmd_t,
+ *  \sa #FM_GET_DIR_LIST_FILE_CC, #FM_GetDirListFileCmd_t,
  *      #FM_DirListFileStats_t, FM_DirListEntry_t
  */
 bool FM_GetDirListFileCmd(const CFE_SB_Buffer_t *BufPtr);
@@ -364,7 +364,7 @@ bool FM_GetDirListFileCmd(const CFE_SB_Buffer_t *BufPtr);
  *  \retval true  Command successful
  *  \retval false Command not successful
  *
- *  \sa #FM_GET_DIR_PKT_CC, #FM_GetDirPktCmd_t, #FM_DirListPkt_t
+ *  \sa #FM_GET_DIR_LIST_PKT_CC, #FM_GetDirListPktCmd_t, #FM_DirListPkt_t
  */
 bool FM_GetDirListPktCmd(const CFE_SB_Buffer_t *BufPtr);
 
@@ -421,7 +421,7 @@ bool FM_SetTableStateCmd(const CFE_SB_Buffer_t *BufPtr);
  *  \retval true  Command successful
  *  \retval false Command not successful
  *
- *  \sa #FM_SET_FILE_PERM_CC, #FM_SetPermCmd_t, #FM_SET_PERM_CMD_EID, #FM_SET_PERM_ERR_EID
+ *  \sa #FM_SET_PERMISSIONS_CC, #FM_SetPermissionsCmd_t, #FM_SET_PERM_CMD_EID, #FM_SET_PERM_ERR_EID
  */
 bool FM_SetPermissionsCmd(const CFE_SB_Buffer_t *BufPtr);
 

--- a/unit-test/fm_app_tests.c
+++ b/unit-test/fm_app_tests.c
@@ -347,7 +347,7 @@ void Test_FM_AppInit_TableInitSuccess(void)
 /* ********************************
  * Report HK Tests
  * *******************************/
-void Test_FM_ReportHK_ReturnPktLengthTrue(void)
+void Test_FM_SendHkCmd_ReturnPktLengthTrue(void)
 {
     FM_HousekeepingPkt_Payload_t *ReportPtr;
 
@@ -366,7 +366,7 @@ void Test_FM_ReportHK_ReturnPktLengthTrue(void)
     FM_GlobalData.ChildPreviousCC     = 8;
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ReportHK(NULL));
+    UtAssert_VOIDCALL(FM_SendHkCmd(NULL));
 
     /* Assert */
     UtAssert_STUB_COUNT(FM_IsValidCmdPktLength, 1);
@@ -389,13 +389,13 @@ void Test_FM_ReportHK_ReturnPktLengthTrue(void)
     UtAssert_INT32_EQ(ReportPtr->ChildPreviousCC, FM_GlobalData.ChildPreviousCC);
 }
 
-void Test_FM_ReportHK_ReturnPktLengthFalse(void)
+void Test_FM_SendHkCmd_ReturnPktLengthFalse(void)
 {
     /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ReportHK(NULL));
+    UtAssert_VOIDCALL(FM_SendHkCmd(NULL));
 
     /* Assert */
     UtAssert_STUB_COUNT(FM_ReleaseTablePointers, 0);
@@ -426,7 +426,7 @@ void Test_FM_ProcessCmd_NoopCmdCCReturn(void)
 void Test_FM_ProcessCmd_ResetCountersCCReturn(void)
 {
     /* Arrange */
-    CFE_MSG_FcnCode_t fcn_code = FM_RESET_CC;
+    CFE_MSG_FcnCode_t fcn_code = FM_RESET_COUNTERS_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_ResetCountersCmd), true);
@@ -444,7 +444,7 @@ void Test_FM_ProcessCmd_ResetCountersCCReturn(void)
 void Test_FM_ProcessCmd_CopyFileCCReturn(void)
 {
     /* Arrange */
-    CFE_MSG_FcnCode_t fcn_code = FM_COPY_CC;
+    CFE_MSG_FcnCode_t fcn_code = FM_COPY_FILE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_CopyFileCmd), true);
@@ -462,7 +462,7 @@ void Test_FM_ProcessCmd_CopyFileCCReturn(void)
 void Test_FM_ProcessCmd_MoveFileCCReturn(void)
 {
     /* Arrange */
-    CFE_MSG_FcnCode_t fcn_code = FM_MOVE_CC;
+    CFE_MSG_FcnCode_t fcn_code = FM_MOVE_FILE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_MoveFileCmd), true);
@@ -480,7 +480,7 @@ void Test_FM_ProcessCmd_MoveFileCCReturn(void)
 void Test_FM_ProcessCmd_RenameFileCCReturn(void)
 {
     /* Arrange */
-    CFE_MSG_FcnCode_t fcn_code = FM_RENAME_CC;
+    CFE_MSG_FcnCode_t fcn_code = FM_RENAME_FILE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_RenameFileCmd), true);
@@ -498,7 +498,7 @@ void Test_FM_ProcessCmd_RenameFileCCReturn(void)
 void Test_FM_ProcessCmd_DeleteFileCCReturn(void)
 {
     /* Arrange */
-    CFE_MSG_FcnCode_t fcn_code = FM_DELETE_CC;
+    CFE_MSG_FcnCode_t fcn_code = FM_DELETE_FILE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_DeleteFileCmd), true);
@@ -516,7 +516,7 @@ void Test_FM_ProcessCmd_DeleteFileCCReturn(void)
 void Test_FM_ProcessCmd_DeleteAllFilesCCReturn(void)
 {
     /* Arrange */
-    CFE_MSG_FcnCode_t fcn_code = FM_DELETE_ALL_CC;
+    CFE_MSG_FcnCode_t fcn_code = FM_DELETE_ALL_FILES_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_DeleteAllFilesCmd), true);
@@ -534,7 +534,7 @@ void Test_FM_ProcessCmd_DeleteAllFilesCCReturn(void)
 void Test_FM_ProcessCmd_DecompressFileCCReturn(void)
 {
     /* Arrange */
-    CFE_MSG_FcnCode_t fcn_code = FM_DECOMPRESS_CC;
+    CFE_MSG_FcnCode_t fcn_code = FM_DECOMPRESS_FILE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_DecompressFileCmd), true);
@@ -552,7 +552,7 @@ void Test_FM_ProcessCmd_DecompressFileCCReturn(void)
 void Test_FM_ProcessCmd_ConcatFilesCCReturn(void)
 {
     /* Arrange */
-    CFE_MSG_FcnCode_t fcn_code = FM_CONCAT_CC;
+    CFE_MSG_FcnCode_t fcn_code = FM_CONCAT_FILES_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_ConcatFilesCmd), true);
@@ -606,7 +606,7 @@ void Test_FM_ProcessCmd_GetOpenFilesCCReturn(void)
 void Test_FM_ProcessCmd_CreateDirectoryCCReturn(void)
 {
     /* Arrange */
-    CFE_MSG_FcnCode_t fcn_code = FM_CREATE_DIR_CC;
+    CFE_MSG_FcnCode_t fcn_code = FM_CREATE_DIRECTORY_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_CreateDirectoryCmd), true);
@@ -624,7 +624,7 @@ void Test_FM_ProcessCmd_CreateDirectoryCCReturn(void)
 void Test_FM_ProcessCmd_DeleteDirectoryCCReturn(void)
 {
     /* Arrange */
-    CFE_MSG_FcnCode_t fcn_code = FM_DELETE_DIR_CC;
+    CFE_MSG_FcnCode_t fcn_code = FM_DELETE_DIRECTORY_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_DeleteDirectoryCmd), true);
@@ -642,7 +642,7 @@ void Test_FM_ProcessCmd_DeleteDirectoryCCReturn(void)
 void Test_FM_ProcessCmd_GetDirListFileCCReturn(void)
 {
     /* Arrange */
-    CFE_MSG_FcnCode_t fcn_code = FM_GET_DIR_FILE_CC;
+    CFE_MSG_FcnCode_t fcn_code = FM_GET_DIR_LIST_FILE_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_GetDirListFileCmd), true);
@@ -660,7 +660,7 @@ void Test_FM_ProcessCmd_GetDirListFileCCReturn(void)
 void Test_FM_ProcessCmd_GetDirListPktCCReturn(void)
 {
     /* Arrange */
-    CFE_MSG_FcnCode_t fcn_code = FM_GET_DIR_PKT_CC;
+    CFE_MSG_FcnCode_t fcn_code = FM_GET_DIR_LIST_PKT_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_GetDirListPktCmd), true);
@@ -714,7 +714,7 @@ void Test_FM_ProcessCmd_SetTableStateCCReturn(void)
 void Test_FM_ProcessCmd_SetPermissionsCCReturn(void)
 {
     /* Arrange */
-    CFE_MSG_FcnCode_t fcn_code = FM_SET_FILE_PERM_CC;
+    CFE_MSG_FcnCode_t fcn_code = FM_SET_PERMISSIONS_CC;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_SetPermissionsCmd), true);
@@ -859,11 +859,11 @@ void add_FM_ProcessCmd_tests(void)
     UtTest_Add(Test_FM_ProcessCmd_DefaultReturn, FM_Test_Setup, FM_Test_Teardown, "Test_FM_PRocessCmd_DefaultReturn");
 }
 
-void add_FM_ReportHK_tests(void)
+void add_FM_SendHkCmd_tests(void)
 {
-    UtTest_Add(Test_FM_ReportHK_ReturnPktLengthTrue, FM_Test_Setup, FM_Test_Teardown, "Test_FM_ReportHK_Return");
-    UtTest_Add(Test_FM_ReportHK_ReturnPktLengthFalse, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ReportHK_ReturnPktLengthFalse");
+    UtTest_Add(Test_FM_SendHkCmd_ReturnPktLengthTrue, FM_Test_Setup, FM_Test_Teardown, "Test_FM_SendHkCmd_Return");
+    UtTest_Add(Test_FM_SendHkCmd_ReturnPktLengthFalse, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_SendHkCmd_ReturnPktLengthFalse");
 }
 
 /*
@@ -874,6 +874,6 @@ void UtTest_Setup(void)
     add_FM_ProcessPkt_tests();
     add_FM_AppInit_tests();
     add_FM_AppMain_tests();
-    add_FM_ReportHK_tests();
+    add_FM_SendHkCmd_tests();
     add_FM_ProcessCmd_tests();
 }

--- a/unit-test/fm_child_tests.c
+++ b/unit-test/fm_child_tests.c
@@ -162,7 +162,7 @@ void Test_FM_ChildProcess_ChildReadIndexGreaterChildQDepth(void)
 void Test_FM_ChildProcess_FMCopyCC(void)
 {
     /* Arrange */
-    FM_GlobalData.ChildQueue[0].CommandCode = FM_COPY_CC;
+    FM_GlobalData.ChildQueue[0].CommandCode = FM_COPY_FILE_CC;
 
     /* Act */
     UtAssert_VOIDCALL(FM_ChildProcess());
@@ -179,7 +179,7 @@ void Test_FM_ChildProcess_FMCopyCC(void)
 void Test_FM_ChildProcess_FMMoveCC(void)
 {
     /* Arrange */
-    FM_GlobalData.ChildQueue[0].CommandCode = FM_MOVE_CC;
+    FM_GlobalData.ChildQueue[0].CommandCode = FM_MOVE_FILE_CC;
 
     /* Act */
     UtAssert_VOIDCALL(FM_ChildProcess());
@@ -196,7 +196,7 @@ void Test_FM_ChildProcess_FMMoveCC(void)
 void Test_FM_ChildProcess_FMRenameCC(void)
 {
     /* Arrange */
-    FM_GlobalData.ChildQueue[0].CommandCode = FM_RENAME_CC;
+    FM_GlobalData.ChildQueue[0].CommandCode = FM_RENAME_FILE_CC;
 
     /* Act */
     UtAssert_VOIDCALL(FM_ChildProcess());
@@ -213,7 +213,7 @@ void Test_FM_ChildProcess_FMRenameCC(void)
 void Test_FM_ChildProcess_FMDeleteCC(void)
 {
     /* Arrange */
-    FM_GlobalData.ChildQueue[0].CommandCode = FM_DELETE_CC;
+    FM_GlobalData.ChildQueue[0].CommandCode = FM_DELETE_FILE_CC;
 
     /* Act */
     UtAssert_VOIDCALL(FM_ChildProcess());
@@ -230,7 +230,7 @@ void Test_FM_ChildProcess_FMDeleteCC(void)
 void Test_FM_ChildProcess_FMDeleteAllCC(void)
 {
     /* Arrange */
-    FM_GlobalData.ChildQueue[0].CommandCode = FM_DELETE_ALL_CC;
+    FM_GlobalData.ChildQueue[0].CommandCode = FM_DELETE_ALL_FILES_CC;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryOpen), !OS_SUCCESS);
 
@@ -250,7 +250,7 @@ void Test_FM_ChildProcess_FMDeleteAllCC(void)
 void Test_FM_ChildProcess_FMDecompressCC(void)
 {
     /* Arrange */
-    FM_GlobalData.ChildQueue[0].CommandCode = FM_DECOMPRESS_CC;
+    FM_GlobalData.ChildQueue[0].CommandCode = FM_DECOMPRESS_FILE_CC;
 
     UT_SetDefaultReturnValue(UT_KEY(FM_Decompress_Impl), !CFE_SUCCESS);
 
@@ -269,7 +269,7 @@ void Test_FM_ChildProcess_FMDecompressCC(void)
 void Test_FM_ChildProcess_FMConcatCC(void)
 {
     /* Arrange */
-    FM_GlobalData.ChildQueue[0].CommandCode = FM_CONCAT_CC;
+    FM_GlobalData.ChildQueue[0].CommandCode = FM_CONCAT_FILES_CC;
     FM_GlobalData.ChildCurrentCC            = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_cp), !OS_SUCCESS);
@@ -289,7 +289,7 @@ void Test_FM_ChildProcess_FMConcatCC(void)
 void Test_FM_ChildProcess_FMCreateDirCC(void)
 {
     /* Arrange */
-    FM_GlobalData.ChildQueue[0].CommandCode = FM_CREATE_DIR_CC;
+    FM_GlobalData.ChildQueue[0].CommandCode = FM_CREATE_DIRECTORY_CC;
     FM_GlobalData.ChildCurrentCC            = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_mkdir), !OS_SUCCESS);
@@ -309,7 +309,7 @@ void Test_FM_ChildProcess_FMCreateDirCC(void)
 void Test_FM_ChildProcess_FMDeleteDirCC(void)
 {
     /* Arrange */
-    FM_GlobalData.ChildQueue[0].CommandCode = FM_DELETE_DIR_CC;
+    FM_GlobalData.ChildQueue[0].CommandCode = FM_DELETE_DIRECTORY_CC;
     FM_GlobalData.ChildCurrentCC            = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryOpen), !OS_SUCCESS);
@@ -354,7 +354,7 @@ void Test_FM_ChildProcess_FMGetFileInfoCC(void)
 void Test_FM_ChildProcess_FMGetDirListsFileCC(void)
 {
     /* Arrange */
-    FM_GlobalData.ChildQueue[0].CommandCode = FM_GET_DIR_FILE_CC;
+    FM_GlobalData.ChildQueue[0].CommandCode = FM_GET_DIR_LIST_FILE_CC;
     FM_GlobalData.ChildCurrentCC            = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryOpen), !OS_SUCCESS);
@@ -374,7 +374,7 @@ void Test_FM_ChildProcess_FMGetDirListsFileCC(void)
 void Test_FM_ChildProcess_FMGetDirListsPktCC(void)
 {
     /* Arrange */
-    FM_GlobalData.ChildQueue[0].CommandCode = FM_GET_DIR_PKT_CC;
+    FM_GlobalData.ChildQueue[0].CommandCode = FM_GET_DIR_LIST_PKT_CC;
     FM_GlobalData.ChildCurrentCC            = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryRead), !OS_SUCCESS);
@@ -397,7 +397,7 @@ void Test_FM_ChildProcess_FMGetDirListsPktCC(void)
 void Test_FM_ChildProcess_FMSetFilePermCC(void)
 {
     /* Arrange */
-    FM_GlobalData.ChildQueue[0].CommandCode = FM_SET_FILE_PERM_CC;
+    FM_GlobalData.ChildQueue[0].CommandCode = FM_SET_PERMISSIONS_CC;
     FM_GlobalData.ChildCurrentCC            = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_chmod), !OS_SUCCESS);
@@ -435,7 +435,7 @@ void Test_FM_ChildProcess_DefaultSwitch(void)
  * ***************/
 void Test_FM_ChildCopyCmd_OScpIsSuccess(void)
 {
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_COPY_CC};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_COPY_FILE_CC};
 
     /* Act */
     UtAssert_VOIDCALL(FM_ChildCopyCmd(&queue_entry));
@@ -450,7 +450,7 @@ void Test_FM_ChildCopyCmd_OScpIsSuccess(void)
 
 void Test_FM_ChildCopyCmd_OScpNotSuccess(void)
 {
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_COPY_CC};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_COPY_FILE_CC};
 
     /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(OS_cp), !OS_SUCCESS);
@@ -471,7 +471,7 @@ void Test_FM_ChildCopyCmd_OScpNotSuccess(void)
  * ***************/
 void Test_FM_ChildMoveCmd_OSmvNotSuccess(void)
 {
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_MOVE_CC};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_MOVE_FILE_CC};
 
     /* Arrange */
     UT_SetDefaultReturnValue(UT_KEY(OS_mv), !OS_SUCCESS);
@@ -490,7 +490,7 @@ void Test_FM_ChildMoveCmd_OSmvNotSuccess(void)
 
 void Test_FM_ChildMoveCmd_OSmvSuccess(void)
 {
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_MOVE_CC};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_MOVE_FILE_CC};
 
     /* Act */
     UtAssert_VOIDCALL(FM_ChildMoveCmd(&queue_entry));
@@ -510,7 +510,7 @@ void Test_FM_ChildMoveCmd_OSmvSuccess(void)
 void Test_FM_ChildRenameCmd_OSRenameSuccess(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_RENAME_CC};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_RENAME_FILE_CC};
 
     /* Act */
     UtAssert_VOIDCALL(FM_ChildRenameCmd(&queue_entry));
@@ -527,7 +527,7 @@ void Test_FM_ChildRenameCmd_OSRenameSuccess(void)
 void Test_FM_ChildRenameCmd_OSRenameNotSuccess(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_RENAME_CC};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_RENAME_FILE_CC};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_rename), !OS_SUCCESS);
 
@@ -549,7 +549,7 @@ void Test_FM_ChildRenameCmd_OSRenameNotSuccess(void)
 void Test_FM_ChildDeleteCmd_OSRemoveSuccess(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_CC};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_FILE_CC};
 
     /* Act */
     UtAssert_VOIDCALL(FM_ChildDeleteCmd(&queue_entry));
@@ -566,7 +566,7 @@ void Test_FM_ChildDeleteCmd_OSRemoveSuccess(void)
 void Test_FM_ChildDeleteCmd_OSRemoveNotSuccess(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_CC};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_FILE_CC};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_remove), !OS_SUCCESS);
 
@@ -583,18 +583,18 @@ void Test_FM_ChildDeleteCmd_OSRemoveNotSuccess(void)
 }
 
 /* ****************
- * ChildDeleteAllCmd Tests
+ * ChildDeleteAllFilesCmd Tests
  * ***************/
-void Test_FM_ChildDeleteAllCmd_DirOpenNotSuccess(void)
+void Test_FM_ChildDeleteAllFilesCmd_DirOpenNotSuccess(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryOpen), !OS_SUCCESS);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildDeleteAllFilesCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
@@ -606,16 +606,16 @@ void Test_FM_ChildDeleteAllCmd_DirOpenNotSuccess(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_OS_ERR_EID);
 }
 
-void Test_FM_ChildDeleteAllCmd_DirReadNotSuccess(void)
+void Test_FM_ChildDeleteAllFilesCmd_DirReadNotSuccess(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryRead), !OS_SUCCESS);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildDeleteAllFilesCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
@@ -627,18 +627,18 @@ void Test_FM_ChildDeleteAllCmd_DirReadNotSuccess(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_EID);
 }
 
-void Test_FM_ChildDeleteAllCmd_DirEntryThisDirectory(void)
+void Test_FM_ChildDeleteAllFilesCmd_DirEntryThisDirectory(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = FM_THIS_DIRECTORY};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildDeleteAllFilesCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
@@ -652,18 +652,18 @@ void Test_FM_ChildDeleteAllCmd_DirEntryThisDirectory(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_EID);
 }
 
-void Test_FM_ChildDeleteAllCmd_DirEntryParentDirectory(void)
+void Test_FM_ChildDeleteAllFilesCmd_DirEntryParentDirectory(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = FM_PARENT_DIRECTORY};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildDeleteAllFilesCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
@@ -677,10 +677,10 @@ void Test_FM_ChildDeleteAllCmd_DirEntryParentDirectory(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_EID);
 }
 
-void Test_FM_ChildDeleteAllCmd_PathFilenameLengthGreaterMaxPthLen(void)
+void Test_FM_ChildDeleteAllFilesCmd_PathFilenameLengthGreaterMaxPthLen(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_ALL_CC,
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_ALL_FILES_CC,
                                         .Source1     = "dummy_source1",
                                         .Source2     = "dummy_source2HasAReallyLongNameSomeSayTheNameIs42Characters"};
     os_dirent_t          direntry    = {.FileName = "ThisDirectory"};
@@ -689,7 +689,7 @@ void Test_FM_ChildDeleteAllCmd_PathFilenameLengthGreaterMaxPthLen(void)
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildDeleteAllFilesCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, queue_entry.CommandCode);
@@ -705,11 +705,11 @@ void Test_FM_ChildDeleteAllCmd_PathFilenameLengthGreaterMaxPthLen(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_DELETE_ALL_FILES_ND_WARNING_EID);
 }
 
-void Test_FM_ChildDeleteAllCmd_InvalidFilenameState(void)
+void Test_FM_ChildDeleteAllFilesCmd_InvalidFilenameState(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = "ThisDirectory"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
@@ -717,7 +717,7 @@ void Test_FM_ChildDeleteAllCmd_InvalidFilenameState(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_GetFilenameState), FM_NAME_IS_INVALID);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildDeleteAllFilesCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, queue_entry.CommandCode);
@@ -733,11 +733,11 @@ void Test_FM_ChildDeleteAllCmd_InvalidFilenameState(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_DELETE_ALL_FILES_ND_WARNING_EID);
 }
 
-void Test_FM_ChildDeleteAllCmd_NotInUseFilenameState(void)
+void Test_FM_ChildDeleteAllFilesCmd_NotInUseFilenameState(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = "ThisDirectory"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
@@ -745,7 +745,7 @@ void Test_FM_ChildDeleteAllCmd_NotInUseFilenameState(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_GetFilenameState), FM_NAME_IS_NOT_IN_USE);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildDeleteAllFilesCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, queue_entry.CommandCode);
@@ -761,11 +761,11 @@ void Test_FM_ChildDeleteAllCmd_NotInUseFilenameState(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_DELETE_ALL_FILES_ND_WARNING_EID);
 }
 
-void Test_FM_ChildDeleteAllCmd_DirectoryFilenameState(void)
+void Test_FM_ChildDeleteAllFilesCmd_DirectoryFilenameState(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = "ThisDirectory"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
@@ -773,7 +773,7 @@ void Test_FM_ChildDeleteAllCmd_DirectoryFilenameState(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_GetFilenameState), FM_NAME_IS_DIRECTORY);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildDeleteAllFilesCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, queue_entry.CommandCode);
@@ -789,11 +789,11 @@ void Test_FM_ChildDeleteAllCmd_DirectoryFilenameState(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_DELETE_ALL_SKIP_WARNING_EID);
 }
 
-void Test_FM_ChildDeleteAllCmd_OpenFilenameState(void)
+void Test_FM_ChildDeleteAllFilesCmd_OpenFilenameState(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = "ThisDirectory"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
@@ -801,7 +801,7 @@ void Test_FM_ChildDeleteAllCmd_OpenFilenameState(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_GetFilenameState), FM_NAME_IS_FILE_OPEN);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildDeleteAllFilesCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, queue_entry.CommandCode);
@@ -817,11 +817,11 @@ void Test_FM_ChildDeleteAllCmd_OpenFilenameState(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_DELETE_ALL_FILES_ND_WARNING_EID);
 }
 
-void Test_FM_ChildDeleteAllCmd_ClosedFilename_OSRmNotSuccess(void)
+void Test_FM_ChildDeleteAllFilesCmd_ClosedFilename_OSRmNotSuccess(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = "ThisDirectory"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
@@ -830,7 +830,7 @@ void Test_FM_ChildDeleteAllCmd_ClosedFilename_OSRmNotSuccess(void)
     UT_SetDefaultReturnValue(UT_KEY(OS_remove), !OS_SUCCESS);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildDeleteAllFilesCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, queue_entry.CommandCode);
@@ -847,11 +847,11 @@ void Test_FM_ChildDeleteAllCmd_ClosedFilename_OSRmNotSuccess(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_DELETE_ALL_FILES_ND_WARNING_EID);
 }
 
-void Test_FM_ChildDeleteAllCmd_ClosedFilename_OSrmSuccess(void)
+void Test_FM_ChildDeleteAllFilesCmd_ClosedFilename_OSrmSuccess(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = "ThisDirectory"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
@@ -859,7 +859,7 @@ void Test_FM_ChildDeleteAllCmd_ClosedFilename_OSrmSuccess(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_GetFilenameState), FM_NAME_IS_FILE_CLOSED);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildDeleteAllFilesCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
@@ -875,11 +875,11 @@ void Test_FM_ChildDeleteAllCmd_ClosedFilename_OSrmSuccess(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_EID);
 }
 
-void Test_FM_ChildDeleteAllCmd_FilenameStateDefaultReturn(void)
+void Test_FM_ChildDeleteAllFilesCmd_FilenameStateDefaultReturn(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = "ThisDirectory"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
@@ -887,7 +887,7 @@ void Test_FM_ChildDeleteAllCmd_FilenameStateDefaultReturn(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_GetFilenameState), -1); /* default case */
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildDeleteAllCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildDeleteAllFilesCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 1, queue_entry.CommandCode);
@@ -904,18 +904,18 @@ void Test_FM_ChildDeleteAllCmd_FilenameStateDefaultReturn(void)
 }
 
 /* ****************
- * ChildDecompressCmd Tests
+ * ChildDecompressFileCmd Tests
  * ***************/
 
-void Test_FM_ChildDecompressCmd_FSDecompressSuccess(void)
+void Test_FM_ChildDecompressFileCmd_FSDecompressSuccess(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DECOMPRESS_CC};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DECOMPRESS_FILE_CC};
 
     FM_GlobalData.ChildCurrentCC = 1;
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildDecompressCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildDecompressFileCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
@@ -926,16 +926,16 @@ void Test_FM_ChildDecompressCmd_FSDecompressSuccess(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DECOM_CMD_EID);
 }
 
-void Test_FM_ChildDecompressCmd_FSDecompressNotSuccess(void)
+void Test_FM_ChildDecompressFileCmd_FSDecompressNotSuccess(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DECOMPRESS_CC};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DECOMPRESS_FILE_CC};
 
     FM_GlobalData.ChildCurrentCC = 1;
     UT_SetDefaultReturnValue(UT_KEY(FM_Decompress_Impl), !CFE_SUCCESS);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildDecompressCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildDecompressFileCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
@@ -947,19 +947,19 @@ void Test_FM_ChildDecompressCmd_FSDecompressNotSuccess(void)
 }
 
 /* ****************
- * ChildConcatCmd Tests
+ * ChildConcatFilesCmd Tests
  * ***************/
-void Test_FM_ChildConcatCmd_OSCpNotSuccess(void)
+void Test_FM_ChildConcatFilesCmd_OSCpNotSuccess(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_CONCAT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_CONCAT_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
     FM_GlobalData.ChildCurrentCC = 1;
     UT_SetDefaultReturnValue(UT_KEY(OS_cp), !OS_SUCCESS);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildConcatCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildConcatFilesCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
@@ -970,16 +970,16 @@ void Test_FM_ChildConcatCmd_OSCpNotSuccess(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CONCAT_OSCPY_ERR_EID);
 }
 
-void Test_FM_ChildConcatCmd_OSOpenCreateSourceNotSuccess(void)
+void Test_FM_ChildConcatFilesCmd_OSOpenCreateSourceNotSuccess(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_CONCAT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_CONCAT_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), !OS_SUCCESS);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildConcatCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildConcatFilesCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
@@ -992,16 +992,16 @@ void Test_FM_ChildConcatCmd_OSOpenCreateSourceNotSuccess(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CONCAT_OPEN_SRC2_ERR_EID);
 }
 
-void Test_FM_ChildConcatCmd_OSOpenCreateTargetNotSuccess(void)
+void Test_FM_ChildConcatFilesCmd_OSOpenCreateTargetNotSuccess(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_CONCAT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_CONCAT_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_OpenCreate), 2, !OS_SUCCESS);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildConcatCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildConcatFilesCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
@@ -1015,16 +1015,16 @@ void Test_FM_ChildConcatCmd_OSOpenCreateTargetNotSuccess(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CONCAT_OPEN_TGT_ERR_EID);
 }
 
-void Test_FM_ChildConcatCmd_OSReadBytesZero(void)
+void Test_FM_ChildConcatFilesCmd_OSReadBytesZero(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_CONCAT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_CONCAT_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_read), 0);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildConcatCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildConcatFilesCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
@@ -1039,16 +1039,16 @@ void Test_FM_ChildConcatCmd_OSReadBytesZero(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CONCAT_CMD_EID);
 }
 
-void Test_FM_ChildConcatCmd_OSReadBytesLessThanZero(void)
+void Test_FM_ChildConcatFilesCmd_OSReadBytesLessThanZero(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_CONCAT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_CONCAT_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_read), -1);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildConcatCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildConcatFilesCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
@@ -1063,17 +1063,17 @@ void Test_FM_ChildConcatCmd_OSReadBytesLessThanZero(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CONCAT_OSRD_ERR_EID);
 }
 
-void Test_FM_ChildConcatCmd_BytesWrittenNotEqualBytesRead(void)
+void Test_FM_ChildConcatFilesCmd_BytesWrittenNotEqualBytesRead(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_CONCAT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_CONCAT_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_read), 1);
     UT_SetDefaultReturnValue(UT_KEY(OS_write), 0);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildConcatCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildConcatFilesCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
@@ -1088,18 +1088,18 @@ void Test_FM_ChildConcatCmd_BytesWrittenNotEqualBytesRead(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CONCAT_OSWR_ERR_EID);
 }
 
-void Test_FM_ChildConcatCmd_CopyInProgressTrueLoopCountEqualChildFileLoopCount(void)
+void Test_FM_ChildConcatFilesCmd_CopyInProgressTrueLoopCountEqualChildFileLoopCount(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_CONCAT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_CONCAT_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_read), 1);
     UT_SetDefaultReturnValue(UT_KEY(OS_write), 1);
     UT_SetDeferredRetcode(UT_KEY(OS_read), FM_CHILD_FILE_LOOP_COUNT + 1, -1);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildConcatCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildConcatFilesCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
@@ -1341,15 +1341,15 @@ void Test_FM_ChildFileInfoCmd_BytesReadGreaterThanZero(void)
 }
 
 /* ****************
- * ChildCreateDirCmd Tests
+ * ChildCreateDirectoryCmd Tests
  * ***************/
-void Test_FM_ChildCreateDirCmd_OSMkDirSuccess(void)
+void Test_FM_ChildCreateDirectoryCmd_OSMkDirSuccess(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_CREATE_DIR_CC};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_CREATE_DIRECTORY_CC};
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildCreateDirCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildCreateDirectoryCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
@@ -1360,15 +1360,15 @@ void Test_FM_ChildCreateDirCmd_OSMkDirSuccess(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CREATE_DIR_CMD_EID);
 }
 
-void Test_FM_ChildCreateDirCmd_OSMkDirNotSuccess(void)
+void Test_FM_ChildCreateDirectoryCmd_OSMkDirNotSuccess(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_CREATE_DIR_CC};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_CREATE_DIRECTORY_CC};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_mkdir), !CFE_SUCCESS);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildCreateDirCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildCreateDirectoryCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
@@ -1380,17 +1380,17 @@ void Test_FM_ChildCreateDirCmd_OSMkDirNotSuccess(void)
 }
 
 /* ****************
- * ChildDeleteDirCmd Tests
+ * ChildDeleteDirectoryCmd Tests
  * ***************/
-void Test_FM_ChildDeleteDirCmd_OSDirectoryOpenNoSuccess(void)
+void Test_FM_ChildDeleteDirectoryCmd_OSDirectoryOpenNoSuccess(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_DIR_CC};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_DIRECTORY_CC};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryOpen), !OS_SUCCESS);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildDeleteDirCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildDeleteDirectoryCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
@@ -1401,15 +1401,15 @@ void Test_FM_ChildDeleteDirCmd_OSDirectoryOpenNoSuccess(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_OPENDIR_OS_ERR_EID);
 }
 
-void Test_FM_ChildDeleteDirCmd_OSDirectoryReadNoSuccess(void)
+void Test_FM_ChildDeleteDirectoryCmd_OSDirectoryReadNoSuccess(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_DIR_CC};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_DIRECTORY_CC};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryRead), !OS_SUCCESS);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildDeleteDirCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildDeleteDirectoryCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
@@ -1422,17 +1422,17 @@ void Test_FM_ChildDeleteDirCmd_OSDirectoryReadNoSuccess(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_DIR_CMD_EID);
 }
 
-void Test_FM_ChildDeleteDirCmd_StrCmpThisDirectoryZero(void)
+void Test_FM_ChildDeleteDirectoryCmd_StrCmpThisDirectoryZero(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_DIR_CC};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_DIRECTORY_CC};
     os_dirent_t          direntry    = {.FileName = FM_THIS_DIRECTORY};
 
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildDeleteDirCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildDeleteDirectoryCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
@@ -1444,16 +1444,16 @@ void Test_FM_ChildDeleteDirCmd_StrCmpThisDirectoryZero(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_DIR_CMD_EID);
 }
 
-void Test_FM_ChildDeleteDirCmd_StrCmpParentDirectoryZero(void)
+void Test_FM_ChildDeleteDirectoryCmd_StrCmpParentDirectoryZero(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_DIR_CC};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_DIRECTORY_CC};
     os_dirent_t          direntry    = {.FileName = FM_PARENT_DIRECTORY};
 
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildDeleteDirCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildDeleteDirectoryCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
@@ -1465,15 +1465,15 @@ void Test_FM_ChildDeleteDirCmd_StrCmpParentDirectoryZero(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_DIR_EMPTY_ERR_EID);
 }
 
-void Test_FM_ChildDeleteDirCmd_RemoveTheDirIsTrueRmDirSuccess(void)
+void Test_FM_ChildDeleteDirectoryCmd_RemoveTheDirIsTrueRmDirSuccess(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_DIR_CC};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_DIRECTORY_CC};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryRead), !OS_SUCCESS);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildDeleteDirCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildDeleteDirectoryCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
@@ -1485,16 +1485,16 @@ void Test_FM_ChildDeleteDirCmd_RemoveTheDirIsTrueRmDirSuccess(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_DIR_CMD_EID);
 }
 
-void Test_FM_ChildDeleteDirCmd_RemoveDirTrueOSRmDirNotSuccess(void)
+void Test_FM_ChildDeleteDirectoryCmd_RemoveDirTrueOSRmDirNotSuccess(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_DIR_CC};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_DIRECTORY_CC};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryRead), !OS_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(OS_rmdir), !OS_SUCCESS);
 
     /* Act */
-    UtAssert_VOIDCALL(FM_ChildDeleteDirCmd(&queue_entry));
+    UtAssert_VOIDCALL(FM_ChildDeleteDirectoryCmd(&queue_entry));
 
     /* Assert */
     UT_FM_Child_Cmd_Assert(0, 1, 0, queue_entry.CommandCode);
@@ -1512,7 +1512,7 @@ void Test_FM_ChildDeleteDirCmd_RemoveDirTrueOSRmDirNotSuccess(void)
 void Test_FM_ChildDirListFileCmd_OSDirOpenNotSuccess(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_GET_DIR_FILE_CC};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_GET_DIR_LIST_FILE_CC};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryOpen), !OS_SUCCESS);
 
@@ -1533,7 +1533,7 @@ void Test_FM_ChildDirListFileCmd_ChildDirListFileInitFalse(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_GET_DIR_FILE_CC, .Source1 = "dummy_source1", .Target = "dummy_target"};
+        .CommandCode = FM_GET_DIR_LIST_FILE_CC, .Source1 = "dummy_source1", .Target = "dummy_target"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), !OS_SUCCESS);
 
@@ -1555,7 +1555,7 @@ void Test_FM_ChildDirListFileCmd_ChildDirListFileInitTrue(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_GET_DIR_FILE_CC, .Source1 = "dummy_source1", .Target = "dummy_target"};
+        .CommandCode = FM_GET_DIR_LIST_FILE_CC, .Source1 = "dummy_source1", .Target = "dummy_target"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryRead), !OS_SUCCESS);
 
@@ -1580,7 +1580,7 @@ void Test_FM_ChildDirListPktCmd_OSDirOpenNotSuccess(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_GET_DIR_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_GET_DIR_LIST_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryOpen), !OS_SUCCESS);
 
@@ -1602,7 +1602,7 @@ void Test_FM_ChildDirListPktCmd_OSDirReadNotSuccess(void)
 
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_GET_DIR_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_GET_DIR_LIST_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryRead), !OS_SUCCESS);
 
@@ -1628,7 +1628,7 @@ void Test_FM_ChildDirListPktCmd_DirEntryNameThisDirectory(void)
 
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_GET_DIR_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_GET_DIR_LIST_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = FM_THIS_DIRECTORY};
 
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
@@ -1656,7 +1656,7 @@ void Test_FM_ChildDirListPktCmd_DirEntryNameParentDirectory(void)
 
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_GET_DIR_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_GET_DIR_LIST_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry = {.FileName = FM_PARENT_DIRECTORY};
 
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
@@ -1684,7 +1684,7 @@ void Test_FM_ChildDirListPktCmd_DirListOffsetNotExceeded(void)
 
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_GET_DIR_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2", .DirListOffset = 1};
+        .CommandCode = FM_GET_DIR_LIST_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2", .DirListOffset = 1};
     os_dirent_t direntry = {.FileName = "filename"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
@@ -1714,7 +1714,7 @@ void Test_FM_ChildDirListPktCmd_DirListOffsetExceeded(void)
 
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_GET_DIR_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_GET_DIR_LIST_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
     os_dirent_t direntry[FM_DIR_LIST_PKT_ENTRIES + 1];
 
     /* Unit under test doesn't really care if the entry name is empty */
@@ -1747,7 +1747,7 @@ void Test_FM_ChildDirListPktCmd_PathAndEntryLengthGreaterMaxPathLength(void)
     FM_DirListPkt_Payload_t *ReportPtr;
 
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_ALL_CC,
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_ALL_FILES_CC,
                                         .Source1     = "dummy_source1",
                                         .Source2 = "dummy_source2_has_a_long_name_to_make_path_length_longer_than_64"};
     os_dirent_t          direntry    = {.FileName = "direntry_long"};
@@ -1779,7 +1779,7 @@ void Test_FM_ChildDirListPktCmd_PathAndEntryLengthGreaterMaxPathLength(void)
 void Test_FM_ChildSetPermissionsCmd_OSChmodSuccess(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_SET_FILE_PERM_CC};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_SET_PERMISSIONS_CC};
 
     /* Act */
     UtAssert_VOIDCALL(FM_ChildSetPermissionsCmd(&queue_entry));
@@ -1796,7 +1796,7 @@ void Test_FM_ChildSetPermissionsCmd_OSChmodSuccess(void)
 void Test_FM_ChildSetPermissionsCmd_OSChmodNotSuccess(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_SET_FILE_PERM_CC};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_SET_PERMISSIONS_CC};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_chmod), !OS_SUCCESS);
 
@@ -2346,76 +2346,76 @@ void add_FM_ChildDeleteCmd_tests(void)
                "Test_FM_ChildDeleteCmd_OSRemoveNotSuccess");
 }
 
-void add_FM_ChildDeleteAllCmd_tests(void)
+void add_FM_ChildDeleteAllFilesCmd_tests(void)
 {
-    UtTest_Add(Test_FM_ChildDeleteAllCmd_DirOpenNotSuccess, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildDeleteAllCmd_DirOpenNotSuccess");
+    UtTest_Add(Test_FM_ChildDeleteAllFilesCmd_DirOpenNotSuccess, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildDeleteAllFilesCmd_DirOpenNotSuccess");
 
-    UtTest_Add(Test_FM_ChildDeleteAllCmd_DirReadNotSuccess, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildDeleteAllCmd_DirReadNotSuccess");
+    UtTest_Add(Test_FM_ChildDeleteAllFilesCmd_DirReadNotSuccess, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildDeleteAllFilesCmd_DirReadNotSuccess");
 
-    UtTest_Add(Test_FM_ChildDeleteAllCmd_DirEntryThisDirectory, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildDeleteAllCmd_DirEntryThisDirectory");
+    UtTest_Add(Test_FM_ChildDeleteAllFilesCmd_DirEntryThisDirectory, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildDeleteAllFilesCmd_DirEntryThisDirectory");
 
-    UtTest_Add(Test_FM_ChildDeleteAllCmd_DirEntryParentDirectory, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildDeleteAllCmd_DirEntryParentDirectory");
+    UtTest_Add(Test_FM_ChildDeleteAllFilesCmd_DirEntryParentDirectory, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildDeleteAllFilesCmd_DirEntryParentDirectory");
 
-    UtTest_Add(Test_FM_ChildDeleteAllCmd_PathFilenameLengthGreaterMaxPthLen, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildDeleteAllCmd_PathFilenameLengthGreaterMaxPthLen");
+    UtTest_Add(Test_FM_ChildDeleteAllFilesCmd_PathFilenameLengthGreaterMaxPthLen, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildDeleteAllFilesCmd_PathFilenameLengthGreaterMaxPthLen");
 
-    UtTest_Add(Test_FM_ChildDeleteAllCmd_InvalidFilenameState, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildDeleteAllCmd_InvalidFilenameState");
+    UtTest_Add(Test_FM_ChildDeleteAllFilesCmd_InvalidFilenameState, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildDeleteAllFilesCmd_InvalidFilenameState");
 
-    UtTest_Add(Test_FM_ChildDeleteAllCmd_NotInUseFilenameState, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildDeleteAllCmd_NotInUseFilenameState");
+    UtTest_Add(Test_FM_ChildDeleteAllFilesCmd_NotInUseFilenameState, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildDeleteAllFilesCmd_NotInUseFilenameState");
 
-    UtTest_Add(Test_FM_ChildDeleteAllCmd_DirectoryFilenameState, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildDeleteAllCmd_DirectoryFilenameState");
+    UtTest_Add(Test_FM_ChildDeleteAllFilesCmd_DirectoryFilenameState, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildDeleteAllFilesCmd_DirectoryFilenameState");
 
-    UtTest_Add(Test_FM_ChildDeleteAllCmd_OpenFilenameState, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildDeleteAllCmd_OpenFilenameState");
+    UtTest_Add(Test_FM_ChildDeleteAllFilesCmd_OpenFilenameState, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildDeleteAllFilesCmd_OpenFilenameState");
 
-    UtTest_Add(Test_FM_ChildDeleteAllCmd_ClosedFilename_OSRmNotSuccess, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildDeleteAllCmd_ClosedFilename_OSRmNotSuccess");
+    UtTest_Add(Test_FM_ChildDeleteAllFilesCmd_ClosedFilename_OSRmNotSuccess, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildDeleteAllFilesCmd_ClosedFilename_OSRmNotSuccess");
 
-    UtTest_Add(Test_FM_ChildDeleteAllCmd_ClosedFilename_OSrmSuccess, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildDeleteAllCmd_ClosedFilename_OSrmSuccess");
+    UtTest_Add(Test_FM_ChildDeleteAllFilesCmd_ClosedFilename_OSrmSuccess, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildDeleteAllFilesCmd_ClosedFilename_OSrmSuccess");
 
-    UtTest_Add(Test_FM_ChildDeleteAllCmd_FilenameStateDefaultReturn, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildDeleteAllCmd_FilenameStateDefaultReturn");
+    UtTest_Add(Test_FM_ChildDeleteAllFilesCmd_FilenameStateDefaultReturn, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildDeleteAllFilesCmd_FilenameStateDefaultReturn");
 }
 
-void add_FM_ChildDecompressCmd_tests(void)
+void add_FM_ChildDecompressFileCmd_tests(void)
 {
-    UtTest_Add(Test_FM_ChildDecompressCmd_FSDecompressNotSuccess, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildDecompressCmd_FSDecompressNotSuccess");
+    UtTest_Add(Test_FM_ChildDecompressFileCmd_FSDecompressNotSuccess, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildDecompressFileCmd_FSDecompressNotSuccess");
 
-    UtTest_Add(Test_FM_ChildDecompressCmd_FSDecompressSuccess, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildDecompressCmd_FSDecompressSuccess");
+    UtTest_Add(Test_FM_ChildDecompressFileCmd_FSDecompressSuccess, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildDecompressFileCmd_FSDecompressSuccess");
 }
 
-void add_FM_ChildConcatCmd_tests(void)
+void add_FM_ChildConcatFilesCmd_tests(void)
 {
-    UtTest_Add(Test_FM_ChildConcatCmd_OSCpNotSuccess, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildConcatCmd_OSCpNotSuccess");
+    UtTest_Add(Test_FM_ChildConcatFilesCmd_OSCpNotSuccess, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildConcatFilesCmd_OSCpNotSuccess");
 
-    UtTest_Add(Test_FM_ChildConcatCmd_OSOpenCreateSourceNotSuccess, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildConcatCmd_OSOpenCreateSourceNotSuccess");
+    UtTest_Add(Test_FM_ChildConcatFilesCmd_OSOpenCreateSourceNotSuccess, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildConcatFilesCmd_OSOpenCreateSourceNotSuccess");
 
-    UtTest_Add(Test_FM_ChildConcatCmd_OSOpenCreateTargetNotSuccess, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildConcatCmd_OSOpenCreateTargetNotSuccess");
+    UtTest_Add(Test_FM_ChildConcatFilesCmd_OSOpenCreateTargetNotSuccess, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildConcatFilesCmd_OSOpenCreateTargetNotSuccess");
 
-    UtTest_Add(Test_FM_ChildConcatCmd_OSReadBytesZero, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildConcatCmd_OSReadBytesZero");
+    UtTest_Add(Test_FM_ChildConcatFilesCmd_OSReadBytesZero, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildConcatFilesCmd_OSReadBytesZero");
 
-    UtTest_Add(Test_FM_ChildConcatCmd_OSReadBytesLessThanZero, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildConcatCmd_OSReadBytesLessThanZero");
+    UtTest_Add(Test_FM_ChildConcatFilesCmd_OSReadBytesLessThanZero, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildConcatFilesCmd_OSReadBytesLessThanZero");
 
-    UtTest_Add(Test_FM_ChildConcatCmd_BytesWrittenNotEqualBytesRead, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildConcatCmd_BytesWrittenNotEqualBytesRead");
+    UtTest_Add(Test_FM_ChildConcatFilesCmd_BytesWrittenNotEqualBytesRead, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildConcatFilesCmd_BytesWrittenNotEqualBytesRead");
 
-    UtTest_Add(Test_FM_ChildConcatCmd_CopyInProgressTrueLoopCountEqualChildFileLoopCount, FM_Test_Setup,
-               FM_Test_Teardown, "Test_FM_ChildConcatCmd_CopyInProgressTrueLoopCountEqualChildFileLoopCount");
+    UtTest_Add(Test_FM_ChildConcatFilesCmd_CopyInProgressTrueLoopCountEqualChildFileLoopCount, FM_Test_Setup,
+               FM_Test_Teardown, "Test_FM_ChildConcatFilesCmd_CopyInProgressTrueLoopCountEqualChildFileLoopCount");
 }
 
 void add_FM_ChildFileInfoCmd_tests(void)
@@ -2448,34 +2448,34 @@ void add_FM_ChildFileInfoCmd_tests(void)
                "Test_FM_ChildFileInfoCmd_BytesReadGreaterThanZero");
 }
 
-void add_FM_ChildCreateDirCmd_tests(void)
+void add_FM_ChildCreateDirectoryCmd_tests(void)
 {
-    UtTest_Add(Test_FM_ChildCreateDirCmd_OSMkDirNotSuccess, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildCreateDirCmd_OSMkDirNotSuccess");
+    UtTest_Add(Test_FM_ChildCreateDirectoryCmd_OSMkDirNotSuccess, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildCreateDirectoryCmd_OSMkDirNotSuccess");
 
-    UtTest_Add(Test_FM_ChildCreateDirCmd_OSMkDirSuccess, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildCreateDirCmd_OSMkDirSuccess");
+    UtTest_Add(Test_FM_ChildCreateDirectoryCmd_OSMkDirSuccess, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildCreateDirectoryCmd_OSMkDirSuccess");
 }
 
-void add_FM_ChildDeleteDirCmd_tests(void)
+void add_FM_ChildDeleteDirectoryCmd_tests(void)
 {
-    UtTest_Add(Test_FM_ChildDeleteDirCmd_OSDirectoryOpenNoSuccess, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildDeleteDirCmd_OSDirectoryOpenNoSuccess");
+    UtTest_Add(Test_FM_ChildDeleteDirectoryCmd_OSDirectoryOpenNoSuccess, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildDeleteDirectoryCmd_OSDirectoryOpenNoSuccess");
 
-    UtTest_Add(Test_FM_ChildDeleteDirCmd_OSDirectoryReadNoSuccess, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildDeleteDirCmd_OSDirectoryReadNoSuccess");
+    UtTest_Add(Test_FM_ChildDeleteDirectoryCmd_OSDirectoryReadNoSuccess, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildDeleteDirectoryCmd_OSDirectoryReadNoSuccess");
 
-    UtTest_Add(Test_FM_ChildDeleteDirCmd_StrCmpThisDirectoryZero, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildDeleteDirCmd_StrCmpThisDirectoryZero");
+    UtTest_Add(Test_FM_ChildDeleteDirectoryCmd_StrCmpThisDirectoryZero, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildDeleteDirectoryCmd_StrCmpThisDirectoryZero");
 
-    UtTest_Add(Test_FM_ChildDeleteDirCmd_StrCmpParentDirectoryZero, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildDeleteDirCmd_StrCmpParentDirectoryZero");
+    UtTest_Add(Test_FM_ChildDeleteDirectoryCmd_StrCmpParentDirectoryZero, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildDeleteDirectoryCmd_StrCmpParentDirectoryZero");
 
-    UtTest_Add(Test_FM_ChildDeleteDirCmd_RemoveTheDirIsTrueRmDirSuccess, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildDeleteDirCmd_RemoveTheDirIsTrueRmDirSuccess");
+    UtTest_Add(Test_FM_ChildDeleteDirectoryCmd_RemoveTheDirIsTrueRmDirSuccess, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildDeleteDirectoryCmd_RemoveTheDirIsTrueRmDirSuccess");
 
-    UtTest_Add(Test_FM_ChildDeleteDirCmd_RemoveDirTrueOSRmDirNotSuccess, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ChildDeleteDirCmd_RemoveDirTrueOSRmDirNotSuccess");
+    UtTest_Add(Test_FM_ChildDeleteDirectoryCmd_RemoveDirTrueOSRmDirNotSuccess, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ChildDeleteDirectoryCmd_RemoveDirTrueOSRmDirNotSuccess");
 }
 
 void add_FM_ChildDirListFileCmd_tests(void)
@@ -2616,12 +2616,12 @@ void UtTest_Setup(void)
     add_FM_ChildMoveCmd_tests();
     add_FM_ChildRenameCmd_tests();
     add_FM_ChildDeleteCmd_tests();
-    add_FM_ChildDeleteAllCmd_tests();
-    add_FM_ChildDecompressCmd_tests();
-    add_FM_ChildConcatCmd_tests();
+    add_FM_ChildDeleteAllFilesCmd_tests();
+    add_FM_ChildDecompressFileCmd_tests();
+    add_FM_ChildConcatFilesCmd_tests();
     add_FM_ChildFileInfoCmd_tests();
-    add_FM_ChildCreateDirCmd_tests();
-    add_FM_ChildDeleteDirCmd_tests();
+    add_FM_ChildCreateDirectoryCmd_tests();
+    add_FM_ChildDeleteDirectoryCmd_tests();
     add_FM_ChildDirListFileCmd_tests();
     add_FM_ChildDirListPktCmd_tests();
     add_FM_ChildSetPermissionsCmd_tests();

--- a/unit-test/fm_cmds_tests.c
+++ b/unit-test/fm_cmds_tests.c
@@ -212,7 +212,7 @@ void Test_FM_CopyFileCmd_Success(void)
     UtAssert_True(Result == true, "FM_CopyFileCmd returned true");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_COPY_CC);
+    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_COPY_FILE_CC);
 }
 
 void Test_FM_CopyFileCmd_BadLength(void)
@@ -402,7 +402,7 @@ void Test_FM_MoveFileCmd_Success(void)
     UtAssert_True(Result == true, "FM_MoveFileCmd returned true");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_MOVE_CC);
+    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_MOVE_FILE_CC);
 }
 
 void Test_FM_MoveFileCmd_BadLength(void)
@@ -597,7 +597,7 @@ void Test_FM_RenameFileCmd_Success(void)
     UtAssert_True(Result == true, "FM_RenameFileCmd returned true");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_RENAME_CC);
+    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_RENAME_FILE_CC);
 }
 
 void Test_FM_RenameFileCmd_BadLength(void)
@@ -708,7 +708,7 @@ void Test_FM_DeleteFileCmd_Success(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    CFE_MSG_FcnCode_t forced_CmdCode = FM_DELETE_CC;
+    CFE_MSG_FcnCode_t forced_CmdCode = FM_DELETE_FILE_CC;
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &forced_CmdCode, sizeof(forced_CmdCode), false);
 
     UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
@@ -723,7 +723,7 @@ void Test_FM_DeleteFileCmd_Success(void)
     UtAssert_True(Result == true, "FM_DeleteFileCmd returned true");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_DELETE_CC);
+    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_DELETE_FILE_CC);
 }
 
 void Test_FM_DeleteFileCmd_BadLength(void)
@@ -731,7 +731,7 @@ void Test_FM_DeleteFileCmd_BadLength(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    CFE_MSG_FcnCode_t forced_CmdCode = FM_DELETE_CC;
+    CFE_MSG_FcnCode_t forced_CmdCode = FM_DELETE_FILE_CC;
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &forced_CmdCode, sizeof(forced_CmdCode), false);
 
     UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
@@ -754,7 +754,7 @@ void Test_FM_DeleteFileCmd_FileNotClosed(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    CFE_MSG_FcnCode_t forced_CmdCode = FM_DELETE_CC;
+    CFE_MSG_FcnCode_t forced_CmdCode = FM_DELETE_FILE_CC;
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &forced_CmdCode, sizeof(forced_CmdCode), false);
 
     UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
@@ -777,7 +777,7 @@ void Test_FM_DeleteFileCmd_NoChildTask(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    CFE_MSG_FcnCode_t forced_CmdCode = FM_DELETE_CC;
+    CFE_MSG_FcnCode_t forced_CmdCode = FM_DELETE_FILE_CC;
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &forced_CmdCode, sizeof(forced_CmdCode), false);
 
     UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
@@ -815,7 +815,7 @@ void Test_FM_DeleteAllFilesCmd_Success(void)
 {
     FM_DirectoryName_Payload_t *CmdPtr;
 
-    CmdPtr = &UT_CmdBuf.DeleteAllCmd.Payload;
+    CmdPtr = &UT_CmdBuf.DeleteAllFilesCmd.Payload;
 
     strncpy(CmdPtr->Directory, "dir", sizeof(CmdPtr->Directory) - 1);
 
@@ -834,7 +834,7 @@ void Test_FM_DeleteAllFilesCmd_Success(void)
     UtAssert_True(Result == true, "FM_DeleteAllFilesCmd returned true");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_DELETE_ALL_CC);
+    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_DELETE_ALL_FILES_CC);
 }
 
 void Test_FM_DeleteAllFilesCmd_BadLength(void)
@@ -881,7 +881,7 @@ void Test_FM_DeleteAllFilesCmd_NoChildTask(void)
 {
     FM_DirectoryName_Payload_t *CmdPtr;
 
-    CmdPtr = &UT_CmdBuf.DeleteAllCmd.Payload;
+    CmdPtr = &UT_CmdBuf.DeleteAllFilesCmd.Payload;
 
     strncpy(CmdPtr->Directory, "dir", sizeof(CmdPtr->Directory) - 1);
     FM_GlobalData.ChildWriteIndex           = 0;
@@ -938,7 +938,7 @@ void Test_FM_DecompressFileCmd_Success(void)
     UtAssert_True(Result == true, "FM_DecompressFileCmd returned true");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_DECOMPRESS_CC);
+    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_DECOMPRESS_FILE_CC);
 }
 
 void Test_FM_DecompressFileCmd_BadLength(void)
@@ -1050,7 +1050,7 @@ void Test_FM_ConcatFilesCmd_Success(void)
 {
     FM_TwoSourceOneTarget_Payload_t *CmdPtr;
 
-    CmdPtr = &UT_CmdBuf.ConcatCmd.Payload;
+    CmdPtr = &UT_CmdBuf.ConcatFilesCmd.Payload;
 
     strncpy(CmdPtr->Source1, "src1", sizeof(CmdPtr->Source1) - 1);
     strncpy(CmdPtr->Source2, "src2", sizeof(CmdPtr->Source2) - 1);
@@ -1072,7 +1072,7 @@ void Test_FM_ConcatFilesCmd_Success(void)
     UtAssert_True(Result == true, "FM_ConcatFilesCmd returned true");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_CONCAT_CC);
+    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_CONCAT_FILES_CC);
 }
 
 void Test_FM_ConcatFilesCmd_BadLength(void)
@@ -1357,7 +1357,7 @@ void Test_FM_CreateDirectoryCmd_Success(void)
 {
     FM_DirectoryName_Payload_t *CmdPtr;
 
-    CmdPtr = &UT_CmdBuf.CreateDirCmd.Payload;
+    CmdPtr = &UT_CmdBuf.CreateDirectoryCmd.Payload;
 
     strncpy(CmdPtr->Directory, "dir", sizeof(CmdPtr->Directory) - 1);
     FM_GlobalData.ChildWriteIndex           = 0;
@@ -1375,7 +1375,7 @@ void Test_FM_CreateDirectoryCmd_Success(void)
     UtAssert_True(Result == true, "FM_CreateDirectoryCmd returned true");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_CREATE_DIR_CC);
+    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_CREATE_DIRECTORY_CC);
 }
 
 void Test_FM_CreateDirectoryCmd_BadLength(void)
@@ -1461,7 +1461,7 @@ void Test_FM_DeleteDirectoryCmd_Success(void)
 {
     FM_DirectoryName_Payload_t *CmdPtr;
 
-    CmdPtr = &UT_CmdBuf.DeleteDirCmd.Payload;
+    CmdPtr = &UT_CmdBuf.DeleteDirectoryCmd.Payload;
 
     strncpy(CmdPtr->Directory, "dir", sizeof(CmdPtr->Directory) - 1);
     FM_GlobalData.ChildWriteIndex           = 0;
@@ -1479,7 +1479,7 @@ void Test_FM_DeleteDirectoryCmd_Success(void)
     UtAssert_True(Result == true, "FM_DeleteDirectoryCmd returned true");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_DELETE_DIR_CC);
+    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_DELETE_DIRECTORY_CC);
 }
 
 void Test_FM_DeleteDirectoryCmd_BadLength(void)
@@ -1565,7 +1565,7 @@ void Test_FM_GetDirListFileCmd_Success(void)
 {
     FM_GetDirectoryToFile_Payload_t *CmdPtr;
 
-    CmdPtr = &UT_CmdBuf.GetDirFileCmd.Payload;
+    CmdPtr = &UT_CmdBuf.GetDirListFileCmd.Payload;
 
     strncpy(CmdPtr->Filename, "file", sizeof(CmdPtr->Filename) - 1);
     strncpy(CmdPtr->Directory, "dir", sizeof(CmdPtr->Directory) - 1);
@@ -1585,14 +1585,14 @@ void Test_FM_GetDirListFileCmd_Success(void)
     UtAssert_True(Result == true, "FM_GetDirListFileCmd returned true");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_GET_DIR_FILE_CC);
+    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_GET_DIR_LIST_FILE_CC);
 }
 
 void Test_FM_GetDirListFileCmd_SuccessDefaultPath(void)
 {
     FM_GetDirectoryToFile_Payload_t *CmdPtr;
 
-    CmdPtr = &UT_CmdBuf.GetDirFileCmd.Payload;
+    CmdPtr = &UT_CmdBuf.GetDirListFileCmd.Payload;
 
     strncpy(CmdPtr->Directory, "dir", sizeof(CmdPtr->Directory) - 1);
     CmdPtr->Filename[0]                     = '\0';
@@ -1612,7 +1612,7 @@ void Test_FM_GetDirListFileCmd_SuccessDefaultPath(void)
     UtAssert_True(Result == true, "FM_GetDirListFileCmd returned true");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_GET_DIR_FILE_CC);
+    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_GET_DIR_LIST_FILE_CC);
 }
 
 void Test_FM_GetDirListFileCmd_BadLength(void)
@@ -1661,7 +1661,7 @@ void Test_FM_GetDirListFileCmd_TargetFileOpen(void)
 {
     FM_GetDirectoryToFile_Payload_t *CmdPtr;
 
-    CmdPtr = &UT_CmdBuf.GetDirFileCmd.Payload;
+    CmdPtr = &UT_CmdBuf.GetDirListFileCmd.Payload;
 
     strncpy(CmdPtr->Filename, "file", sizeof(CmdPtr->Filename) - 1);
     strncpy(CmdPtr->Directory, "dir", sizeof(CmdPtr->Directory) - 1);
@@ -1689,7 +1689,7 @@ void Test_FM_GetDirListFileCmd_NoChildTask(void)
 {
     FM_GetDirectoryToFile_Payload_t *CmdPtr;
 
-    CmdPtr = &UT_CmdBuf.GetDirFileCmd.Payload;
+    CmdPtr = &UT_CmdBuf.GetDirListFileCmd.Payload;
 
     strncpy(CmdPtr->Filename, "file", sizeof(CmdPtr->Filename) - 1);
     strncpy(CmdPtr->Directory, "dir", sizeof(CmdPtr->Directory) - 1);
@@ -1741,7 +1741,7 @@ void Test_FM_GetDirListPktCmd_Success(void)
 {
     FM_GetDirectoryToPkt_Payload_t *CmdPtr;
 
-    CmdPtr = &UT_CmdBuf.GetDirPktCmd.Payload;
+    CmdPtr = &UT_CmdBuf.GetDirListPktCmd.Payload;
 
     strncpy(CmdPtr->Directory, "dir", sizeof(CmdPtr->Directory) - 1);
 
@@ -1760,7 +1760,7 @@ void Test_FM_GetDirListPktCmd_Success(void)
     UtAssert_True(Result == true, "FM_GetDirListPktCmd returned true");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_GET_DIR_PKT_CC);
+    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_GET_DIR_LIST_PKT_CC);
 }
 
 void Test_FM_GetDirListPktCmd_BadLength(void)
@@ -2296,7 +2296,7 @@ void Test_FM_SetPermissionsCmd_Success(void)
 {
     FM_FilenameAndMode_Payload_t *CmdPtr;
 
-    CmdPtr = &UT_CmdBuf.SetPermCmd.Payload;
+    CmdPtr = &UT_CmdBuf.SetPermissionsCmd.Payload;
 
     strncpy(CmdPtr->FileName, "file", sizeof(CmdPtr->FileName) - 1);
     UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
@@ -2311,7 +2311,7 @@ void Test_FM_SetPermissionsCmd_Success(void)
     UtAssert_True(Result == true, "FM_SetPermissionsCmd returned true");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_SET_FILE_PERM_CC);
+    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_SET_PERMISSIONS_CC);
 }
 
 void Test_FM_SetPermissionsCmd_BadLength(void)

--- a/unit-test/stubs/fm_app_stubs.c
+++ b/unit-test/stubs/fm_app_stubs.c
@@ -77,12 +77,12 @@ void FM_ProcessPkt(const CFE_SB_Buffer_t *MessagePtr)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for FM_ReportHK()
+ * Generated stub function for FM_SendHkCmd()
  * ----------------------------------------------------
  */
-void FM_ReportHK(const CFE_MSG_CommandHeader_t *Msg)
+void FM_SendHkCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    UT_GenStub_AddParam(FM_ReportHK, const CFE_MSG_CommandHeader_t *, Msg);
+    UT_GenStub_AddParam(FM_SendHkCmd, const CFE_SB_Buffer_t *, BufPtr);
 
-    UT_GenStub_Execute(FM_ReportHK, Basic, NULL);
+    UT_GenStub_Execute(FM_SendHkCmd, Basic, NULL);
 }

--- a/unit-test/stubs/fm_child_stubs.c
+++ b/unit-test/stubs/fm_child_stubs.c
@@ -28,14 +28,14 @@
 
 /*
  * ----------------------------------------------------
- * Generated stub function for FM_ChildConcatCmd()
+ * Generated stub function for FM_ChildConcatFilesCmd()
  * ----------------------------------------------------
  */
-void FM_ChildConcatCmd(const FM_ChildQueueEntry_t *CmdArgs)
+void FM_ChildConcatFilesCmd(const FM_ChildQueueEntry_t *CmdArgs)
 {
-    UT_GenStub_AddParam(FM_ChildConcatCmd, const FM_ChildQueueEntry_t *, CmdArgs);
+    UT_GenStub_AddParam(FM_ChildConcatFilesCmd, const FM_ChildQueueEntry_t *, CmdArgs);
 
-    UT_GenStub_Execute(FM_ChildConcatCmd, Basic, NULL);
+    UT_GenStub_Execute(FM_ChildConcatFilesCmd, Basic, NULL);
 }
 
 /*
@@ -52,38 +52,38 @@ void FM_ChildCopyCmd(const FM_ChildQueueEntry_t *CmdArgs)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for FM_ChildCreateDirCmd()
+ * Generated stub function for FM_ChildCreateDirectoryCmd()
  * ----------------------------------------------------
  */
-void FM_ChildCreateDirCmd(const FM_ChildQueueEntry_t *CmdArgs)
+void FM_ChildCreateDirectoryCmd(const FM_ChildQueueEntry_t *CmdArgs)
 {
-    UT_GenStub_AddParam(FM_ChildCreateDirCmd, const FM_ChildQueueEntry_t *, CmdArgs);
+    UT_GenStub_AddParam(FM_ChildCreateDirectoryCmd, const FM_ChildQueueEntry_t *, CmdArgs);
 
-    UT_GenStub_Execute(FM_ChildCreateDirCmd, Basic, NULL);
+    UT_GenStub_Execute(FM_ChildCreateDirectoryCmd, Basic, NULL);
 }
 
 /*
  * ----------------------------------------------------
- * Generated stub function for FM_ChildDecompressCmd()
+ * Generated stub function for FM_ChildDecompressFileCmd()
  * ----------------------------------------------------
  */
-void FM_ChildDecompressCmd(const FM_ChildQueueEntry_t *CmdArgs)
+void FM_ChildDecompressFileCmd(const FM_ChildQueueEntry_t *CmdArgs)
 {
-    UT_GenStub_AddParam(FM_ChildDecompressCmd, const FM_ChildQueueEntry_t *, CmdArgs);
+    UT_GenStub_AddParam(FM_ChildDecompressFileCmd, const FM_ChildQueueEntry_t *, CmdArgs);
 
-    UT_GenStub_Execute(FM_ChildDecompressCmd, Basic, NULL);
+    UT_GenStub_Execute(FM_ChildDecompressFileCmd, Basic, NULL);
 }
 
 /*
  * ----------------------------------------------------
- * Generated stub function for FM_ChildDeleteAllCmd()
+ * Generated stub function for FM_ChildDeleteAllFilesCmd()
  * ----------------------------------------------------
  */
-void FM_ChildDeleteAllCmd(FM_ChildQueueEntry_t *CmdArgs)
+void FM_ChildDeleteAllFilesCmd(FM_ChildQueueEntry_t *CmdArgs)
 {
-    UT_GenStub_AddParam(FM_ChildDeleteAllCmd, FM_ChildQueueEntry_t *, CmdArgs);
+    UT_GenStub_AddParam(FM_ChildDeleteAllFilesCmd, FM_ChildQueueEntry_t *, CmdArgs);
 
-    UT_GenStub_Execute(FM_ChildDeleteAllCmd, Basic, NULL);
+    UT_GenStub_Execute(FM_ChildDeleteAllFilesCmd, Basic, NULL);
 }
 
 /*
@@ -100,14 +100,14 @@ void FM_ChildDeleteCmd(const FM_ChildQueueEntry_t *CmdArgs)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for FM_ChildDeleteDirCmd()
+ * Generated stub function for FM_ChildDeleteDirectoryCmd()
  * ----------------------------------------------------
  */
-void FM_ChildDeleteDirCmd(const FM_ChildQueueEntry_t *CmdArgs)
+void FM_ChildDeleteDirectoryCmd(const FM_ChildQueueEntry_t *CmdArgs)
 {
-    UT_GenStub_AddParam(FM_ChildDeleteDirCmd, const FM_ChildQueueEntry_t *, CmdArgs);
+    UT_GenStub_AddParam(FM_ChildDeleteDirectoryCmd, const FM_ChildQueueEntry_t *, CmdArgs);
 
-    UT_GenStub_Execute(FM_ChildDeleteDirCmd, Basic, NULL);
+    UT_GenStub_Execute(FM_ChildDeleteDirectoryCmd, Basic, NULL);
 }
 
 /*

--- a/unit-test/utilities/fm_test_utils.h
+++ b/unit-test/utilities/fm_test_utils.h
@@ -41,25 +41,25 @@ extern CFE_EVS_SendEvent_context_t context_CFE_EVS_SendEvent[];
 typedef union
 {
     CFE_SB_Buffer_t                Buf;
-    FM_HousekeepingCmd_t           HousekeepingCmd;
+    FM_SendHkCmd_t                 SendHkCmd;
     FM_NoopCmd_t                   NoopCmd;
-    FM_ResetCmd_t                  ResetCmd;
+    FM_ResetCountersCmd_t          ResetCountersCmd;
     FM_CopyFileCmd_t               CopyFileCmd;
     FM_MoveFileCmd_t               MoveFileCmd;
     FM_RenameFileCmd_t             RenameFileCmd;
     FM_DeleteFileCmd_t             DeleteFileCmd;
-    FM_DeleteAllCmd_t              DeleteAllCmd;
-    FM_DecompressCmd_t             DecompressCmd;
-    FM_ConcatCmd_t                 ConcatCmd;
+    FM_DeleteAllFilesCmd_t         DeleteAllFilesCmd;
+    FM_DecompressFileCmd_t         DecompressFileCmd;
+    FM_ConcatFilesCmd_t            ConcatFilesCmd;
     FM_GetFileInfoCmd_t            GetFileInfoCmd;
     FM_GetOpenFilesCmd_t           GetOpenFilesCmd;
-    FM_CreateDirCmd_t              CreateDirCmd;
-    FM_DeleteDirCmd_t              DeleteDirCmd;
-    FM_GetDirFileCmd_t             GetDirFileCmd;
-    FM_GetDirPktCmd_t              GetDirPktCmd;
+    FM_CreateDirectoryCmd_t        CreateDirectoryCmd;
+    FM_DeleteDirectoryCmd_t        DeleteDirectoryCmd;
+    FM_GetDirListFileCmd_t         GetDirListFileCmd;
+    FM_GetDirListPktCmd_t          GetDirListPktCmd;
     FM_MonitorFilesystemSpaceCmd_t GetFreeSpaceCmd;
     FM_SetTableStateCmd_t          SetTableStateCmd;
-    FM_SetPermCmd_t                SetPermCmd;
+    FM_SetPermissionsCmd_t         SetPermissionsCmd;
 } UT_CmdBuf_t;
 
 extern UT_CmdBuf_t UT_CmdBuf;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/FM/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Use of CFE_MSG_PTR requires objects and members to be named correctly per CFE_MSG definitions. Includes other remaining cleanup items.  Mainly:

1. Consistency in naming of header objects 
2. Consistency in naming between command names and command handler functions (fix missing words, fix mismatch abbreviations, etc)

Fixes #15

**Testing performed**
Build and run all tests

**Expected behavior changes**
No impact to behavior.  More future proof code.

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
