### PR TITLE
Fix #92, Use size_t for 'size' variables

### DIFF
--- a/fsw/inc/fm_events.h
+++ b/fsw/inc/fm_events.h
@@ -19,7 +19,7 @@
 
 /**
  * @file
- *   Specification for the CFS File Manager Event Identifers.
+ *   Specification for the CFS File Manager Event Identifiers.
  */
 #ifndef FM_EVENTS_H
 #define FM_EVENTS_H

--- a/fsw/src/fm_child.c
+++ b/fsw/src/fm_child.c
@@ -39,7 +39,7 @@
 
 /************************************************************************
 ** OSAL Compatibility for directory name access
-** New OSAL version have an access macro to get the string.  If that
+** New OSAL version has an access macro to get the string. If that
 ** macro is defined, use it, otherwise assume "d_name" structure member.
 *************************************************************************/
 #ifndef OS_DIRENTRY_NAME
@@ -195,7 +195,7 @@ void FM_ChildProcess(void)
     const char *          TaskText = "Child Task";
     FM_ChildQueueEntry_t *CmdArgs  = &FM_GlobalData.ChildQueue[FM_GlobalData.ChildReadIndex];
 
-    /* Invoke the command specific handler */
+    /* Invoke the command-specific handler */
     switch (CmdArgs->CommandCode)
     {
         case FM_COPY_FILE_CC:
@@ -448,7 +448,7 @@ void FM_ChildDeleteAllFilesCmd(FM_ChildQueueEntry_t *CmdArgs)
     char        Filename[2 * OS_MAX_PATH_LEN] = "";
 
     /*
-    ** Command argument useage for this command:
+    ** Command argument usage for this command:
     **
     **  CmdArgs->CommandCode = FM_DELETE_ALL_FILES_CC
     **  CmdArgs->Source1     = directory name
@@ -815,7 +815,7 @@ void FM_ChildFileInfoCmd(FM_ChildQueueEntry_t *CmdArgs)
     FM_GlobalData.ChildCurrentCC = CmdArgs->CommandCode;
 
     /*
-    ** Command argument useage for this command:
+    ** Command argument usage for this command:
     **
     **  CmdArgs->CommandCode   = FM_GET_DIR_LIST_FILE_CC
     **  CmdArgs->Source1       = name of directory or file
@@ -1090,7 +1090,7 @@ void FM_ChildDirListFileCmd(const FM_ChildQueueEntry_t *CmdArgs)
     FM_GlobalData.ChildCurrentCC = CmdArgs->CommandCode;
 
     /*
-    ** Command argument useage for this command:
+    ** Command argument usage for this command:
     **
     **  CmdArgs->CommandCode = FM_GET_DIR_LIST_FILE_CC
     **  CmdArgs->Source1     = directory name
@@ -1147,8 +1147,8 @@ void FM_ChildDirListPktCmd(const FM_ChildQueueEntry_t *CmdArgs)
     os_dirent_t        DirEntry;
     int32              ListIndex      = 0;
     FM_DirListEntry_t *ListEntry      = NULL;
-    int32              PathLength     = 0;
-    int32              EntryLength    = 0;
+    size_t             PathLength     = 0;
+    size_t             EntryLength    = 0;
     int32              FilesTillSleep = FM_CHILD_STAT_SLEEP_FILECOUNT;
     int32              Status;
 
@@ -1160,7 +1160,7 @@ void FM_ChildDirListPktCmd(const FM_ChildQueueEntry_t *CmdArgs)
     FM_GlobalData.ChildCurrentCC = CmdArgs->CommandCode;
 
     /*
-    ** Command argument useage for this command:
+    ** Command argument usage for this command:
     **
     **  CmdArgs->CommandCode   = FM_GET_DIR_LIST_PKT_CC
     **  CmdArgs->Source1       = directory name
@@ -1209,7 +1209,7 @@ void FM_ChildDirListPktCmd(const FM_ChildQueueEntry_t *CmdArgs)
                 /* Do not count the "." and ".." directory entries */
                 ReportPtr->TotalFiles++;
 
-                /* Start collecting directory entries at command specified offset */
+                /* Start collecting directory entries at command-specified offset */
                 /* Stop collecting directory entries when telemetry packet is full */
                 if ((ReportPtr->TotalFiles > ReportPtr->FirstFile) &&
                     (ReportPtr->PacketFiles < FM_DIR_LIST_PKT_ENTRIES))
@@ -1335,7 +1335,7 @@ bool FM_ChildDirListFileInit(osal_id_t *FileHandlePtr, const char *Directory, co
             strncpy(FM_GlobalData.DirListFileStats.DirName, Directory, OS_MAX_PATH_LEN - 1);
             FM_GlobalData.DirListFileStats.DirName[OS_MAX_PATH_LEN - 1] = '\0';
 
-            /* Write blank FM directory statistics structure as a place holder */
+            /* Write blank FM directory statistics structure as a placeholder */
             BytesWritten = OS_write(FileHandle, &FM_GlobalData.DirListFileStats, sizeof(FM_DirListFileStats_t));
             if (BytesWritten == sizeof(FM_DirListFileStats_t))
             {
@@ -1393,13 +1393,13 @@ void FM_ChildDirListFileLoop(osal_id_t DirId, osal_id_t FileHandle, const char *
                              const char *Filename, uint8 getSizeTimeMode)
 {
     const char *      CmdText                   = "Directory List to File";
-    int32             WriteLength               = sizeof(FM_DirListEntry_t);
+    size_t            WriteLength               = sizeof(FM_DirListEntry_t);
     bool              ReadingDirectory          = true;
     bool              CommandResult             = true;
     uint32            DirEntries                = 0;
     uint32            FileEntries               = 0;
-    int32             EntryLength               = 0;
-    int32             PathLength                = 0;
+    size_t            EntryLength               = 0;
+    size_t            PathLength                = 0;
     int32             BytesWritten              = 0;
     int32             FilesTillSleep            = FM_CHILD_STAT_SLEEP_FILECOUNT;
     int32             Status                    = 0;
@@ -1445,7 +1445,7 @@ void FM_ChildDirListFileLoop(osal_id_t DirId, osal_id_t FileHandle, const char *
 
                     /*
                      * Populate directory list file entry -
-                     * Note this is guaranteed to be null terminated due to the memset()
+                     * Note this is guaranteed to be null-terminated due to the memset()
                      * this will leave at least one null char after the string.
                      */
                     memset(&DirListData, 0, sizeof(DirListData));
@@ -1491,7 +1491,7 @@ void FM_ChildDirListFileLoop(osal_id_t DirId, osal_id_t FileHandle, const char *
         FM_GlobalData.DirListFileStats.DirEntries  = DirEntries;
         FM_GlobalData.DirListFileStats.FileEntries = FileEntries;
 
-        /* Back up to the start of the statisitics data */
+        /* Back up to the start of the statistics data */
         OS_lseek(FileHandle, sizeof(CFE_FS_Header_t), OS_SEEK_SET);
 
         /* Write an updated version of the statistics data */

--- a/fsw/src/fm_cmd_utils.c
+++ b/fsw/src/fm_cmd_utils.c
@@ -132,7 +132,7 @@ static void SearchOpenFileData(osal_id_t ObjId, void *CallbackArg)
     }
 }
 
-uint32 FM_GetFilenameState(const char *Filename, uint32 BufferSize, bool FileInfoCmd)
+uint32 FM_GetFilenameState(const char *Filename, size_t BufferSize, bool FileInfoCmd)
 {
     os_fstat_t FileStatus;
     uint32     FilenameState   = FM_NAME_IS_INVALID;
@@ -217,7 +217,7 @@ uint32 FM_GetFilenameState(const char *Filename, uint32 BufferSize, bool FileInf
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-uint32 FM_VerifyNameValid(const char *Name, uint32 BufferSize, uint32 EventID, const char *CmdText)
+uint32 FM_VerifyNameValid(const char *Name, size_t BufferSize, uint32 EventID, const char *CmdText)
 {
     char   LocalFile[1 + OS_MAX_PATH_LEN];
     uint32 FilenameState = FM_NAME_IS_INVALID;
@@ -228,8 +228,8 @@ uint32 FM_VerifyNameValid(const char *Name, uint32 BufferSize, uint32 EventID, c
     if (FilenameState == FM_NAME_IS_INVALID)
     {
         /*
-         * This function provided by SB will copy the string from a fixed size buffer,
-         * and always ensures the result is null terminated
+         * This function provided by SB will copy the string from a fixed-size buffer,
+         * and always ensures the result is null-terminated
          */
         CFE_SB_MessageStringGet(LocalFile, Name, NULL, sizeof(LocalFile), BufferSize);
         CFE_EVS_SendEvent(EventID, CFE_EVS_EventType_ERROR, "%s error: invalid name: name = %s", CmdText, LocalFile);
@@ -244,7 +244,7 @@ uint32 FM_VerifyNameValid(const char *Name, uint32 BufferSize, uint32 EventID, c
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_VerifyFileState(FM_File_States State, const char *Filename, uint32 BufferSize, uint32 EventID,
+bool FM_VerifyFileState(FM_File_States State, const char *Filename, size_t BufferSize, uint32 EventID,
                         const char *CmdText)
 {
     bool        Result        = false;
@@ -337,8 +337,8 @@ bool FM_VerifyFileState(FM_File_States State, const char *Filename, uint32 Buffe
     if (!Result)
     {
         /*
-         * This function provided by SB will copy the string from a fixed size buffer,
-         * and always ensures the result is null terminated
+         * This function provided by SB will copy the string from a fixed-size buffer,
+         * and always ensures the result is null-terminated
          */
         CFE_SB_MessageStringGet(LocalFile, Filename, NULL, sizeof(LocalFile), BufferSize);
         CFE_EVS_SendEvent((EventID + ErrorCode), CFE_EVS_EventType_ERROR, "%s error: %s: name = %s", CmdText, ErrorDesc,
@@ -354,7 +354,7 @@ bool FM_VerifyFileState(FM_File_States State, const char *Filename, uint32 Buffe
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_VerifyFileClosed(const char *Filename, uint32 BufferSize, uint32 EventID, const char *CmdText)
+bool FM_VerifyFileClosed(const char *Filename, size_t BufferSize, uint32 EventID, const char *CmdText)
 {
     return FM_VerifyFileState(FM_FILE_CLOSED, Filename, BufferSize, EventID, CmdText);
 }
@@ -365,7 +365,7 @@ bool FM_VerifyFileClosed(const char *Filename, uint32 BufferSize, uint32 EventID
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_VerifyFileExists(const char *Filename, uint32 BufferSize, uint32 EventID, const char *CmdText)
+bool FM_VerifyFileExists(const char *Filename, size_t BufferSize, uint32 EventID, const char *CmdText)
 {
     return FM_VerifyFileState(FM_FILE_EXISTS, Filename, BufferSize, EventID, CmdText);
 }
@@ -376,7 +376,7 @@ bool FM_VerifyFileExists(const char *Filename, uint32 BufferSize, uint32 EventID
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_VerifyFileNoExist(const char *Filename, uint32 BufferSize, uint32 EventID, const char *CmdText)
+bool FM_VerifyFileNoExist(const char *Filename, size_t BufferSize, uint32 EventID, const char *CmdText)
 {
     return FM_VerifyFileState(FM_FILE_NOEXIST, Filename, BufferSize, EventID, CmdText);
 }
@@ -387,7 +387,7 @@ bool FM_VerifyFileNoExist(const char *Filename, uint32 BufferSize, uint32 EventI
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_VerifyFileNotOpen(const char *Filename, uint32 BufferSize, uint32 EventID, const char *CmdText)
+bool FM_VerifyFileNotOpen(const char *Filename, size_t BufferSize, uint32 EventID, const char *CmdText)
 {
     return FM_VerifyFileState(FM_FILE_NOTOPEN, Filename, BufferSize, EventID, CmdText);
 }
@@ -398,7 +398,7 @@ bool FM_VerifyFileNotOpen(const char *Filename, uint32 BufferSize, uint32 EventI
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_VerifyDirExists(const char *Directory, uint32 BufferSize, uint32 EventID, const char *CmdText)
+bool FM_VerifyDirExists(const char *Directory, size_t BufferSize, uint32 EventID, const char *CmdText)
 {
     return FM_VerifyFileState(FM_DIR_EXISTS, Directory, BufferSize, EventID, CmdText);
 }
@@ -409,7 +409,7 @@ bool FM_VerifyDirExists(const char *Directory, uint32 BufferSize, uint32 EventID
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_VerifyDirNoExist(const char *Name, uint32 BufferSize, uint32 EventID, const char *CmdText)
+bool FM_VerifyDirNoExist(const char *Name, size_t BufferSize, uint32 EventID, const char *CmdText)
 {
     return FM_VerifyFileState(FM_DIR_NOEXIST, Name, BufferSize, EventID, CmdText);
 }
@@ -506,7 +506,7 @@ void FM_AppendPathSep(char *Directory, uint32 BufferSize)
     **   the string is both non-zero and less than the size
     **   of the string buffer.
     */
-    uint32 StringLength = 0;
+    size_t StringLength = 0;
 
     StringLength = strlen(Directory);
 

--- a/fsw/src/fm_cmd_utils.h
+++ b/fsw/src/fm_cmd_utils.h
@@ -62,8 +62,8 @@ typedef enum
  *  \par Assumptions, External Events, and Notes:
  *
  *  \param [in]  Overwrite Value being tested
- *  \param [in]  EventID   Error event ID (command specific)
- *  \param [in]  CmdText   Error event text (command specific)
+ *  \param [in]  EventID   Error event ID (command-specific)
+ *  \param [in]  CmdText   Error event text (command-specific)
  *
  *  \return Boolean valid overwrite response
  *  \retval true  Overwrite argument valid
@@ -114,7 +114,7 @@ uint32 FM_GetOpenFilesData(FM_OpenFilesEntry_t *OpenFilesData);
  *
  *  \sa #OS_stat, #OS_FDGetInfo
  */
-uint32 FM_GetFilenameState(const char *Filename, uint32 BufferSize, bool FileInfoCmd);
+uint32 FM_GetFilenameState(const char *Filename, size_t BufferSize, bool FileInfoCmd);
 
 /**
  *  \brief Verify Name Function
@@ -127,8 +127,8 @@ uint32 FM_GetFilenameState(const char *Filename, uint32 BufferSize, bool FileInf
  *
  *  \param [in]  Name       Pointer to buffer containing name
  *  \param [in]  BufferSize Size of name character buffer
- *  \param [in]  EventID    Error event ID (command specific)
- *  \param [in]  CmdText    Error event text (command specific)
+ *  \param [in]  EventID    Error event ID (command-specific)
+ *  \param [in]  CmdText    Error event text (command-specific)
  *
  *  \return File state
  *  \retval #FM_NAME_IS_INVALID     \copydoc FM_NAME_IS_INVALID
@@ -139,7 +139,7 @@ uint32 FM_GetFilenameState(const char *Filename, uint32 BufferSize, bool FileInf
  *
  *  \sa #FM_GetFilenameState
  */
-uint32 FM_VerifyNameValid(const char *Name, uint32 BufferSize, uint32 EventID, const char *CmdText);
+uint32 FM_VerifyNameValid(const char *Name, size_t BufferSize, uint32 EventID, const char *CmdText);
 
 /**
  *  \brief Verify File State Function
@@ -153,8 +153,8 @@ uint32 FM_VerifyNameValid(const char *Name, uint32 BufferSize, uint32 EventID, c
  *  \param [in]  State      State of file to verify
  *  \param [in]  Filename   Pointer to buffer containing filename
  *  \param [in]  BufferSize Size of filename character buffer
- *  \param [in]  EventID    Error event ID (command specific)
- *  \param [in]  CmdText    Error event text (command specific)
+ *  \param [in]  EventID    Error event ID (command-specific)
+ *  \param [in]  CmdText    Error event text (command-specific)
  *
  *  \return Boolean file state response
  *  \retval true  File is in the given state
@@ -162,7 +162,7 @@ uint32 FM_VerifyNameValid(const char *Name, uint32 BufferSize, uint32 EventID, c
  *
  *  \sa #FM_GetFilenameState
  */
-bool FM_VerifyFileState(FM_File_States State, const char *Filename, uint32 BufferSize, uint32 EventID,
+bool FM_VerifyFileState(FM_File_States State, const char *Filename, size_t BufferSize, uint32 EventID,
                         const char *CmdText);
 
 /**
@@ -176,8 +176,8 @@ bool FM_VerifyFileState(FM_File_States State, const char *Filename, uint32 Buffe
  *
  *  \param [in]  Filename   Pointer to buffer containing filename
  *  \param [in]  BufferSize Size of filename character buffer
- *  \param [in]  EventID    Error event ID (command specific)
- *  \param [in]  CmdText    Error event text (command specific)
+ *  \param [in]  EventID    Error event ID (command-specific)
+ *  \param [in]  CmdText    Error event text (command-specific)
  *
  *  \return Boolean file closed response
  *  \retval true  File is closed
@@ -185,7 +185,7 @@ bool FM_VerifyFileState(FM_File_States State, const char *Filename, uint32 Buffe
  *
  *  \sa #FM_VerifyFileState
  */
-bool FM_VerifyFileClosed(const char *Filename, uint32 BufferSize, uint32 EventID, const char *CmdText);
+bool FM_VerifyFileClosed(const char *Filename, size_t BufferSize, uint32 EventID, const char *CmdText);
 
 /**
  *  \brief Verify File Exists Function
@@ -199,8 +199,8 @@ bool FM_VerifyFileClosed(const char *Filename, uint32 BufferSize, uint32 EventID
  *
  *  \param [in]  Filename   Pointer to buffer containing filename
  *  \param [in]  BufferSize Size of filename character buffer
- *  \param [in]  EventID    Error event ID (command specific)
- *  \param [in]  CmdText    Error event text (command specific)
+ *  \param [in]  EventID    Error event ID (command-specific)
+ *  \param [in]  CmdText    Error event text (command-specific)
  *
  *  \return Boolean file exists response
  *  \retval true  File exists
@@ -208,7 +208,7 @@ bool FM_VerifyFileClosed(const char *Filename, uint32 BufferSize, uint32 EventID
  *
  *  \sa #FM_VerifyFileState
  */
-bool FM_VerifyFileExists(const char *Filename, uint32 BufferSize, uint32 EventID, const char *CmdText);
+bool FM_VerifyFileExists(const char *Filename, size_t BufferSize, uint32 EventID, const char *CmdText);
 
 /**
  *  \brief Verify File Does Not Exist Function
@@ -222,8 +222,8 @@ bool FM_VerifyFileExists(const char *Filename, uint32 BufferSize, uint32 EventID
  *
  *  \param [in]  Filename   Pointer to buffer containing name
  *  \param [in]  BufferSize Size of name character buffer
- *  \param [in]  EventID    Error event ID (command specific)
- *  \param [in]  CmdText    Error event text (command specific)
+ *  \param [in]  EventID    Error event ID (command-specific)
+ *  \param [in]  CmdText    Error event text (command-specific)
  *
  *  \return Boolean file does not exist response
  *  \retval true  File does not exist
@@ -231,7 +231,7 @@ bool FM_VerifyFileExists(const char *Filename, uint32 BufferSize, uint32 EventID
  *
  *  \sa #FM_VerifyFileState
  */
-bool FM_VerifyFileNoExist(const char *Filename, uint32 BufferSize, uint32 EventID, const char *CmdText);
+bool FM_VerifyFileNoExist(const char *Filename, size_t BufferSize, uint32 EventID, const char *CmdText);
 
 /**
  *  \brief Verify File Is Not Open Function
@@ -244,8 +244,8 @@ bool FM_VerifyFileNoExist(const char *Filename, uint32 BufferSize, uint32 EventI
  *
  *  \param [in]  Filename   Pointer to buffer containing name
  *  \param [in]  BufferSize Size of name character buffer
- *  \param [in]  EventID    Error event ID (command specific)
- *  \param [in]  CmdText    Error event text (command specific)
+ *  \param [in]  EventID    Error event ID (command-specific)
+ *  \param [in]  CmdText    Error event text (command-specific)
  *
  *  \return Boolean file not open or not in use response
  *  \retval true  File is not open or not in use
@@ -253,7 +253,7 @@ bool FM_VerifyFileNoExist(const char *Filename, uint32 BufferSize, uint32 EventI
  *
  *  \sa #FM_VerifyFileState
  */
-bool FM_VerifyFileNotOpen(const char *Filename, uint32 BufferSize, uint32 EventID, const char *CmdText);
+bool FM_VerifyFileNotOpen(const char *Filename, size_t BufferSize, uint32 EventID, const char *CmdText);
 
 /**
  *  \brief Verify Directory Exists Function
@@ -266,8 +266,8 @@ bool FM_VerifyFileNotOpen(const char *Filename, uint32 BufferSize, uint32 EventI
  *
  *  \param [in]  Directory  Pointer to buffer containing directory name
  *  \param [in]  BufferSize Size of directory name character buffer
- *  \param [in]  EventID    Error event ID (command specific)
- *  \param [in]  CmdText    Error event text (command specific)
+ *  \param [in]  EventID    Error event ID (command-specific)
+ *  \param [in]  CmdText    Error event text (command-specific)
  *
  *  \return Boolean directory exists response
  *  \retval true  Directory exists
@@ -275,7 +275,7 @@ bool FM_VerifyFileNotOpen(const char *Filename, uint32 BufferSize, uint32 EventI
  *
  *  \sa #FM_VerifyFileState
  */
-bool FM_VerifyDirExists(const char *Directory, uint32 BufferSize, uint32 EventID, const char *CmdText);
+bool FM_VerifyDirExists(const char *Directory, size_t BufferSize, uint32 EventID, const char *CmdText);
 
 /**
  *  \brief Verify Directory Does Not Exist Function
@@ -288,8 +288,8 @@ bool FM_VerifyDirExists(const char *Directory, uint32 BufferSize, uint32 EventID
  *
  *  \param [in]  Name       Pointer to buffer containing directory name
  *  \param [in]  BufferSize Size of directory name character buffer
- *  \param [in]  EventID    Error event ID (command specific)
- *  \param [in]  CmdText    Error event text (command specific)
+ *  \param [in]  EventID    Error event ID (command-specific)
+ *  \param [in]  CmdText    Error event text (command-specific)
  *
  *  \return Boolean directory does not exist response
  *  \retval true  Directory does not exist
@@ -297,7 +297,7 @@ bool FM_VerifyDirExists(const char *Directory, uint32 BufferSize, uint32 EventID
  *
  *  \sa #FM_VerifyFileState
  */
-bool FM_VerifyDirNoExist(const char *Name, uint32 BufferSize, uint32 EventID, const char *CmdText);
+bool FM_VerifyDirNoExist(const char *Name, size_t BufferSize, uint32 EventID, const char *CmdText);
 
 /**
  *  \brief Verify Child Task Interface Function
@@ -308,8 +308,8 @@ bool FM_VerifyDirNoExist(const char *Name, uint32 BufferSize, uint32 EventID, co
  *
  *  \par Assumptions, External Events, and Notes:
  *
- *  \param [in]  EventID Error event ID (command specific)
- *  \param [in]  CmdText Error event text (command specific)
+ *  \param [in]  EventID Error event ID (command-specific)
+ *  \param [in]  CmdText Error event text (command-specific)
  *
  *  \return Boolean child task queue available response
  *  \retval true  Child task queue available

--- a/unit-test/stubs/fm_cmd_utils_stubs.c
+++ b/unit-test/stubs/fm_cmd_utils_stubs.c
@@ -72,7 +72,7 @@ int32 FM_GetDirectorySpaceEstimate(const char *Directory, uint64 *BlockCount, ui
  * Generated stub function for FM_GetFilenameState()
  * ----------------------------------------------------
  */
-uint32 FM_GetFilenameState(const char *Filename, uint32 BufferSize, bool FileInfoCmd)
+uint32 FM_GetFilenameState(const char *Filename, size_t BufferSize, bool FileInfoCmd)
 {
     UT_GenStub_SetupReturnBuffer(FM_GetFilenameState, uint32);
 
@@ -152,7 +152,7 @@ bool FM_VerifyChildTask(uint32 EventID, const char *CmdText)
  * Generated stub function for FM_VerifyDirExists()
  * ----------------------------------------------------
  */
-bool FM_VerifyDirExists(const char *Directory, uint32 BufferSize, uint32 EventID, const char *CmdText)
+bool FM_VerifyDirExists(const char *Directory, size_t BufferSize, uint32 EventID, const char *CmdText)
 {
     UT_GenStub_SetupReturnBuffer(FM_VerifyDirExists, bool);
 
@@ -171,7 +171,7 @@ bool FM_VerifyDirExists(const char *Directory, uint32 BufferSize, uint32 EventID
  * Generated stub function for FM_VerifyDirNoExist()
  * ----------------------------------------------------
  */
-bool FM_VerifyDirNoExist(const char *Name, uint32 BufferSize, uint32 EventID, const char *CmdText)
+bool FM_VerifyDirNoExist(const char *Name, size_t BufferSize, uint32 EventID, const char *CmdText)
 {
     UT_GenStub_SetupReturnBuffer(FM_VerifyDirNoExist, bool);
 
@@ -190,7 +190,7 @@ bool FM_VerifyDirNoExist(const char *Name, uint32 BufferSize, uint32 EventID, co
  * Generated stub function for FM_VerifyFileClosed()
  * ----------------------------------------------------
  */
-bool FM_VerifyFileClosed(const char *Filename, uint32 BufferSize, uint32 EventID, const char *CmdText)
+bool FM_VerifyFileClosed(const char *Filename, size_t BufferSize, uint32 EventID, const char *CmdText)
 {
     UT_GenStub_SetupReturnBuffer(FM_VerifyFileClosed, bool);
 
@@ -209,7 +209,7 @@ bool FM_VerifyFileClosed(const char *Filename, uint32 BufferSize, uint32 EventID
  * Generated stub function for FM_VerifyFileExists()
  * ----------------------------------------------------
  */
-bool FM_VerifyFileExists(const char *Filename, uint32 BufferSize, uint32 EventID, const char *CmdText)
+bool FM_VerifyFileExists(const char *Filename, size_t BufferSize, uint32 EventID, const char *CmdText)
 {
     UT_GenStub_SetupReturnBuffer(FM_VerifyFileExists, bool);
 
@@ -228,7 +228,7 @@ bool FM_VerifyFileExists(const char *Filename, uint32 BufferSize, uint32 EventID
  * Generated stub function for FM_VerifyFileNoExist()
  * ----------------------------------------------------
  */
-bool FM_VerifyFileNoExist(const char *Filename, uint32 BufferSize, uint32 EventID, const char *CmdText)
+bool FM_VerifyFileNoExist(const char *Filename, size_t BufferSize, uint32 EventID, const char *CmdText)
 {
     UT_GenStub_SetupReturnBuffer(FM_VerifyFileNoExist, bool);
 
@@ -247,7 +247,7 @@ bool FM_VerifyFileNoExist(const char *Filename, uint32 BufferSize, uint32 EventI
  * Generated stub function for FM_VerifyFileNotOpen()
  * ----------------------------------------------------
  */
-bool FM_VerifyFileNotOpen(const char *Filename, uint32 BufferSize, uint32 EventID, const char *CmdText)
+bool FM_VerifyFileNotOpen(const char *Filename, size_t BufferSize, uint32 EventID, const char *CmdText)
 {
     UT_GenStub_SetupReturnBuffer(FM_VerifyFileNotOpen, bool);
 
@@ -266,7 +266,7 @@ bool FM_VerifyFileNotOpen(const char *Filename, uint32 BufferSize, uint32 EventI
  * Generated stub function for FM_VerifyFileState()
  * ----------------------------------------------------
  */
-bool FM_VerifyFileState(FM_File_States State, const char *Filename, uint32 BufferSize, uint32 EventID,
+bool FM_VerifyFileState(FM_File_States State, const char *Filename, size_t BufferSize, uint32 EventID,
                         const char *CmdText)
 {
     UT_GenStub_SetupReturnBuffer(FM_VerifyFileState, bool);
@@ -287,7 +287,7 @@ bool FM_VerifyFileState(FM_File_States State, const char *Filename, uint32 Buffe
  * Generated stub function for FM_VerifyNameValid()
  * ----------------------------------------------------
  */
-uint32 FM_VerifyNameValid(const char *Name, uint32 BufferSize, uint32 EventID, const char *CmdText)
+uint32 FM_VerifyNameValid(const char *Name, size_t BufferSize, uint32 EventID, const char *CmdText)
 {
     UT_GenStub_SetupReturnBuffer(FM_VerifyNameValid, uint32);
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #92 
Easy-to-find size variables converted to `size_t` type.

All except the local variables in `FM_ChildDirListPktCmd()` and `FM_ChildDirListFileLoop()` were already of type `uint32`, so no real risk of signedness issues popping up.

Note: I did not scrub the entire app - if someone can suggest some additional variables to convert over to `size_t` I can add them to this PR.

A few typos and spacing issues cleared up in the same files.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
Variables representing size should use `size_t` where possible - more expressive and more compliant with the various (relevant) coding guidelines.

**Contributor Info**
Avi Weiss @thnkslprpt