### PR TITLE
Fix #89, separate msg size verify

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(APP_SRC_FILES
   fsw/src/fm_app.c
   fsw/src/fm_cmds.c
   fsw/src/fm_child.c
+  fsw/src/fm_dispatch.c
   fsw/src/fm_tbl.c
 )
 

--- a/fsw/src/fm_app.h
+++ b/fsw/src/fm_app.h
@@ -162,34 +162,6 @@ void FM_AppMain(void);
 int32 FM_AppInit(void);
 
 /**
- *  \brief Process Input Command Packets
- *
- *  \par Description
- *
- *       Branch to appropriate input packet handler: HK request or FM commands.
- *
- *  \par Assumptions, External Events, and Notes: None
- *
- *  \param [in] MessagePtr Pointer to Software Bus message buffer.
- *
- *  \sa #FM_SendHkCmd, #FM_ProcessCmd
- */
-void FM_ProcessPkt(const CFE_SB_Buffer_t *MessagePtr);
-
-/**
- *  \brief Process FM Ground Commands
- *
- *  \par Description
- *
- *       Branch to the command specific handlers for FM ground commands.
- *
- *  \par Assumptions, External Events, and Notes: None
- *
- *  \param [in]  BufPtr Pointer to Software Bus message buffer.
- */
-void FM_ProcessCmd(const CFE_SB_Buffer_t *BufPtr);
-
-/**
  *  \brief Housekeeping Request Command Handler
  *
  *  \par Description

--- a/fsw/src/fm_cmd_utils.c
+++ b/fsw/src/fm_cmd_utils.c
@@ -41,32 +41,6 @@ static bool   FileIsOpen    = false;
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* FM utility function -- verify command packet length             */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-bool FM_IsValidCmdPktLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength, uint32 EventID, const char *CmdText)
-{
-    bool   FunctionResult = true;
-    size_t ActualLength   = 0;
-
-    CFE_MSG_GetSize(MsgPtr, &ActualLength);
-
-    /* Verify command packet length */
-    if (ActualLength != ExpectedLength)
-    {
-        FunctionResult = false;
-
-        CFE_EVS_SendEvent(EventID, CFE_EVS_EventType_ERROR,
-                          "%s error: invalid command packet length: expected = %d, actual = %d", CmdText,
-                          (int)ExpectedLength, (int)ActualLength);
-    }
-
-    return FunctionResult;
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
 /* FM utility function -- verify state is not invalid              */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/fm_cmd_utils.h
+++ b/fsw/src/fm_cmd_utils.h
@@ -52,27 +52,6 @@ typedef enum
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /**
- *  \brief Verify Command Packet Length Function
- *
- *  \par Description
- *       This function is invoked from each of the command handlers to verify the
- *       length of the command packet.
- *
- *  \par Assumptions, External Events, and Notes:
- *
- *  \param [in]  MsgPtr         Pointer to Message
- *  \param [in]  ExpectedLength Expected packet length (command specific)
- *  \param [in]  EventID        Error event ID (command specific)
- *  \param [in]  CmdText        Error event text (command specific)
- *
- *  \return Boolean valid packet length response
- *  \retval true  Packet length valid
- *  \retval false Packet length invalid
- */
-bool FM_IsValidCmdPktLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength, uint32 EventID,
-                            const char *CmdText);
-
-/**
  *  \brief Verify Target File Overwrite Function
  *
  *  \par Description

--- a/fsw/src/fm_cmds.c
+++ b/fsw/src/fm_cmds.c
@@ -55,20 +55,12 @@
 
 bool FM_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    const char *CmdText       = "No-op";
-    bool        CommandResult = false;
+    const char *CmdText = "No-op";
 
-    /* Verify message length */
-    CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_NoopCmd_t), FM_NOOP_PKT_ERR_EID, CmdText);
+    CFE_EVS_SendEvent(FM_NOOP_CMD_EID, CFE_EVS_EventType_INFORMATION, "%s command: FM version %d.%d.%d.%d", CmdText,
+                      FM_MAJOR_VERSION, FM_MINOR_VERSION, FM_REVISION, FM_MISSION_REV);
 
-    /* Send command completion event (info) */
-    if (CommandResult == true)
-    {
-        CFE_EVS_SendEvent(FM_NOOP_CMD_EID, CFE_EVS_EventType_INFORMATION, "%s command: FM version %d.%d.%d.%d", CmdText,
-                          FM_MAJOR_VERSION, FM_MINOR_VERSION, FM_REVISION, FM_MISSION_REV);
-    }
-
-    return CommandResult;
+    return true;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -79,27 +71,19 @@ bool FM_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    const char *CmdText       = "Reset Counters";
-    bool        CommandResult = false;
+    const char *CmdText = "Reset Counters";
 
-    /* Verify message length */
-    CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_ResetCountersCmd_t), FM_RESET_PKT_ERR_EID, CmdText);
+    FM_GlobalData.CommandCounter    = 0;
+    FM_GlobalData.CommandErrCounter = 0;
 
-    /* Reset command counters */
-    if (CommandResult == true)
-    {
-        FM_GlobalData.CommandCounter    = 0;
-        FM_GlobalData.CommandErrCounter = 0;
+    FM_GlobalData.ChildCmdCounter     = 0;
+    FM_GlobalData.ChildCmdErrCounter  = 0;
+    FM_GlobalData.ChildCmdWarnCounter = 0;
 
-        FM_GlobalData.ChildCmdCounter     = 0;
-        FM_GlobalData.ChildCmdErrCounter  = 0;
-        FM_GlobalData.ChildCmdWarnCounter = 0;
+    /* Send command completion event (debug) */
+    CFE_EVS_SendEvent(FM_RESET_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command", CmdText);
 
-        /* Send command completion event (debug) */
-        CFE_EVS_SendEvent(FM_RESET_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command", CmdText);
-    }
-
-    return CommandResult;
+    return true;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -110,20 +94,14 @@ bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_CopyFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    FM_ChildQueueEntry_t *CmdArgs       = NULL;
-    const char *          CmdText       = "Copy File";
-    bool                  CommandResult = false;
+    FM_ChildQueueEntry_t *CmdArgs = NULL;
+    const char *          CmdText = "Copy File";
+    bool                  CommandResult;
 
     const FM_OvwSourceTargetFilename_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_CopyFileCmd_t);
 
-    /* Verify command packet length */
-    CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_CopyFileCmd_t), FM_COPY_PKT_ERR_EID, CmdText);
-
     /* Verify that overwrite argument is valid */
-    if (CommandResult == true)
-    {
-        CommandResult = FM_VerifyOverwrite(CmdPtr->Overwrite, FM_COPY_OVR_ERR_EID, CmdText);
-    }
+    CommandResult = FM_VerifyOverwrite(CmdPtr->Overwrite, FM_COPY_OVR_ERR_EID, CmdText);
 
     /* Verify that source file exists and is not a directory */
     if (CommandResult == true)
@@ -178,20 +156,14 @@ bool FM_CopyFileCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_MoveFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    FM_ChildQueueEntry_t *CmdArgs       = NULL;
-    const char *          CmdText       = "Move File";
-    bool                  CommandResult = false;
+    FM_ChildQueueEntry_t *CmdArgs = NULL;
+    const char *          CmdText = "Move File";
+    bool                  CommandResult;
 
     const FM_OvwSourceTargetFilename_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_MoveFileCmd_t);
 
-    /* Verify command packet length */
-    CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_MoveFileCmd_t), FM_MOVE_PKT_ERR_EID, CmdText);
-
     /* Verify that overwrite argument is valid */
-    if (CommandResult == true)
-    {
-        CommandResult = FM_VerifyOverwrite(CmdPtr->Overwrite, FM_MOVE_OVR_ERR_EID, CmdText);
-    }
+    CommandResult = FM_VerifyOverwrite(CmdPtr->Overwrite, FM_MOVE_OVR_ERR_EID, CmdText);
 
     /* Verify that source file exists and not a directory */
     if (CommandResult == true)
@@ -247,20 +219,14 @@ bool FM_MoveFileCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_RenameFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    FM_ChildQueueEntry_t *CmdArgs       = NULL;
-    const char *          CmdText       = "Rename File";
-    bool                  CommandResult = false;
+    FM_ChildQueueEntry_t *CmdArgs = NULL;
+    const char *          CmdText = "Rename File";
+    bool                  CommandResult;
 
     const FM_SourceTargetFileName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_RenameFileCmd_t);
 
-    /* Verify command packet length */
-    CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_RenameFileCmd_t), FM_RENAME_PKT_ERR_EID, CmdText);
-
     /* Verify that source file exists and is not a directory */
-    if (CommandResult == true)
-    {
-        CommandResult = FM_VerifyFileExists(CmdPtr->Source, sizeof(CmdPtr->Source), FM_RENAME_SRC_BASE_EID, CmdText);
-    }
+    CommandResult = FM_VerifyFileExists(CmdPtr->Source, sizeof(CmdPtr->Source), FM_RENAME_SRC_BASE_EID, CmdText);
 
     /* Verify that target file does not exist */
     if (CommandResult == true)
@@ -303,21 +269,14 @@ bool FM_RenameFileCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_DeleteFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    FM_ChildQueueEntry_t *CmdArgs       = NULL;
-    const char *          CmdText       = "Delete File";
-    bool                  CommandResult = false;
+    FM_ChildQueueEntry_t *CmdArgs = NULL;
+    const char *          CmdText = "Delete File";
+    bool                  CommandResult;
 
     const FM_SingleFilename_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_DeleteFileCmd_t);
 
-    /* Verify command packet length */
-    CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DeleteFileCmd_t), FM_DELETE_PKT_ERR_EID, CmdText);
-
     /* Verify that file exists, is not a directory and is not open */
-    if (CommandResult == true)
-    {
-        CommandResult =
-            FM_VerifyFileClosed(CmdPtr->Filename, sizeof(CmdPtr->Filename), FM_DELETE_SRC_BASE_EID, CmdText);
-    }
+    CommandResult = FM_VerifyFileClosed(CmdPtr->Filename, sizeof(CmdPtr->Filename), FM_DELETE_SRC_BASE_EID, CmdText);
 
     /* Check for lower priority child task availability */
     if (CommandResult == true)
@@ -353,20 +312,13 @@ bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr)
     const char *          CmdText                     = "Delete All Files";
     char                  DirWithSep[OS_MAX_PATH_LEN] = "\0";
     FM_ChildQueueEntry_t *CmdArgs                     = NULL;
-    bool                  CommandResult               = false;
+    bool                  CommandResult;
 
     const FM_DirectoryName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_DeleteAllFilesCmd_t);
 
-    /* Verify message length */
-    CommandResult =
-        FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DeleteAllFilesCmd_t), FM_DELETE_ALL_PKT_ERR_EID, CmdText);
-
     /* Verify that the directory exists */
-    if (CommandResult == true)
-    {
-        CommandResult =
-            FM_VerifyDirExists(CmdPtr->Directory, sizeof(CmdPtr->Directory), FM_DELETE_ALL_SRC_BASE_EID, CmdText);
-    }
+    CommandResult =
+        FM_VerifyDirExists(CmdPtr->Directory, sizeof(CmdPtr->Directory), FM_DELETE_ALL_SRC_BASE_EID, CmdText);
 
     if (CommandResult == true)
     {
@@ -407,20 +359,14 @@ bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    const char *          CmdText       = "Decompress File";
-    FM_ChildQueueEntry_t *CmdArgs       = NULL;
-    bool                  CommandResult = false;
+    const char *          CmdText = "Decompress File";
+    FM_ChildQueueEntry_t *CmdArgs = NULL;
+    bool                  CommandResult;
 
     const FM_SourceTargetFileName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_DecompressFileCmd_t);
 
-    /* Verify command packet length */
-    CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DecompressFileCmd_t), FM_DECOM_PKT_ERR_EID, CmdText);
-
     /* Verify that source file exists, is not a directory and is not open */
-    if (CommandResult == true)
-    {
-        CommandResult = FM_VerifyFileClosed(CmdPtr->Source, sizeof(CmdPtr->Source), FM_DECOM_SRC_BASE_EID, CmdText);
-    }
+    CommandResult = FM_VerifyFileClosed(CmdPtr->Source, sizeof(CmdPtr->Source), FM_DECOM_SRC_BASE_EID, CmdText);
 
     /* Verify that target file does not exist */
     if (CommandResult == true)
@@ -461,20 +407,14 @@ bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_ConcatFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    const char *          CmdText       = "Concat Files";
-    FM_ChildQueueEntry_t *CmdArgs       = NULL;
-    bool                  CommandResult = false;
+    const char *          CmdText = "Concat Files";
+    FM_ChildQueueEntry_t *CmdArgs = NULL;
+    bool                  CommandResult;
 
     const FM_TwoSourceOneTarget_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_ConcatFilesCmd_t);
 
-    /* Verify command packet length */
-    CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_ConcatFilesCmd_t), FM_CONCAT_PKT_ERR_EID, CmdText);
-
     /* Verify that source file #1 exists, is not a directory and is not open */
-    if (CommandResult == true)
-    {
-        CommandResult = FM_VerifyFileClosed(CmdPtr->Source1, sizeof(CmdPtr->Source1), FM_CONCAT_SRC1_BASE_EID, CmdText);
-    }
+    CommandResult = FM_VerifyFileClosed(CmdPtr->Source1, sizeof(CmdPtr->Source1), FM_CONCAT_SRC1_BASE_EID, CmdText);
 
     /* Verify that source file #2 exists, is not a directory and is not open */
     if (CommandResult == true)
@@ -525,25 +465,18 @@ bool FM_GetFileInfoCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     const char *          CmdText       = "Get File Info";
     FM_ChildQueueEntry_t *CmdArgs       = NULL;
-    bool                  CommandResult = false;
+    bool                  CommandResult = true;
     uint32                FilenameState = FM_NAME_IS_INVALID;
 
     const FM_FilenameAndCRC_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_GetFileInfoCmd_t);
 
-    /* Verify command packet length */
-    CommandResult =
-        FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_GetFileInfoCmd_t), FM_GET_FILE_INFO_PKT_ERR_EID, CmdText);
-
     /* Verify that the source name is valid for a file or directory */
-    if (CommandResult == true)
-    {
-        FilenameState =
-            FM_VerifyNameValid(CmdPtr->Filename, sizeof(CmdPtr->Filename), FM_GET_FILE_INFO_SRC_ERR_EID, CmdText);
+    FilenameState =
+        FM_VerifyNameValid(CmdPtr->Filename, sizeof(CmdPtr->Filename), FM_GET_FILE_INFO_SRC_ERR_EID, CmdText);
 
-        if (FilenameState == FM_NAME_IS_INVALID)
-        {
-            CommandResult = false;
-        }
+    if (FilenameState == FM_NAME_IS_INVALID)
+    {
+        CommandResult = false;
     }
 
     /* Check for lower priority child task availability */
@@ -585,35 +518,28 @@ bool FM_GetFileInfoCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    const char *CmdText       = "Get Open Files";
-    bool        CommandResult = false;
-    uint32      NumOpenFiles  = 0;
+    const char *CmdText      = "Get Open Files";
+    uint32      NumOpenFiles = 0;
 
     FM_OpenFilesPkt_Payload_t *ReportPtr = &FM_GlobalData.OpenFilesPkt.Payload;
 
-    /* Verify command packet length */
-    CommandResult =
-        FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_GetOpenFilesCmd_t), FM_GET_OPEN_FILES_PKT_ERR_EID, CmdText);
-    if (CommandResult == true)
-    {
-        /* Initialize open files telemetry packet */
-        CFE_MSG_Init(CFE_MSG_PTR(FM_GlobalData.OpenFilesPkt.TelemetryHeader),
-                     CFE_SB_ValueToMsgId(FM_OPEN_FILES_TLM_MID), sizeof(FM_OpenFilesPkt_t));
+    /* Initialize open files telemetry packet */
+    CFE_MSG_Init(CFE_MSG_PTR(FM_GlobalData.OpenFilesPkt.TelemetryHeader), CFE_SB_ValueToMsgId(FM_OPEN_FILES_TLM_MID),
+                 sizeof(FM_OpenFilesPkt_t));
 
-        /* Get list of open files and count */
-        NumOpenFiles = FM_GetOpenFilesData(ReportPtr->OpenFilesList);
+    /* Get list of open files and count */
+    NumOpenFiles = FM_GetOpenFilesData(ReportPtr->OpenFilesList);
 
-        ReportPtr->NumOpenFiles = NumOpenFiles;
+    ReportPtr->NumOpenFiles = NumOpenFiles;
 
-        /* Timestamp and send open files telemetry packet */
-        CFE_SB_TimeStampMsg(CFE_MSG_PTR(FM_GlobalData.OpenFilesPkt.TelemetryHeader));
-        CFE_SB_TransmitMsg(CFE_MSG_PTR(FM_GlobalData.OpenFilesPkt.TelemetryHeader), true);
+    /* Timestamp and send open files telemetry packet */
+    CFE_SB_TimeStampMsg(CFE_MSG_PTR(FM_GlobalData.OpenFilesPkt.TelemetryHeader));
+    CFE_SB_TransmitMsg(CFE_MSG_PTR(FM_GlobalData.OpenFilesPkt.TelemetryHeader), true);
 
-        /* Send command completion event (debug) */
-        CFE_EVS_SendEvent(FM_GET_OPEN_FILES_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command", CmdText);
-    }
+    /* Send command completion event (debug) */
+    CFE_EVS_SendEvent(FM_GET_OPEN_FILES_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command", CmdText);
 
-    return CommandResult;
+    return true;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -624,22 +550,15 @@ bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_CreateDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    FM_ChildQueueEntry_t *CmdArgs       = NULL;
-    const char *          CmdText       = "Create Directory";
-    bool                  CommandResult = false;
+    FM_ChildQueueEntry_t *CmdArgs = NULL;
+    const char *          CmdText = "Create Directory";
+    bool                  CommandResult;
 
     const FM_DirectoryName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_CreateDirectoryCmd_t);
 
-    /* Verify command packet length */
-    CommandResult =
-        FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_CreateDirectoryCmd_t), FM_CREATE_DIR_PKT_ERR_EID, CmdText);
-
     /* Verify that the directory name is not already in use */
-    if (CommandResult == true)
-    {
-        CommandResult =
-            FM_VerifyDirNoExist(CmdPtr->Directory, sizeof(CmdPtr->Directory), FM_CREATE_DIR_SRC_BASE_EID, CmdText);
-    }
+    CommandResult =
+        FM_VerifyDirNoExist(CmdPtr->Directory, sizeof(CmdPtr->Directory), FM_CREATE_DIR_SRC_BASE_EID, CmdText);
 
     /* Check for lower priority child task availability */
     if (CommandResult == true)
@@ -672,22 +591,15 @@ bool FM_CreateDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
 
 bool FM_DeleteDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    FM_ChildQueueEntry_t *CmdArgs       = NULL;
-    const char *          CmdText       = "Delete Directory";
-    bool                  CommandResult = false;
+    FM_ChildQueueEntry_t *CmdArgs = NULL;
+    const char *          CmdText = "Delete Directory";
+    bool                  CommandResult;
 
     const FM_DirectoryName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_DeleteDirectoryCmd_t);
 
-    /* Verify command packet length */
-    CommandResult =
-        FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DeleteDirectoryCmd_t), FM_DELETE_DIR_PKT_ERR_EID, CmdText);
-
     /* Verify that the directory exists */
-    if (CommandResult == true)
-    {
-        CommandResult =
-            FM_VerifyDirExists(CmdPtr->Directory, sizeof(CmdPtr->Directory), FM_DELETE_DIR_SRC_BASE_EID, CmdText);
-    }
+    CommandResult =
+        FM_VerifyDirExists(CmdPtr->Directory, sizeof(CmdPtr->Directory), FM_DELETE_DIR_SRC_BASE_EID, CmdText);
 
     /* Check for lower priority child task availability */
     if (CommandResult == true)
@@ -724,20 +636,13 @@ bool FM_GetDirListFileCmd(const CFE_SB_Buffer_t *BufPtr)
     char                  DirWithSep[OS_MAX_PATH_LEN] = "\0";
     char                  Filename[OS_MAX_PATH_LEN]   = "\0";
     FM_ChildQueueEntry_t *CmdArgs                     = NULL;
-    bool                  CommandResult               = false;
+    bool                  CommandResult;
 
     const FM_GetDirectoryToFile_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_GetDirListFileCmd_t);
 
-    /* Verify command packet length */
-    CommandResult =
-        FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_GetDirListFileCmd_t), FM_GET_DIR_FILE_PKT_ERR_EID, CmdText);
-
     /* Verify that source directory exists */
-    if (CommandResult == true)
-    {
-        CommandResult =
-            FM_VerifyDirExists(CmdPtr->Directory, sizeof(CmdPtr->Directory), FM_GET_DIR_FILE_SRC_BASE_EID, CmdText);
-    }
+    CommandResult =
+        FM_VerifyDirExists(CmdPtr->Directory, sizeof(CmdPtr->Directory), FM_GET_DIR_FILE_SRC_BASE_EID, CmdText);
 
     /* Verify that target file is not already open */
     if (CommandResult == true)
@@ -803,20 +708,13 @@ bool FM_GetDirListPktCmd(const CFE_SB_Buffer_t *BufPtr)
     const char *          CmdText                     = "Directory List to Packet";
     char                  DirWithSep[OS_MAX_PATH_LEN] = "\0";
     FM_ChildQueueEntry_t *CmdArgs                     = NULL;
-    bool                  CommandResult               = false;
+    bool                  CommandResult;
 
     const FM_GetDirectoryToPkt_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_GetDirListPktCmd_t);
 
-    /* Verify command packet length */
-    CommandResult =
-        FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_GetDirListPktCmd_t), FM_GET_DIR_PKT_PKT_ERR_EID, CmdText);
-
     /* Verify that source directory exists */
-    if (CommandResult == true)
-    {
-        CommandResult =
-            FM_VerifyDirExists(CmdPtr->Directory, sizeof(CmdPtr->Directory), FM_GET_DIR_PKT_SRC_BASE_EID, CmdText);
-    }
+    CommandResult =
+        FM_VerifyDirExists(CmdPtr->Directory, sizeof(CmdPtr->Directory), FM_GET_DIR_PKT_SRC_BASE_EID, CmdText);
 
     /* Check for lower priority child task availability */
     if (CommandResult == true)
@@ -860,86 +758,80 @@ bool FM_GetDirListPktCmd(const CFE_SB_Buffer_t *BufPtr)
 bool FM_MonitorFilesystemSpaceCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     const char *CmdText       = "Get Free Space";
-    bool        CommandResult = false;
+    bool        CommandResult = true;
     uint32      i             = 0;
     int32       OpResult;
 
     const FM_MonitorTableEntry_t *MonitorPtr;
     FM_MonitorReportEntry_t *     ReportPtr;
 
-    /* Verify command packet length */
-    CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_MonitorFilesystemSpaceCmd_t),
-                                           FM_GET_FREE_SPACE_PKT_ERR_EID, CmdText);
-    if (CommandResult == true)
+    /* Verify that we have a pointer to the file system table data */
+    if (FM_GlobalData.MonitorTablePtr == NULL)
     {
-        /* Verify that we have a pointer to the file system table data */
-        if (FM_GlobalData.MonitorTablePtr == NULL)
-        {
-            CommandResult = false;
+        CommandResult = false;
 
-            CFE_EVS_SendEvent(FM_GET_FREE_SPACE_TBL_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "%s error: file system free space table is not loaded", CmdText);
-        }
-        else
-        {
-            /* Initialize the file system free space telemetry packet */
-            CFE_MSG_Init(CFE_MSG_PTR(FM_GlobalData.MonitorReportPkt.TelemetryHeader),
-                         CFE_SB_ValueToMsgId(FM_FREE_SPACE_TLM_MID), sizeof(FM_MonitorReportPkt_t));
+        CFE_EVS_SendEvent(FM_GET_FREE_SPACE_TBL_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "%s error: file system free space table is not loaded", CmdText);
+    }
+    else
+    {
+        /* Initialize the file system free space telemetry packet */
+        CFE_MSG_Init(CFE_MSG_PTR(FM_GlobalData.MonitorReportPkt.TelemetryHeader),
+                     CFE_SB_ValueToMsgId(FM_FREE_SPACE_TLM_MID), sizeof(FM_MonitorReportPkt_t));
 
-            /* Process enabled file system table entries */
-            MonitorPtr = FM_GlobalData.MonitorTablePtr->Entries;
-            ReportPtr  = FM_GlobalData.MonitorReportPkt.Payload.FileSys;
-            for (i = 0; i < FM_TABLE_ENTRY_COUNT; i++)
+        /* Process enabled file system table entries */
+        MonitorPtr = FM_GlobalData.MonitorTablePtr->Entries;
+        ReportPtr  = FM_GlobalData.MonitorReportPkt.Payload.FileSys;
+        for (i = 0; i < FM_TABLE_ENTRY_COUNT; i++)
+        {
+            if (MonitorPtr->Type != FM_MonitorTableEntry_Type_UNUSED)
             {
-                if (MonitorPtr->Type != FM_MonitorTableEntry_Type_UNUSED)
+                CFE_SB_MessageStringSet(ReportPtr->Name, MonitorPtr->Name, sizeof(ReportPtr->Name),
+                                        sizeof(MonitorPtr->Name));
+                ReportPtr->ReportType = MonitorPtr->Type;
+
+                /* Pre-initialize to 0, will be overwritten with real value if successful */
+                ReportPtr->Blocks = 0;
+                ReportPtr->Bytes  = 0;
+
+                if (MonitorPtr->Enabled)
                 {
-                    CFE_SB_MessageStringSet(ReportPtr->Name, MonitorPtr->Name, sizeof(ReportPtr->Name),
-                                            sizeof(MonitorPtr->Name));
-                    ReportPtr->ReportType = MonitorPtr->Type;
-
-                    /* Pre-initialize to 0, will be overwritten with real value if successful */
-                    ReportPtr->Blocks = 0;
-                    ReportPtr->Bytes  = 0;
-
-                    if (MonitorPtr->Enabled)
+                    if (MonitorPtr->Type == FM_MonitorTableEntry_Type_VOLUME_FREE_SPACE)
                     {
-                        if (MonitorPtr->Type == FM_MonitorTableEntry_Type_VOLUME_FREE_SPACE)
-                        {
-                            OpResult = FM_GetVolumeFreeSpace(MonitorPtr->Name, &ReportPtr->Blocks, &ReportPtr->Bytes);
-                        }
-                        else if (MonitorPtr->Type == FM_MonitorTableEntry_Type_DIRECTORY_ESTIMATE)
-                        {
-                            OpResult =
-                                FM_GetDirectorySpaceEstimate(MonitorPtr->Name, &ReportPtr->Blocks, &ReportPtr->Bytes);
-                        }
-                        else
-                        {
-                            OpResult = CFE_STATUS_NOT_IMPLEMENTED;
-                        }
+                        OpResult = FM_GetVolumeFreeSpace(MonitorPtr->Name, &ReportPtr->Blocks, &ReportPtr->Bytes);
+                    }
+                    else if (MonitorPtr->Type == FM_MonitorTableEntry_Type_DIRECTORY_ESTIMATE)
+                    {
+                        OpResult =
+                            FM_GetDirectorySpaceEstimate(MonitorPtr->Name, &ReportPtr->Blocks, &ReportPtr->Bytes);
+                    }
+                    else
+                    {
+                        OpResult = CFE_STATUS_NOT_IMPLEMENTED;
+                    }
 
-                        if (OpResult != CFE_SUCCESS)
-                        {
-                            CommandResult = false;
-                        }
+                    if (OpResult != CFE_SUCCESS)
+                    {
+                        CommandResult = false;
                     }
                 }
-                else
-                {
-                    /* Make sure this entry is all clear */
-                    memset(ReportPtr, 0, sizeof(*ReportPtr));
-                }
-
-                ++MonitorPtr;
-                ++ReportPtr;
+            }
+            else
+            {
+                /* Make sure this entry is all clear */
+                memset(ReportPtr, 0, sizeof(*ReportPtr));
             }
 
-            /* Timestamp and send file system free space telemetry packet */
-            CFE_SB_TimeStampMsg(CFE_MSG_PTR(FM_GlobalData.MonitorReportPkt.TelemetryHeader));
-            CFE_SB_TransmitMsg(CFE_MSG_PTR(FM_GlobalData.MonitorReportPkt.TelemetryHeader), true);
-
-            /* Send command completion event (debug) */
-            CFE_EVS_SendEvent(FM_MONITOR_FILESYSTEM_SPACE_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command", CmdText);
+            ++MonitorPtr;
+            ++ReportPtr;
         }
+
+        /* Timestamp and send file system free space telemetry packet */
+        CFE_SB_TimeStampMsg(CFE_MSG_PTR(FM_GlobalData.MonitorReportPkt.TelemetryHeader));
+        CFE_SB_TransmitMsg(CFE_MSG_PTR(FM_GlobalData.MonitorReportPkt.TelemetryHeader), true);
+
+        /* Send command completion event (debug) */
+        CFE_EVS_SendEvent(FM_MONITOR_FILESYSTEM_SPACE_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command", CmdText);
     }
 
     return CommandResult;
@@ -954,63 +846,56 @@ bool FM_MonitorFilesystemSpaceCmd(const CFE_SB_Buffer_t *BufPtr)
 bool FM_SetTableStateCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     const char *CmdText       = "Set Table State";
-    bool        CommandResult = false;
+    bool        CommandResult = true;
 
     const FM_TableIndexAndState_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_SetTableStateCmd_t);
 
-    /* Verify command packet length */
-    CommandResult =
-        FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_SetTableStateCmd_t), FM_SET_TABLE_STATE_PKT_ERR_EID, CmdText);
-    if (CommandResult == true)
+    if (FM_GlobalData.MonitorTablePtr == NULL)
     {
-        if (FM_GlobalData.MonitorTablePtr == NULL)
-        {
-            /* File system table has not been loaded */
-            CommandResult = false;
+        /* File system table has not been loaded */
+        CommandResult = false;
 
-            CFE_EVS_SendEvent(FM_SET_TABLE_STATE_TBL_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "%s error: file system free space table is not loaded", CmdText);
-        }
-        else if (CmdPtr->TableEntryIndex >= FM_TABLE_ENTRY_COUNT)
-        {
-            /* Table index argument is out of range */
-            CommandResult = false;
+        CFE_EVS_SendEvent(FM_SET_TABLE_STATE_TBL_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "%s error: file system free space table is not loaded", CmdText);
+    }
+    else if (CmdPtr->TableEntryIndex >= FM_TABLE_ENTRY_COUNT)
+    {
+        /* Table index argument is out of range */
+        CommandResult = false;
 
-            CFE_EVS_SendEvent(FM_SET_TABLE_STATE_ARG_IDX_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "%s error: invalid command argument: index = %d", CmdText, (int)CmdPtr->TableEntryIndex);
-        }
-        else if ((CmdPtr->TableEntryState != FM_TABLE_ENTRY_ENABLED) &&
-                 (CmdPtr->TableEntryState != FM_TABLE_ENTRY_DISABLED))
-        {
-            /* State argument must be either enabled or disabled */
-            CommandResult = false;
+        CFE_EVS_SendEvent(FM_SET_TABLE_STATE_ARG_IDX_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "%s error: invalid command argument: index = %d", CmdText, (int)CmdPtr->TableEntryIndex);
+    }
+    else if ((CmdPtr->TableEntryState != FM_TABLE_ENTRY_ENABLED) &&
+             (CmdPtr->TableEntryState != FM_TABLE_ENTRY_DISABLED))
+    {
+        /* State argument must be either enabled or disabled */
+        CommandResult = false;
 
-            CFE_EVS_SendEvent(FM_SET_TABLE_STATE_ARG_STATE_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "%s error: invalid command argument: state = %d", CmdText, (int)CmdPtr->TableEntryState);
-        }
-        else if (FM_GlobalData.MonitorTablePtr->Entries[CmdPtr->TableEntryIndex].Type ==
-                 FM_MonitorTableEntry_Type_UNUSED)
-        {
-            /* Current table entry state must not be unused */
-            CommandResult = false;
+        CFE_EVS_SendEvent(FM_SET_TABLE_STATE_ARG_STATE_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "%s error: invalid command argument: state = %d", CmdText, (int)CmdPtr->TableEntryState);
+    }
+    else if (FM_GlobalData.MonitorTablePtr->Entries[CmdPtr->TableEntryIndex].Type == FM_MonitorTableEntry_Type_UNUSED)
+    {
+        /* Current table entry state must not be unused */
+        CommandResult = false;
 
-            CFE_EVS_SendEvent(FM_SET_TABLE_STATE_UNUSED_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "%s error: cannot modify unused table entry: index = %d", CmdText,
-                              (int)CmdPtr->TableEntryIndex);
-        }
-        else
-        {
-            /* Update the table entry state as commanded */
-            FM_GlobalData.MonitorTablePtr->Entries[CmdPtr->TableEntryIndex].Enabled = CmdPtr->TableEntryState;
+        CFE_EVS_SendEvent(FM_SET_TABLE_STATE_UNUSED_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "%s error: cannot modify unused table entry: index = %d", CmdText,
+                          (int)CmdPtr->TableEntryIndex);
+    }
+    else
+    {
+        /* Update the table entry state as commanded */
+        FM_GlobalData.MonitorTablePtr->Entries[CmdPtr->TableEntryIndex].Enabled = CmdPtr->TableEntryState;
 
-            /* Notify cFE that we have modified the table data */
-            CFE_TBL_Modified(FM_GlobalData.MonitorTableHandle);
+        /* Notify cFE that we have modified the table data */
+        CFE_TBL_Modified(FM_GlobalData.MonitorTableHandle);
 
-            /* Send command completion event (info) */
-            CFE_EVS_SendEvent(FM_SET_TABLE_STATE_CMD_EID, CFE_EVS_EventType_INFORMATION,
-                              "%s command: index = %d, state = %d", CmdText, (int)CmdPtr->TableEntryIndex,
-                              (int)CmdPtr->TableEntryState);
-        }
+        /* Send command completion event (info) */
+        CFE_EVS_SendEvent(FM_SET_TABLE_STATE_CMD_EID, CFE_EVS_EventType_INFORMATION,
+                          "%s command: index = %d, state = %d", CmdText, (int)CmdPtr->TableEntryIndex,
+                          (int)CmdPtr->TableEntryState);
     }
 
     return CommandResult;
@@ -1026,22 +911,16 @@ bool FM_SetPermissionsCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     FM_ChildQueueEntry_t *CmdArgs       = NULL;
     const char *          CmdText       = "Set Permissions";
-    bool                  CommandResult = false;
+    bool                  CommandResult = true;
     bool                  FilenameState = FM_NAME_IS_INVALID;
 
     const FM_FilenameAndMode_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_SetPermissionsCmd_t);
 
-    /* Verify command packet length */
-    CommandResult = FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_SetPermissionsCmd_t), FM_SET_PERM_ERR_EID, CmdText);
+    FilenameState = FM_VerifyNameValid(CmdPtr->FileName, sizeof(CmdPtr->FileName), 0, CmdText);
 
-    if (CommandResult == true)
+    if (FilenameState == FM_NAME_IS_INVALID)
     {
-        FilenameState = FM_VerifyNameValid(CmdPtr->FileName, sizeof(CmdPtr->FileName), 0, CmdText);
-
-        if (FilenameState == FM_NAME_IS_INVALID)
-        {
-            CommandResult = false;
-        }
+        CommandResult = false;
     }
 
     /* Check for lower priority child task availability */

--- a/fsw/src/fm_dispatch.c
+++ b/fsw/src/fm_dispatch.c
@@ -1,0 +1,540 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,918-1, and identified as “Core Flight
+ * Software System (cFS) File Manager Application Version 2.6.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *  Core Flight System (CFS) File Manager (FM) Application
+ *
+ *  The File Manager (FM) Application provides onboard file system
+ *  management services by processing commands for copying and moving
+ *  files, decompressing files, concatenating files, creating directories,
+ *  deleting files and directories, and providing file and directory status.
+ *  When the File Manager application receives a housekeeping request
+ *  (scheduled within the scheduler application), FM  reports it's housekeeping
+ *  status values via telemetry messaging.
+ */
+
+#include "fm_dispatch.h"
+#include "fm_msg.h"
+#include "fm_msgdefs.h"
+#include "fm_msgids.h"
+#include "fm_events.h"
+#include "fm_cmds.h"
+#include "fm_app.h"
+
+#include "cfe.h"
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM utility function -- verify command packet length             */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+bool FM_IsValidCmdPktLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength, uint32 EventID, const char *CmdText)
+{
+    bool   FunctionResult = true;
+    size_t ActualLength   = 0;
+
+    CFE_MSG_GetSize(MsgPtr, &ActualLength);
+
+    /* Verify command packet length */
+    if (ActualLength != ExpectedLength)
+    {
+        FunctionResult = false;
+
+        CFE_EVS_SendEvent(EventID, CFE_EVS_EventType_ERROR,
+                          "%s error: invalid command packet length: expected = %d, actual = %d", CmdText,
+                          (int)ExpectedLength, (int)ActualLength);
+    }
+
+    return FunctionResult;
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM command handler -- NOOP                                      */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+bool FM_NoopVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    /* Verify message length */
+    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_NoopCmd_t), FM_NOOP_PKT_ERR_EID, "No-op"))
+    {
+        return false;
+    }
+
+    return FM_NoopCmd(BufPtr);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM command handler -- Reset Counters                            */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+bool FM_ResetCountersVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    /* Verify message length */
+    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_ResetCountersCmd_t), FM_RESET_PKT_ERR_EID, "Reset Counters"))
+    {
+        return false;
+    }
+
+    return FM_ResetCountersCmd(BufPtr);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM command handler -- Copy File                                 */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+bool FM_CopyFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    /* Verify command packet length */
+    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_CopyFileCmd_t), FM_COPY_PKT_ERR_EID, "Copy File"))
+    {
+        return false;
+    }
+
+    return FM_CopyFileCmd(BufPtr);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM command handler -- Move File                                 */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+bool FM_MoveFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    /* Verify command packet length */
+    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_MoveFileCmd_t), FM_MOVE_PKT_ERR_EID, "Move File"))
+    {
+        return false;
+    }
+
+    return FM_MoveFileCmd(BufPtr);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM command handler -- Rename File                               */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+bool FM_RenameFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    /* Verify command packet length */
+    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_RenameFileCmd_t), FM_RENAME_PKT_ERR_EID, "Rename File"))
+    {
+        return false;
+    }
+
+    return FM_RenameFileCmd(BufPtr);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM command handler -- Delete File                               */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+bool FM_DeleteFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    /* Verify command packet length */
+    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DeleteFileCmd_t), FM_DELETE_PKT_ERR_EID, "Delete File"))
+    {
+        return false;
+    }
+
+    return FM_DeleteFileCmd(BufPtr);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM command handler -- Delete All Files                          */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+bool FM_DeleteAllFilesVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    /* Verify message length */
+    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DeleteAllFilesCmd_t), FM_DELETE_ALL_PKT_ERR_EID,
+                                "Delete All Files"))
+    {
+        return false;
+    }
+
+    return FM_DeleteAllFilesCmd(BufPtr);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM command handler -- Decompress File                           */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+bool FM_DecompressFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    /* Verify command packet length */
+    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DecompressFileCmd_t), FM_DECOM_PKT_ERR_EID, "Decompress File"))
+    {
+        return false;
+    }
+
+    return FM_DecompressFileCmd(BufPtr);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM command handler -- Concatenate Files                         */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+bool FM_ConcatFilesVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    /* Verify command packet length */
+    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_ConcatFilesCmd_t), FM_CONCAT_PKT_ERR_EID, "Concat Files"))
+    {
+        return false;
+    }
+
+    return FM_ConcatFilesCmd(BufPtr);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM command handler -- Get File Info                             */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+bool FM_GetFileInfoVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    /* Verify command packet length */
+    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_GetFileInfoCmd_t), FM_GET_FILE_INFO_PKT_ERR_EID,
+                                "Get File Info"))
+    {
+        return false;
+    }
+
+    return FM_GetFileInfoCmd(BufPtr);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM command handler -- Get List of Open Files                    */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+bool FM_GetOpenFilesVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    /* Verify command packet length */
+    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_GetOpenFilesCmd_t), FM_GET_OPEN_FILES_PKT_ERR_EID,
+                                "Get Open Files"))
+    {
+        return false;
+    }
+
+    return FM_GetOpenFilesCmd(BufPtr);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM command handler -- Create Directory                          */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+bool FM_CreateDirectoryVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    /* Verify command packet length */
+    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_CreateDirectoryCmd_t), FM_CREATE_DIR_PKT_ERR_EID,
+                                "Create Directory"))
+    {
+        return false;
+    }
+
+    return FM_CreateDirectoryCmd(BufPtr);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM command handler -- Delete Directory                          */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+bool FM_DeleteDirectoryVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    /* Verify command packet length */
+    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DeleteDirectoryCmd_t), FM_DELETE_DIR_PKT_ERR_EID,
+                                "Delete Directory"))
+    {
+        return false;
+    }
+
+    return FM_DeleteDirectoryCmd(BufPtr);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM command handler -- Get List of Directory Entries (to file)   */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+bool FM_GetDirListFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    /* Verify command packet length */
+    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_GetDirListFileCmd_t), FM_GET_DIR_FILE_PKT_ERR_EID,
+                                "Directory List to File"))
+    {
+        return false;
+    }
+
+    return FM_GetDirListFileCmd(BufPtr);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM command handler -- Get List of Directory Entries (to pkt)    */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+bool FM_GetDirListPktVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    /* Verify command packet length */
+    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_GetDirListPktCmd_t), FM_GET_DIR_PKT_PKT_ERR_EID,
+                                "Directory List to Packet"))
+    {
+        return false;
+    }
+
+    return FM_GetDirListPktCmd(BufPtr);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM command handler -- Get File System Free Space                */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+bool FM_MonitorFilesystemSpaceVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    /* Verify command packet length */
+    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_MonitorFilesystemSpaceCmd_t), FM_GET_FREE_SPACE_PKT_ERR_EID,
+                                "Get Free Space"))
+    {
+        return false;
+    }
+
+    return FM_MonitorFilesystemSpaceCmd(BufPtr);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM command handler -- Set Table Entry Enable/Disable State      */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+bool FM_SetTableStateVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    /* Verify command packet length */
+    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_SetTableStateCmd_t), FM_SET_TABLE_STATE_PKT_ERR_EID,
+                                "Set Table State"))
+    {
+        return false;
+    }
+
+    return FM_SetTableStateCmd(BufPtr);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM command handler -- Set Permissions for a file                */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+bool FM_SetPermissionsVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    /* Verify command packet length */
+    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_SetPermissionsCmd_t), FM_SET_PERM_ERR_EID, "Set Permissions"))
+    {
+        return false;
+    }
+
+    return FM_SetPermissionsCmd(BufPtr);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM command handler -- Send Housekeeping                         */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void FM_SendHkVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    /* Verify command packet length */
+    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_SendHkCmd_t), FM_HK_REQ_ERR_EID, "HK Request"))
+    {
+        return;
+    }
+
+    FM_SendHkCmd(BufPtr);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM application -- input packet processor                        */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void FM_ProcessPkt(const CFE_SB_Buffer_t *BufPtr)
+{
+    CFE_SB_MsgId_t MessageID = CFE_SB_INVALID_MSG_ID;
+
+    CFE_MSG_GetMsgId(&BufPtr->Msg, &MessageID);
+
+    switch (CFE_SB_MsgIdToValue(MessageID))
+    {
+        /* Housekeeping request */
+        case FM_SEND_HK_MID:
+            FM_SendHkVerifyDispatch(BufPtr);
+            break;
+
+        /* FM ground commands */
+        case FM_CMD_MID:
+            FM_ProcessCmd(BufPtr);
+            break;
+
+        default:
+            CFE_EVS_SendEvent(FM_MID_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Main loop error: invalid message ID: mid = 0x%08lX",
+                              (unsigned long)CFE_SB_MsgIdToValue(MessageID));
+            break;
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* FM application -- command packet processor                      */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void FM_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
+{
+    bool              Result;
+    CFE_MSG_FcnCode_t CommandCode = 0;
+
+    CFE_MSG_GetFcnCode(&BufPtr->Msg, &CommandCode);
+
+    /* Invoke specific command handler */
+    switch (CommandCode)
+    {
+        case FM_NOOP_CC:
+            Result = FM_NoopVerifyDispatch(BufPtr);
+            break;
+
+        case FM_RESET_COUNTERS_CC:
+            Result = FM_ResetCountersVerifyDispatch(BufPtr);
+            break;
+
+        case FM_COPY_FILE_CC:
+            Result = FM_CopyFileVerifyDispatch(BufPtr);
+            break;
+
+        case FM_MOVE_FILE_CC:
+            Result = FM_MoveFileVerifyDispatch(BufPtr);
+            break;
+
+        case FM_RENAME_FILE_CC:
+            Result = FM_RenameFileVerifyDispatch(BufPtr);
+            break;
+
+        case FM_DELETE_FILE_CC:
+            Result = FM_DeleteFileVerifyDispatch(BufPtr);
+            break;
+
+        case FM_DELETE_ALL_FILES_CC:
+            Result = FM_DeleteAllFilesVerifyDispatch(BufPtr);
+            break;
+
+        case FM_DECOMPRESS_FILE_CC:
+            Result = FM_DecompressFileVerifyDispatch(BufPtr);
+            break;
+
+        case FM_CONCAT_FILES_CC:
+            Result = FM_ConcatFilesVerifyDispatch(BufPtr);
+            break;
+
+        case FM_GET_FILE_INFO_CC:
+            Result = FM_GetFileInfoVerifyDispatch(BufPtr);
+            break;
+
+        case FM_GET_OPEN_FILES_CC:
+            Result = FM_GetOpenFilesVerifyDispatch(BufPtr);
+            break;
+
+        case FM_CREATE_DIRECTORY_CC:
+            Result = FM_CreateDirectoryVerifyDispatch(BufPtr);
+            break;
+
+        case FM_DELETE_DIRECTORY_CC:
+            Result = FM_DeleteDirectoryVerifyDispatch(BufPtr);
+            break;
+
+        case FM_GET_DIR_LIST_FILE_CC:
+            Result = FM_GetDirListFileVerifyDispatch(BufPtr);
+            break;
+
+        case FM_GET_DIR_LIST_PKT_CC:
+            Result = FM_GetDirListPktVerifyDispatch(BufPtr);
+            break;
+
+        case FM_MONITOR_FILESYSTEM_SPACE_CC:
+            Result = FM_MonitorFilesystemSpaceVerifyDispatch(BufPtr);
+            break;
+
+        case FM_SET_TABLE_STATE_CC:
+            Result = FM_SetTableStateVerifyDispatch(BufPtr);
+            break;
+
+        case FM_SET_PERMISSIONS_CC:
+            Result = FM_SetPermissionsVerifyDispatch(BufPtr);
+            break;
+
+        default:
+            Result = false;
+            CFE_EVS_SendEvent(FM_CC_ERR_EID, CFE_EVS_EventType_ERROR, "Main loop error: invalid command code: cc = %d",
+                              CommandCode);
+            break;
+    }
+
+    if (Result)
+    {
+        /* Increment command success counter */
+        if (CommandCode != FM_RESET_COUNTERS_CC)
+        {
+            FM_GlobalData.CommandCounter++;
+        }
+    }
+    else
+    {
+        /* Increment command error counter */
+        FM_GlobalData.CommandErrCounter++;
+    }
+}

--- a/fsw/src/fm_dispatch.h
+++ b/fsw/src/fm_dispatch.h
@@ -1,0 +1,103 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,918-1, and identified as “Core Flight
+ * Software System (cFS) File Manager Application Version 2.6.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *   Unit specification for the CFS File Manager Application.
+ */
+#ifndef FM_DISPATCH_H
+#define FM_DISPATCH_H
+
+#include "cfe.h"
+#include "fm_msg.h"
+
+/**
+ *  \brief Process Input Command Packets
+ *
+ *  \par Description
+ *
+ *       Branch to appropriate input packet handler: HK request or FM commands.
+ *
+ *  \par Assumptions, External Events, and Notes: None
+ *
+ *  \param [in] BufPtr Pointer to Software Bus message buffer.
+ *
+ *  \sa #FM_SendHkCmd, #FM_ProcessCmd
+ */
+void FM_ProcessPkt(const CFE_SB_Buffer_t *BufPtr);
+
+/**
+ *  \brief Process FM Ground Commands
+ *
+ *  \par Description
+ *
+ *       Branch to the command specific handlers for FM ground commands.
+ *
+ *  \par Assumptions, External Events, and Notes: None
+ *
+ *  \param [in]  BufPtr Pointer to Software Bus message buffer.
+ */
+void FM_ProcessCmd(const CFE_SB_Buffer_t *BufPtr);
+
+/**
+ *  \brief Verify Command Packet Length Function
+ *
+ *  \par Description
+ *       This function is invoked from each of the command handlers to verify the
+ *       length of the command packet.
+ *
+ *  \par Assumptions, External Events, and Notes:
+ *
+ *  \param [in]  MsgPtr         Pointer to Message
+ *  \param [in]  ExpectedLength Expected packet length (command specific)
+ *  \param [in]  EventID        Error event ID (command specific)
+ *  \param [in]  CmdText        Error event text (command specific)
+ *
+ *  \return Boolean valid packet length response
+ *  \retval true  Packet length valid
+ *  \retval false Packet length invalid
+ */
+bool FM_IsValidCmdPktLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength, uint32 EventID,
+                            const char *CmdText);
+
+/*
+ * Internal dispatch function for each command -
+ * These are declared here so they can be directly invoked by the unit test for coverage
+ */
+bool FM_NoopVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+bool FM_ResetCountersVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+bool FM_CopyFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+bool FM_MoveFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+bool FM_RenameFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+bool FM_DeleteFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+bool FM_DeleteAllFilesVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+bool FM_DecompressFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+bool FM_ConcatFilesVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+bool FM_GetFileInfoVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+bool FM_GetOpenFilesVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+bool FM_CreateDirectoryVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+bool FM_DeleteDirectoryVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+bool FM_GetDirListFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+bool FM_GetDirListPktVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+bool FM_MonitorFilesystemSpaceVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+bool FM_SetTableStateVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+bool FM_SetPermissionsVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+void FM_SendHkVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+
+#endif

--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_cfe_coverage_stubs("fm_internal"
   stubs/fm_cmd_utils_stubs.c
   stubs/fm_cmd_utils_handlers.c
   stubs/fm_compression_stubs.c
+  stubs/fm_dispatch_stubs.c
   stubs/fm_app_stubs.c
   stubs/fm_child_stubs.c
   stubs/fm_tbl_stubs.c

--- a/unit-test/fm_cmd_utils_tests.c
+++ b/unit-test/fm_cmd_utils_tests.c
@@ -45,27 +45,6 @@
  *          TEST CASE FUNCTIONS
  *********************************************************************************/
 
-/*****************
- * IsValidCmdPktLength Tests
- ****************/
-void Test_FM_IsValidCmdPktLength(void)
-{
-    size_t length  = 5;
-    uint32 eventid = 1;
-
-    /* Matching length */
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_TRUE(FM_IsValidCmdPktLength(NULL, length, 1, "Cmd Text"));
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-    /* Mismatched length */
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_FALSE(FM_IsValidCmdPktLength(NULL, length + 1, eventid, "Cmd Text"));
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, eventid);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-}
-
 /* **************************
  * VerifyOverwrite Tests
  * *************************/
@@ -695,7 +674,6 @@ void Test_FM_GetDirectorySpaceEstimate(void)
  */
 void UtTest_Setup(void)
 {
-    UtTest_Add(Test_FM_IsValidCmdPktLength, FM_Test_Setup, FM_Test_Teardown, "Test_FM_IsValidCmdPktLength");
     UtTest_Add(Test_FM_VerifyOverwrite, FM_Test_Setup, FM_Test_Teardown, "Test_FM_VerifyOverwrite");
     UtTest_Add(Test_FM_GetOpenFilesData, FM_Test_Setup, FM_Test_Teardown, "Test_FM_GetOpenFilesData");
     UtTest_Add(Test_FM_GetFilenameState, FM_Test_Setup, FM_Test_Teardown, "Test_FM_GetFilenameState");

--- a/unit-test/fm_cmds_tests.c
+++ b/unit-test/fm_cmds_tests.c
@@ -65,8 +65,6 @@ void Test_FM_NoopCmd_Success(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "%%s command: FM version %%d.%%d.%%d.%%d");
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
-
     bool Result = FM_NoopCmd(&UT_CmdBuf.Buf);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
@@ -85,25 +83,9 @@ void Test_FM_NoopCmd_Success(void)
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 }
 
-void Test_FM_NoopCmd_BadLength(void)
-{
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
-
-    bool Result = FM_NoopCmd(&UT_CmdBuf.Buf);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    /* Assert */
-    UtAssert_True(Result == false, "FM_NoopCmd returned false");
-
-    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-}
-
 void add_FM_NoopCmd_tests(void)
 {
     UtTest_Add(Test_FM_NoopCmd_Success, FM_Test_Setup, FM_Test_Teardown, "Test_FM_NoopCmd_Success");
-
-    UtTest_Add(Test_FM_NoopCmd_BadLength, FM_Test_Setup, FM_Test_Teardown, "Test_FM_NoopCmd_BadLength");
 }
 
 /****************************/
@@ -115,8 +97,6 @@ void Test_FM_ResetCountersCmd_Success(void)
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "%%s command");
-
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
 
     FM_GlobalData.CommandCounter      = 1;
     FM_GlobalData.CommandErrCounter   = 1;
@@ -148,38 +128,9 @@ void Test_FM_ResetCountersCmd_Success(void)
     UtAssert_INT32_EQ(FM_GlobalData.ChildCmdWarnCounter, 0);
 }
 
-void Test_FM_ResetCountersCmd_BadLength(void)
-{
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
-
-    FM_GlobalData.CommandCounter      = 1;
-    FM_GlobalData.CommandErrCounter   = 1;
-    FM_GlobalData.ChildCmdCounter     = 1;
-    FM_GlobalData.ChildCmdErrCounter  = 1;
-    FM_GlobalData.ChildCmdWarnCounter = 1;
-
-    bool Result = FM_ResetCountersCmd(&UT_CmdBuf.Buf);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    /* Assert */
-    UtAssert_True(Result == false, "FM_NoopCmd returned false");
-
-    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildCmdCounter, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildCmdErrCounter, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildCmdWarnCounter, 1);
-}
-
 void add_FM_ResetCountersCmd_tests(void)
 {
     UtTest_Add(Test_FM_ResetCountersCmd_Success, FM_Test_Setup, FM_Test_Teardown, "Test_FM_ResetCountersCmd_Success");
-
-    UtTest_Add(Test_FM_ResetCountersCmd_BadLength, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_ResetCountersCmd_BadLength");
 }
 
 /****************************/
@@ -197,7 +148,6 @@ void Test_FM_CopyFileCmd_Success(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyOverwrite), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
@@ -215,35 +165,11 @@ void Test_FM_CopyFileCmd_Success(void)
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_COPY_FILE_CC);
 }
 
-void Test_FM_CopyFileCmd_BadLength(void)
-{
-    FM_GlobalData.ChildWriteIndex           = 0;
-    FM_GlobalData.ChildQueue[0].CommandCode = 0;
-
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyOverwrite), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileExists), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
-
-    bool Result = FM_CopyFileCmd(&UT_CmdBuf.Buf);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    /* Assert */
-    UtAssert_True(Result == false, "FM_CopyFileCmd returned false");
-
-    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
-}
-
 void Test_FM_CopyFileCmd_BadOverwrite(void)
 {
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyOverwrite), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
@@ -266,7 +192,6 @@ void Test_FM_CopyFileCmd_SourceNotExist(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyOverwrite), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileExists), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
@@ -289,7 +214,6 @@ void Test_FM_CopyFileCmd_NoOverwriteTargetExists(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyOverwrite), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), false);
@@ -317,7 +241,6 @@ void Test_FM_CopyFileCmd_OverwriteFileOpen(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyOverwrite), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
@@ -340,7 +263,6 @@ void Test_FM_CopyFileCmd_NoChildTask(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyOverwrite), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
@@ -361,8 +283,6 @@ void Test_FM_CopyFileCmd_NoChildTask(void)
 void add_FM_CopyFileCmd_tests(void)
 {
     UtTest_Add(Test_FM_CopyFileCmd_Success, FM_Test_Setup, FM_Test_Teardown, "Test_FM_CopyFileCmd_Success");
-
-    UtTest_Add(Test_FM_CopyFileCmd_BadLength, FM_Test_Setup, FM_Test_Teardown, "Test_FM_CopyFileCmd_BadLength");
 
     UtTest_Add(Test_FM_CopyFileCmd_BadOverwrite, FM_Test_Setup, FM_Test_Teardown, "Test_FM_CopyFileCmd_BadOverwrite");
 
@@ -387,7 +307,6 @@ void Test_FM_MoveFileCmd_Success(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyOverwrite), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
@@ -405,35 +324,11 @@ void Test_FM_MoveFileCmd_Success(void)
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_MOVE_FILE_CC);
 }
 
-void Test_FM_MoveFileCmd_BadLength(void)
-{
-    FM_GlobalData.ChildWriteIndex           = 0;
-    FM_GlobalData.ChildQueue[0].CommandCode = 0;
-
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyOverwrite), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileExists), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
-
-    bool Result = FM_MoveFileCmd(&UT_CmdBuf.Buf);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    /* Assert */
-    UtAssert_True(Result == false, "FM_MoveFileCmd returned false");
-
-    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
-}
-
 void Test_FM_MoveFileCmd_BadOverwrite(void)
 {
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyOverwrite), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
@@ -456,7 +351,6 @@ void Test_FM_MoveFileCmd_SourceNotExist(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyOverwrite), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileExists), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
@@ -479,7 +373,6 @@ void Test_FM_MoveFileCmd_NoOverwriteTargetExists(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyOverwrite), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), false);
@@ -507,7 +400,6 @@ void Test_FM_MoveFileCmd_OverwriteFileOpen(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyOverwrite), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
@@ -530,7 +422,6 @@ void Test_FM_MoveFileCmd_NoChildTask(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyOverwrite), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
@@ -551,8 +442,6 @@ void Test_FM_MoveFileCmd_NoChildTask(void)
 void add_FM_MoveFileCmd_tests(void)
 {
     UtTest_Add(Test_FM_MoveFileCmd_Success, FM_Test_Setup, FM_Test_Teardown, "Test_FM_MoveFileCmd_Success");
-
-    UtTest_Add(Test_FM_MoveFileCmd_BadLength, FM_Test_Setup, FM_Test_Teardown, "Test_FM_MoveFileCmd_BadLength");
 
     UtTest_Add(Test_FM_MoveFileCmd_BadOverwrite, FM_Test_Setup, FM_Test_Teardown, "Test_FM_MoveFileCmd_BadOverwrite");
 
@@ -584,7 +473,6 @@ void Test_FM_RenameFileCmd_Success(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
@@ -600,33 +488,11 @@ void Test_FM_RenameFileCmd_Success(void)
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_RENAME_FILE_CC);
 }
 
-void Test_FM_RenameFileCmd_BadLength(void)
-{
-    FM_GlobalData.ChildWriteIndex           = 0;
-    FM_GlobalData.ChildQueue[0].CommandCode = 0;
-
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileExists), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
-
-    bool Result = FM_RenameFileCmd(&UT_CmdBuf.Buf);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    /* Assert */
-    UtAssert_True(Result == false, "FM_RenameFileCmd returned false");
-
-    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
-}
-
 void Test_FM_RenameFileCmd_SourceNotExist(void)
 {
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileExists), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
@@ -647,7 +513,6 @@ void Test_FM_RenameFileCmd_TargetExists(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
@@ -668,7 +533,6 @@ void Test_FM_RenameFileCmd_NoChildTask(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
@@ -687,8 +551,6 @@ void Test_FM_RenameFileCmd_NoChildTask(void)
 void add_FM_RenameFileCmd_tests(void)
 {
     UtTest_Add(Test_FM_RenameFileCmd_Success, FM_Test_Setup, FM_Test_Teardown, "Test_FM_RenameFileCmd_Success");
-
-    UtTest_Add(Test_FM_RenameFileCmd_BadLength, FM_Test_Setup, FM_Test_Teardown, "Test_FM_RenameFileCmd_BadLength");
 
     UtTest_Add(Test_FM_RenameFileCmd_SourceNotExist, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_RenameFileCmd_SourceNotExist");
@@ -711,7 +573,6 @@ void Test_FM_DeleteFileCmd_Success(void)
     CFE_MSG_FcnCode_t forced_CmdCode = FM_DELETE_FILE_CC;
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &forced_CmdCode, sizeof(forced_CmdCode), false);
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileClosed), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
@@ -726,29 +587,6 @@ void Test_FM_DeleteFileCmd_Success(void)
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_DELETE_FILE_CC);
 }
 
-void Test_FM_DeleteFileCmd_BadLength(void)
-{
-    FM_GlobalData.ChildWriteIndex           = 0;
-    FM_GlobalData.ChildQueue[0].CommandCode = 0;
-
-    CFE_MSG_FcnCode_t forced_CmdCode = FM_DELETE_FILE_CC;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &forced_CmdCode, sizeof(forced_CmdCode), false);
-
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileClosed), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
-
-    bool Result = FM_DeleteFileCmd(&UT_CmdBuf.Buf);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    /* Assert */
-    UtAssert_True(Result == false, "FM_DeleteFileCmd returned false");
-
-    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
-}
-
 void Test_FM_DeleteFileCmd_FileNotClosed(void)
 {
     FM_GlobalData.ChildWriteIndex           = 0;
@@ -757,7 +595,6 @@ void Test_FM_DeleteFileCmd_FileNotClosed(void)
     CFE_MSG_FcnCode_t forced_CmdCode = FM_DELETE_FILE_CC;
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &forced_CmdCode, sizeof(forced_CmdCode), false);
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileClosed), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
@@ -780,7 +617,6 @@ void Test_FM_DeleteFileCmd_NoChildTask(void)
     CFE_MSG_FcnCode_t forced_CmdCode = FM_DELETE_FILE_CC;
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &forced_CmdCode, sizeof(forced_CmdCode), false);
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileClosed), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
 
@@ -798,8 +634,6 @@ void Test_FM_DeleteFileCmd_NoChildTask(void)
 void add_FM_DeleteFileCmd_tests(void)
 {
     UtTest_Add(Test_FM_DeleteFileCmd_Success, FM_Test_Setup, FM_Test_Teardown, "Test_FM_DeleteFileCmd_Success");
-
-    UtTest_Add(Test_FM_DeleteFileCmd_BadLength, FM_Test_Setup, FM_Test_Teardown, "Test_FM_DeleteFileCmd_BadLength");
 
     UtTest_Add(Test_FM_DeleteFileCmd_FileNotClosed, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_DeleteFileCmd_FileNotClosed");
@@ -822,7 +656,6 @@ void Test_FM_DeleteAllFilesCmd_Success(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
@@ -837,32 +670,11 @@ void Test_FM_DeleteAllFilesCmd_Success(void)
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_DELETE_ALL_FILES_CC);
 }
 
-void Test_FM_DeleteAllFilesCmd_BadLength(void)
-{
-    FM_GlobalData.ChildWriteIndex           = 0;
-    FM_GlobalData.ChildQueue[0].CommandCode = 0;
-
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
-
-    bool Result = FM_DeleteAllFilesCmd(&UT_CmdBuf.Buf);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    /* Assert */
-    UtAssert_True(Result == false, "FM_DeleteAllFilesCmd returned false");
-
-    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
-}
-
 void Test_FM_DeleteAllFilesCmd_DirNoExist(void)
 {
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
@@ -887,7 +699,6 @@ void Test_FM_DeleteAllFilesCmd_NoChildTask(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
 
@@ -906,9 +717,6 @@ void add_FM_DeleteAllFilesCmd_tests(void)
 {
     UtTest_Add(Test_FM_DeleteAllFilesCmd_Success, FM_Test_Setup, FM_Test_Teardown, "Test_FM_DeleteAllFilesCmd_Success");
 
-    UtTest_Add(Test_FM_DeleteAllFilesCmd_BadLength, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_DeleteAllFilesCmd_BadLength");
-
     UtTest_Add(Test_FM_DeleteAllFilesCmd_DirNoExist, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_DeleteAllFilesCmd_DirNoExist");
 
@@ -925,7 +733,6 @@ void Test_FM_DecompressFileCmd_Success(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileClosed), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
@@ -941,33 +748,11 @@ void Test_FM_DecompressFileCmd_Success(void)
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_DECOMPRESS_FILE_CC);
 }
 
-void Test_FM_DecompressFileCmd_BadLength(void)
-{
-    FM_GlobalData.ChildWriteIndex           = 0;
-    FM_GlobalData.ChildQueue[0].CommandCode = 0;
-
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileClosed), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
-
-    bool Result = FM_DecompressFileCmd(&UT_CmdBuf.Buf);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    /* Assert */
-    UtAssert_True(Result == false, "FM_DecompressFileCmd returned false");
-
-    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
-}
-
 void Test_FM_DecompressFileCmd_SourceFileOpen(void)
 {
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileClosed), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
@@ -988,7 +773,6 @@ void Test_FM_DecompressFileCmd_TargetFileExists(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileClosed), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
@@ -1009,7 +793,6 @@ void Test_FM_DecompressFileCmd_NoChildTask(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileClosed), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
@@ -1028,9 +811,6 @@ void Test_FM_DecompressFileCmd_NoChildTask(void)
 void add_FM_DecompressFileCmd_tests(void)
 {
     UtTest_Add(Test_FM_DecompressFileCmd_Success, FM_Test_Setup, FM_Test_Teardown, "Test_FM_DecompressFileCmd_Success");
-
-    UtTest_Add(Test_FM_DecompressFileCmd_BadLength, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_DecompressFileCmd_BadLength");
 
     UtTest_Add(Test_FM_DecompressFileCmd_SourceFileOpen, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_DecompressFileCmd_SourceFileOpen");
@@ -1059,7 +839,6 @@ void Test_FM_ConcatFilesCmd_Success(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileClosed), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
@@ -1075,32 +854,11 @@ void Test_FM_ConcatFilesCmd_Success(void)
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_CONCAT_FILES_CC);
 }
 
-void Test_FM_ConcatFilesCmd_BadLength(void)
-{
-    FM_GlobalData.ChildWriteIndex           = 0;
-    FM_GlobalData.ChildQueue[0].CommandCode = 0;
-
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileClosed), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
-
-    bool Result                  = FM_ConcatFilesCmd(&UT_CmdBuf.Buf);
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    /* Assert */
-    UtAssert_True(Result == false, "FM_ConcatFilesCmd returned false");
-
-    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
-}
-
 void Test_FM_ConcatFilesCmd_SourceFile1NotClosed(void)
 {
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileClosed), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
@@ -1120,7 +878,6 @@ void Test_FM_ConcatFilesCmd_SourceFile2NotClosed(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileClosed), true);
     UT_SetDeferredRetcode(UT_KEY(FM_VerifyFileClosed), 2, false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
@@ -1141,7 +898,6 @@ void Test_FM_ConcatFilesCmd_TargetFileExists(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileClosed), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
@@ -1161,7 +917,6 @@ void Test_FM_ConcatFilesCmd_NoChildTask(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileClosed), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
@@ -1179,8 +934,6 @@ void Test_FM_ConcatFilesCmd_NoChildTask(void)
 void add_FM_ConcatFilesCmd_tests(void)
 {
     UtTest_Add(Test_FM_ConcatFilesCmd_Success, FM_Test_Setup, FM_Test_Teardown, "Test_FM_ConcatFilesCmd_Success");
-
-    UtTest_Add(Test_FM_ConcatFilesCmd_BadLength, FM_Test_Setup, FM_Test_Teardown, "Test_FM_ConcatFilesCmd_BadLength");
 
     UtTest_Add(Test_FM_ConcatFilesCmd_SourceFile1NotClosed, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_ConcatFilesCmd_SourceFile1NotClosed");
@@ -1210,7 +963,6 @@ void Test_FM_GetFileInfoCmd_Success(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyNameValid), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
@@ -1225,32 +977,11 @@ void Test_FM_GetFileInfoCmd_Success(void)
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_GET_FILE_INFO_CC);
 }
 
-void Test_FM_GetFileInfoCmd_BadLength(void)
-{
-    FM_GlobalData.ChildWriteIndex           = 0;
-    FM_GlobalData.ChildQueue[0].CommandCode = 0;
-
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyNameValid), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
-
-    bool Result = FM_GetFileInfoCmd(&UT_CmdBuf.Buf);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    /* Assert */
-    UtAssert_True(Result == false, "FM_GetFileInfoCmd returned false");
-
-    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
-}
-
 void Test_FM_GetFileInfoCmd_InvalidName(void)
 {
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyNameValid), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
@@ -1270,7 +1001,6 @@ void Test_FM_GetFileInfoCmd_NoChildTask(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyNameValid), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
 
@@ -1289,8 +1019,6 @@ void add_FM_GetFileInfoCmd_tests(void)
 {
     UtTest_Add(Test_FM_GetFileInfoCmd_Success, FM_Test_Setup, FM_Test_Teardown, "Test_FM_GetFileInfoCmd_Success");
 
-    UtTest_Add(Test_FM_GetFileInfoCmd_BadLength, FM_Test_Setup, FM_Test_Teardown, "Test_FM_GetFileInfoCmd_BadLength");
-
     UtTest_Add(Test_FM_GetFileInfoCmd_InvalidName, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_GetFileInfoCmd_InvalidName");
 
@@ -1307,8 +1035,6 @@ void Test_FM_GetOpenFilesCmd_Success(void)
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "%%s command");
-
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
 
     bool Result = FM_GetOpenFilesCmd(&UT_CmdBuf.Buf);
 
@@ -1328,25 +1054,9 @@ void Test_FM_GetOpenFilesCmd_Success(void)
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 }
 
-void Test_FM_GetOpenFilesCmd_BadLength(void)
-{
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
-
-    bool Result = FM_GetOpenFilesCmd(&UT_CmdBuf.Buf);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    /* Assert */
-    UtAssert_True(Result == false, "FM_GetFileInfoCmd returned false");
-
-    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-}
-
 void add_FM_GetOpenFilesCmd_tests(void)
 {
     UtTest_Add(Test_FM_GetOpenFilesCmd_Success, FM_Test_Setup, FM_Test_Teardown, "Test_FM_GetOpenFilesCmd_Success");
-
-    UtTest_Add(Test_FM_GetOpenFilesCmd_BadLength, FM_Test_Setup, FM_Test_Teardown, "Test_FM_GetOpenFilesCmd_BadLength");
 }
 
 /****************************/
@@ -1363,7 +1073,6 @@ void Test_FM_CreateDirectoryCmd_Success(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
@@ -1378,32 +1087,11 @@ void Test_FM_CreateDirectoryCmd_Success(void)
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_CREATE_DIRECTORY_CC);
 }
 
-void Test_FM_CreateDirectoryCmd_BadLength(void)
-{
-    FM_GlobalData.ChildWriteIndex           = 0;
-    FM_GlobalData.ChildQueue[0].CommandCode = 0;
-
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirNoExist), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
-
-    bool Result = FM_CreateDirectoryCmd(&UT_CmdBuf.Buf);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    /* Assert */
-    UtAssert_True(Result == false, "FM_CreateDirectoryCmd returned false");
-
-    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
-}
-
 void Test_FM_CreateDirectoryCmd_DirExists(void)
 {
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirNoExist), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
@@ -1423,7 +1111,6 @@ void Test_FM_CreateDirectoryCmd_NoChildTask(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
 
@@ -1442,9 +1129,6 @@ void add_FM_CreateDirectoryCmd_tests(void)
 {
     UtTest_Add(Test_FM_CreateDirectoryCmd_Success, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_CreateDirectoryCmd_Success");
-
-    UtTest_Add(Test_FM_CreateDirectoryCmd_BadLength, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_CreateDirectoryCmd_BadLength");
 
     UtTest_Add(Test_FM_CreateDirectoryCmd_DirExists, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_CreateDirectoryCmd_DirExists");
@@ -1467,7 +1151,6 @@ void Test_FM_DeleteDirectoryCmd_Success(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
@@ -1482,32 +1165,11 @@ void Test_FM_DeleteDirectoryCmd_Success(void)
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_DELETE_DIRECTORY_CC);
 }
 
-void Test_FM_DeleteDirectoryCmd_BadLength(void)
-{
-    FM_GlobalData.ChildWriteIndex           = 0;
-    FM_GlobalData.ChildQueue[0].CommandCode = 0;
-
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
-
-    bool Result = FM_DeleteDirectoryCmd(&UT_CmdBuf.Buf);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    /* Assert */
-    UtAssert_True(Result == false, "FM_DeleteDirectoryCmd returned false");
-
-    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
-}
-
 void Test_FM_DeleteDirectoryCmd_DirNoExist(void)
 {
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
@@ -1527,7 +1189,6 @@ void Test_FM_DeleteDirectoryCmd_NoChildTask(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
 
@@ -1546,9 +1207,6 @@ void add_FM_DeleteDirectoryCmd_tests(void)
 {
     UtTest_Add(Test_FM_DeleteDirectoryCmd_Success, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_DeleteDirectoryCmd_Success");
-
-    UtTest_Add(Test_FM_DeleteDirectoryCmd_BadLength, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_DeleteDirectoryCmd_BadLength");
 
     UtTest_Add(Test_FM_DeleteDirectoryCmd_DirNoExist, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_DeleteDirectoryCmd_DirNoExist");
@@ -1572,7 +1230,6 @@ void Test_FM_GetDirListFileCmd_Success(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
@@ -1599,7 +1256,6 @@ void Test_FM_GetDirListFileCmd_SuccessDefaultPath(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
@@ -1615,33 +1271,11 @@ void Test_FM_GetDirListFileCmd_SuccessDefaultPath(void)
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_GET_DIR_LIST_FILE_CC);
 }
 
-void Test_FM_GetDirListFileCmd_BadLength(void)
-{
-    FM_GlobalData.ChildWriteIndex           = 0;
-    FM_GlobalData.ChildQueue[0].CommandCode = 0;
-
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
-
-    bool Result = FM_GetDirListFileCmd(&UT_CmdBuf.Buf);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    /* Assert */
-    UtAssert_True(Result == false, "FM_GetDirListFileCmd returned false");
-
-    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
-}
-
 void Test_FM_GetDirListFileCmd_SourceNotExist(void)
 {
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
@@ -1669,7 +1303,6 @@ void Test_FM_GetDirListFileCmd_TargetFileOpen(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
@@ -1697,7 +1330,6 @@ void Test_FM_GetDirListFileCmd_NoChildTask(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
@@ -1719,9 +1351,6 @@ void add_FM_GetDirListFileCmd_tests(void)
 
     UtTest_Add(Test_FM_GetDirListFileCmd_SuccessDefaultPath, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_GetDirListFileCmd_SuccessDefaultPath");
-
-    UtTest_Add(Test_FM_GetDirListFileCmd_BadLength, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_GetDirListFileCmd_BadLength");
 
     UtTest_Add(Test_FM_GetDirListFileCmd_SourceNotExist, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_GetDirListFileCmd_SourceNotExist");
@@ -1748,7 +1377,6 @@ void Test_FM_GetDirListPktCmd_Success(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
@@ -1763,32 +1391,11 @@ void Test_FM_GetDirListPktCmd_Success(void)
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_GET_DIR_LIST_PKT_CC);
 }
 
-void Test_FM_GetDirListPktCmd_BadLength(void)
-{
-    FM_GlobalData.ChildWriteIndex           = 0;
-    FM_GlobalData.ChildQueue[0].CommandCode = 0;
-
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
-
-    bool Result = FM_GetDirListPktCmd(&UT_CmdBuf.Buf);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    /* Assert */
-    UtAssert_True(Result == false, "FM_GetDirListPktCmd returned false");
-
-    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
-}
-
 void Test_FM_GetDirListPktCmd_SourceNotExist(void)
 {
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
@@ -1808,7 +1415,6 @@ void Test_FM_GetDirListPktCmd_NoChildTask(void)
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
 
@@ -1826,9 +1432,6 @@ void Test_FM_GetDirListPktCmd_NoChildTask(void)
 void add_FM_GetDirListPktCmd_tests(void)
 {
     UtTest_Add(Test_FM_GetDirListPktCmd_Success, FM_Test_Setup, FM_Test_Teardown, "Test_FM_GetDirListPktCmd_Success");
-
-    UtTest_Add(Test_FM_GetDirListPktCmd_BadLength, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_GetDirListPktCmd_BadLength");
 
     UtTest_Add(Test_FM_GetDirListPktCmd_SourceNotExist, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_GetDirListPktCmd_SourceNotExist");
@@ -1880,7 +1483,7 @@ void Test_FM_MonitorFilesystemSpaceCmd_Success(void)
 
     UT_SetHandlerFunction(UT_KEY(FM_GetVolumeFreeSpace), UT_Handler_MonitorSpace, &RefVal1);
     UT_SetHandlerFunction(UT_KEY(FM_GetDirectorySpaceEstimate), UT_Handler_MonitorSpace, &RefVal2);
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
+
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
@@ -1909,19 +1512,6 @@ void Test_FM_MonitorFilesystemSpaceCmd_Success(void)
     UtAssert_UINT32_EQ(ReportPtr->FileSys[2].Blocks, 0);
 }
 
-void Test_FM_MonitorFilesystemSpaceCmd_BadLength(void)
-{
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
-
-    UtAssert_BOOL_FALSE(FM_MonitorFilesystemSpaceCmd(&UT_CmdBuf.Buf));
-
-    call_count_CFE_EVS_SendEvent        = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    uint8 call_count_CFE_SB_TransmitMsg = UT_GetStubCount(UT_KEY(CFE_SB_TransmitMsg));
-
-    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(call_count_CFE_SB_TransmitMsg, 0);
-}
-
 void Test_FM_MonitorFilesystemSpaceCmd_NullFreeSpaceTable(void)
 {
     int32 strCmpResult;
@@ -1930,8 +1520,6 @@ void Test_FM_MonitorFilesystemSpaceCmd_NullFreeSpaceTable(void)
              "%%s error: file system free space table is not loaded");
 
     FM_GlobalData.MonitorTablePtr = NULL;
-
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
 
     UtAssert_BOOL_FALSE(FM_MonitorFilesystemSpaceCmd(&UT_CmdBuf.Buf));
 
@@ -1970,7 +1558,6 @@ void Test_FM_MonitorFilesystemSpaceCmd_ImplCallFails(void)
 
     FM_GlobalData.MonitorTablePtr = &DummyTable;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_GetVolumeFreeSpace), CFE_STATUS_EXTERNAL_RESOURCE_FAIL);
 
     /* Assert */
@@ -2015,8 +1602,6 @@ void Test_FM_MonitorFilesystemSpaceCmd_NotImpl(void)
 
     FM_GlobalData.MonitorTablePtr = &DummyTable;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
-
     /* Assert */
     UtAssert_BOOL_FALSE(FM_MonitorFilesystemSpaceCmd(&UT_CmdBuf.Buf));
 
@@ -2043,9 +1628,6 @@ void add_FM_MonitorFilesystemSpaceCmd_tests(void)
 {
     UtTest_Add(Test_FM_MonitorFilesystemSpaceCmd_Success, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_MonitorFilesystemSpaceCmd_Success");
-
-    UtTest_Add(Test_FM_MonitorFilesystemSpaceCmd_BadLength, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_MonitorFilesystemSpaceCmd_BadLength");
 
     UtTest_Add(Test_FM_MonitorFilesystemSpaceCmd_NullFreeSpaceTable, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_MonitorFilesystemSpaceCmd_NullFreeSpaceTable");
@@ -2074,8 +1656,6 @@ void Test_FM_SetTableStateCmd_Success(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "%%s command: index = %%d, state = %%d");
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
-
     FM_MonitorTable_t DummyTable;
 
     memset(&DummyTable, 0, sizeof(DummyTable));
@@ -2098,27 +1678,6 @@ void Test_FM_SetTableStateCmd_Success(void)
     UtAssert_INT32_EQ(FM_GlobalData.MonitorTablePtr->Entries[0].Enabled, FM_TABLE_ENTRY_ENABLED);
 }
 
-void Test_FM_SetTableStateCmd_BadLength(void)
-{
-    FM_TableIndexAndState_Payload_t *CmdPtr;
-
-    CmdPtr = &UT_CmdBuf.SetTableStateCmd.Payload;
-
-    CmdPtr->TableEntryState = FM_TABLE_ENTRY_ENABLED;
-    CmdPtr->TableEntryIndex = 0;
-
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
-
-    bool Result = FM_SetTableStateCmd(&UT_CmdBuf.Buf);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    /* Assert */
-    UtAssert_True(Result == false, "FM_SetTableStateCmd returned false");
-
-    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-}
-
 void Test_FM_SetTableStateCmd_NullFreeSpaceTable(void)
 {
     FM_TableIndexAndState_Payload_t *CmdPtr;
@@ -2134,8 +1693,6 @@ void Test_FM_SetTableStateCmd_NullFreeSpaceTable(void)
              "%%s error: file system free space table is not loaded");
 
     FM_GlobalData.MonitorTablePtr = NULL;
-
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
 
     bool Result = FM_SetTableStateCmd(&UT_CmdBuf.Buf);
 
@@ -2167,8 +1724,6 @@ void Test_FM_SetTableStateCmd_TableEntryIndexTooLarge(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "%%s error: invalid command argument: index = %%d");
-
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
 
     FM_MonitorTable_t DummyTable;
 
@@ -2207,8 +1762,6 @@ void Test_FM_SetTableStateCmd_BadNewState(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "%%s error: invalid command argument: state = %%d");
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
-
     FM_MonitorTable_t DummyTable;
 
     memset(&DummyTable, 0, sizeof(DummyTable));
@@ -2246,8 +1799,6 @@ void Test_FM_SetTableStateCmd_BadCurrentState(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "%%s error: cannot modify unused table entry: index = %%d");
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
-
     FM_MonitorTable_t DummyTable;
 
     memset(&DummyTable, 0, sizeof(DummyTable));
@@ -2271,9 +1822,6 @@ void Test_FM_SetTableStateCmd_BadCurrentState(void)
 void add_FM_SetTableStateCmd_tests(void)
 {
     UtTest_Add(Test_FM_SetTableStateCmd_Success, FM_Test_Setup, FM_Test_Teardown, "Test_FM_SetTableStateCmd_Success");
-
-    UtTest_Add(Test_FM_SetTableStateCmd_BadLength, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_SetTableStateCmd_BadLength");
 
     UtTest_Add(Test_FM_SetTableStateCmd_NullFreeSpaceTable, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_SetTableStateCmd_NullFreeSpaceTable");
@@ -2299,7 +1847,7 @@ void Test_FM_SetPermissionsCmd_Success(void)
     CmdPtr = &UT_CmdBuf.SetPermissionsCmd.Payload;
 
     strncpy(CmdPtr->FileName, "file", sizeof(CmdPtr->FileName) - 1);
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
+
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyNameValid), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
@@ -2314,26 +1862,9 @@ void Test_FM_SetPermissionsCmd_Success(void)
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_SET_PERMISSIONS_CC);
 }
 
-void Test_FM_SetPermissionsCmd_BadLength(void)
-{
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyNameValid), true);
-    UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
-
-    bool Result = FM_SetPermissionsCmd(&UT_CmdBuf.Buf);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    /* Assert */
-    UtAssert_True(Result == false, "FM_SetPermissionsCmd returned false");
-
-    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
-}
-
 void Test_FM_SetPermissionsCmd_BadName(void)
 {
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
+
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyNameValid), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
@@ -2350,7 +1881,7 @@ void Test_FM_SetPermissionsCmd_BadName(void)
 
 void Test_FM_SetPermissionsCmd_NoChildTask(void)
 {
-    UT_SetDefaultReturnValue(UT_KEY(FM_IsValidCmdPktLength), true);
+
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyNameValid), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
@@ -2368,9 +1899,6 @@ void Test_FM_SetPermissionsCmd_NoChildTask(void)
 void add_FM_SetPermissionsCmd_tests(void)
 {
     UtTest_Add(Test_FM_SetPermissionsCmd_Success, FM_Test_Setup, FM_Test_Teardown, "Test_FM_SetPermissionsCmd_Success");
-
-    UtTest_Add(Test_FM_SetPermissionsCmd_BadLength, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_SetPermissionsCmd_BadLength");
 
     UtTest_Add(Test_FM_SetPermissionsCmd_BadName, FM_Test_Setup, FM_Test_Teardown, "Test_FM_SetPermissionsCmd_BadName");
 

--- a/unit-test/fm_dispatch_tests.c
+++ b/unit-test/fm_dispatch_tests.c
@@ -1,0 +1,968 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,918-1, and identified as “Core Flight
+ * Software System (cFS) File Manager Application Version 2.6.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *  Coverage Unit Test cases for the fm_app implementations
+ */
+
+/*
+ * Includes
+ */
+/*
+ * UT includes
+ */
+#include "uttest.h"
+#include "utassert.h"
+#include "utstubs.h"
+
+/* fm testing */
+#include "cfe.h"
+#include "fm_msg.h"
+#include "fm_msgdefs.h"
+#include "fm_msgids.h"
+#include "fm_events.h"
+#include "fm_dispatch.h"
+#include "fm_cmds.h"
+#include "fm_app.h"
+#include "fm_test_utils.h"
+#include <unistd.h>
+#include <stdlib.h>
+#include "cfe.h"
+
+/*********************************************************************************
+ *          TEST CASE FUNCTIONS
+ *********************************************************************************/
+
+/* ********************************
+ * Process Command Tests
+ * *******************************/
+void Test_FM_ProcessCmd_NoopCmdCCReturn(void)
+{
+    /* Arrange */
+    CFE_MSG_FcnCode_t fcn_code;
+    size_t            length;
+
+    fcn_code = FM_NOOP_CC;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
+    length = sizeof(FM_NoopCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UT_SetDefaultReturnValue(UT_KEY(FM_NoopCmd), true);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+    UtAssert_STUB_COUNT(FM_NoopCmd, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+}
+
+void Test_FM_ProcessCmd_ResetCountersCCReturn(void)
+{
+    /* Arrange */
+    CFE_MSG_FcnCode_t fcn_code;
+    size_t            length;
+
+    fcn_code = FM_RESET_COUNTERS_CC;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
+    length = sizeof(FM_ResetCountersCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UT_SetDefaultReturnValue(UT_KEY(FM_ResetCountersCmd), true);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+    UtAssert_STUB_COUNT(FM_ResetCountersCmd, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+}
+
+void Test_FM_ProcessCmd_CopyFileCCReturn(void)
+{
+    /* Arrange */
+    CFE_MSG_FcnCode_t fcn_code;
+    size_t            length;
+
+    fcn_code = FM_COPY_FILE_CC;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
+    length = sizeof(FM_CopyFileCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UT_SetDefaultReturnValue(UT_KEY(FM_CopyFileCmd), true);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+    UtAssert_STUB_COUNT(FM_CopyFileCmd, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+}
+
+void Test_FM_ProcessCmd_MoveFileCCReturn(void)
+{
+    /* Arrange */
+    CFE_MSG_FcnCode_t fcn_code;
+    size_t            length;
+
+    fcn_code = FM_MOVE_FILE_CC;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
+    length = sizeof(FM_MoveFileCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UT_SetDefaultReturnValue(UT_KEY(FM_MoveFileCmd), true);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+    UtAssert_STUB_COUNT(FM_MoveFileCmd, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+}
+
+void Test_FM_ProcessCmd_RenameFileCCReturn(void)
+{
+    /* Arrange */
+    CFE_MSG_FcnCode_t fcn_code;
+    size_t            length;
+
+    fcn_code = FM_RENAME_FILE_CC;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
+    length = sizeof(FM_RenameFileCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UT_SetDefaultReturnValue(UT_KEY(FM_RenameFileCmd), true);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+    UtAssert_STUB_COUNT(FM_RenameFileCmd, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+}
+
+void Test_FM_ProcessCmd_DeleteFileCCReturn(void)
+{
+    /* Arrange */
+    CFE_MSG_FcnCode_t fcn_code;
+    size_t            length;
+
+    fcn_code = FM_DELETE_FILE_CC;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
+    length = sizeof(FM_DeleteFileCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UT_SetDefaultReturnValue(UT_KEY(FM_DeleteFileCmd), true);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+    UtAssert_STUB_COUNT(FM_DeleteFileCmd, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+}
+
+void Test_FM_ProcessCmd_DeleteAllFilesCCReturn(void)
+{
+    /* Arrange */
+    CFE_MSG_FcnCode_t fcn_code;
+    size_t            length;
+
+    fcn_code = FM_DELETE_ALL_FILES_CC;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
+    length = sizeof(FM_DeleteAllFilesCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UT_SetDefaultReturnValue(UT_KEY(FM_DeleteAllFilesCmd), true);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+    UtAssert_STUB_COUNT(FM_DeleteAllFilesCmd, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+}
+
+void Test_FM_ProcessCmd_DecompressFileCCReturn(void)
+{
+    /* Arrange */
+    CFE_MSG_FcnCode_t fcn_code;
+    size_t            length;
+
+    fcn_code = FM_DECOMPRESS_FILE_CC;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
+    length = sizeof(FM_DecompressFileCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UT_SetDefaultReturnValue(UT_KEY(FM_DecompressFileCmd), true);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+    UtAssert_STUB_COUNT(FM_DecompressFileCmd, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+}
+
+void Test_FM_ProcessCmd_ConcatFilesCCReturn(void)
+{
+    /* Arrange */
+    CFE_MSG_FcnCode_t fcn_code;
+    size_t            length;
+
+    fcn_code = FM_CONCAT_FILES_CC;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
+    length = sizeof(FM_ConcatFilesCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UT_SetDefaultReturnValue(UT_KEY(FM_ConcatFilesCmd), true);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+    UtAssert_STUB_COUNT(FM_ConcatFilesCmd, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+}
+
+void Test_FM_ProcessCmd_GetFileInfoCCReturn(void)
+{
+    /* Arrange */
+    CFE_MSG_FcnCode_t fcn_code;
+    size_t            length;
+
+    fcn_code = FM_GET_FILE_INFO_CC;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
+    length = sizeof(FM_GetFileInfoCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UT_SetDefaultReturnValue(UT_KEY(FM_GetFileInfoCmd), true);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+    UtAssert_STUB_COUNT(FM_GetFileInfoCmd, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+}
+
+void Test_FM_ProcessCmd_GetOpenFilesCCReturn(void)
+{
+    /* Arrange */
+    CFE_MSG_FcnCode_t fcn_code;
+    size_t            length;
+
+    fcn_code = FM_GET_OPEN_FILES_CC;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
+    length = sizeof(FM_GetOpenFilesCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UT_SetDefaultReturnValue(UT_KEY(FM_GetOpenFilesCmd), true);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+    UtAssert_STUB_COUNT(FM_GetOpenFilesCmd, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+}
+
+void Test_FM_ProcessCmd_CreateDirectoryCCReturn(void)
+{
+    /* Arrange */
+    CFE_MSG_FcnCode_t fcn_code;
+    size_t            length;
+
+    fcn_code = FM_CREATE_DIRECTORY_CC;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
+    length = sizeof(FM_CreateDirectoryCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UT_SetDefaultReturnValue(UT_KEY(FM_CreateDirectoryCmd), true);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+    UtAssert_STUB_COUNT(FM_CreateDirectoryCmd, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+}
+
+void Test_FM_ProcessCmd_DeleteDirectoryCCReturn(void)
+{
+    /* Arrange */
+    CFE_MSG_FcnCode_t fcn_code;
+    size_t            length;
+
+    fcn_code = FM_DELETE_DIRECTORY_CC;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
+    length = sizeof(FM_DeleteDirectoryCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UT_SetDefaultReturnValue(UT_KEY(FM_DeleteDirectoryCmd), true);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+    UtAssert_STUB_COUNT(FM_DeleteDirectoryCmd, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+}
+
+void Test_FM_ProcessCmd_GetDirListFileCCReturn(void)
+{
+    /* Arrange */
+    CFE_MSG_FcnCode_t fcn_code;
+    size_t            length;
+
+    fcn_code = FM_GET_DIR_LIST_FILE_CC;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
+    length = sizeof(FM_GetDirListFileCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UT_SetDefaultReturnValue(UT_KEY(FM_GetDirListFileCmd), true);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+    UtAssert_STUB_COUNT(FM_GetDirListFileCmd, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+}
+
+void Test_FM_ProcessCmd_GetDirListPktCCReturn(void)
+{
+    /* Arrange */
+    CFE_MSG_FcnCode_t fcn_code;
+    size_t            length;
+
+    fcn_code = FM_GET_DIR_LIST_PKT_CC;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
+    length = sizeof(FM_GetDirListPktCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UT_SetDefaultReturnValue(UT_KEY(FM_GetDirListPktCmd), true);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+    UtAssert_STUB_COUNT(FM_GetDirListPktCmd, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+}
+
+void Test_FM_ProcessCmd_MonitorFilesystemSpaceCCReturn(void)
+{
+    /* Arrange */
+    CFE_MSG_FcnCode_t fcn_code;
+    size_t            length;
+
+    fcn_code = FM_MONITOR_FILESYSTEM_SPACE_CC;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
+    length = sizeof(FM_MonitorFilesystemSpaceCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UT_SetDefaultReturnValue(UT_KEY(FM_MonitorFilesystemSpaceCmd), true);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+    UtAssert_STUB_COUNT(FM_MonitorFilesystemSpaceCmd, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+}
+
+void Test_FM_ProcessCmd_SetTableStateCCReturn(void)
+{
+    /* Arrange */
+    CFE_MSG_FcnCode_t fcn_code;
+    size_t            length;
+
+    fcn_code = FM_SET_TABLE_STATE_CC;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
+    length = sizeof(FM_SetTableStateCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UT_SetDefaultReturnValue(UT_KEY(FM_SetTableStateCmd), true);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+    UtAssert_STUB_COUNT(FM_SetTableStateCmd, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+}
+
+void Test_FM_ProcessCmd_SetPermissionsCCReturn(void)
+{
+    /* Arrange */
+    CFE_MSG_FcnCode_t fcn_code;
+    size_t            length;
+
+    fcn_code = FM_SET_PERMISSIONS_CC;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
+    length = sizeof(FM_SetPermissionsCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UT_SetDefaultReturnValue(UT_KEY(FM_SetPermissionsCmd), true);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+    UtAssert_STUB_COUNT(FM_SetPermissionsCmd, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+}
+
+void Test_FM_ProcessCmd_DefaultReturn(void)
+{
+    /* Arrange */
+    CFE_MSG_FcnCode_t fcn_code;
+
+    fcn_code = -1;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CC_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
+}
+
+void add_FM_ProcessCmd_tests(void)
+{
+    UtTest_Add(Test_FM_ProcessCmd_NoopCmdCCReturn, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ProcessCmd_NoopCmd_Return");
+
+    UtTest_Add(Test_FM_ProcessCmd_ResetCountersCCReturn, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ProcessCmd_NResetCountersCCReturn");
+
+    UtTest_Add(Test_FM_ProcessCmd_CopyFileCCReturn, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ProcessCmd_CopyFileCCReturn");
+
+    UtTest_Add(Test_FM_ProcessCmd_MoveFileCCReturn, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ProcessCmd_MoveFileCCReturn");
+
+    UtTest_Add(Test_FM_ProcessCmd_RenameFileCCReturn, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ProcessCmd_RenameFileCCReturn");
+
+    UtTest_Add(Test_FM_ProcessCmd_DeleteFileCCReturn, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ProcessCmd_DeleteFileCCReturn");
+
+    UtTest_Add(Test_FM_ProcessCmd_DeleteAllFilesCCReturn, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ProcessCmd_DeleteAllFilesCCReturn");
+
+    UtTest_Add(Test_FM_ProcessCmd_DecompressFileCCReturn, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ProcessCmd_DecompressFileCCReturn");
+
+    UtTest_Add(Test_FM_ProcessCmd_ConcatFilesCCReturn, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_PRocessCmd_ConcatFilesCCReturn");
+
+    UtTest_Add(Test_FM_ProcessCmd_GetFileInfoCCReturn, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_PRocessCmd_GetFileInfoCCReturn");
+
+    UtTest_Add(Test_FM_ProcessCmd_GetOpenFilesCCReturn, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_PRocessCmd_GetOpenFilesCCReturn");
+
+    UtTest_Add(Test_FM_ProcessCmd_CreateDirectoryCCReturn, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_PRocessCmd_CreateDirectoryCCReturn");
+
+    UtTest_Add(Test_FM_ProcessCmd_DeleteDirectoryCCReturn, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_PRocessCmd_DeleteDirectoryCCReturn");
+
+    UtTest_Add(Test_FM_ProcessCmd_GetDirListFileCCReturn, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ProcessCmd_GetDirListFIleCCReturn");
+
+    UtTest_Add(Test_FM_ProcessCmd_GetDirListPktCCReturn, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_PRocessCmd_GetDirListPktCCReturn");
+
+    UtTest_Add(Test_FM_ProcessCmd_MonitorFilesystemSpaceCCReturn, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_PRocessCmd_MonitorFilesystemSpaceCCReturn");
+
+    UtTest_Add(Test_FM_ProcessCmd_SetTableStateCCReturn, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_PRocessCmd_SetTableStateCCReturn");
+
+    UtTest_Add(Test_FM_ProcessCmd_SetPermissionsCCReturn, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_PRocessCmd_SetPermissionsCCReturn");
+
+    UtTest_Add(Test_FM_ProcessCmd_DefaultReturn, FM_Test_Setup, FM_Test_Teardown, "Test_FM_PRocessCmd_DefaultReturn");
+}
+
+/* ********************************
+ * ProcessPkt Tests
+ * ********************************/
+void Test_FM_ProcessPkt_CheckMessageReturnHKRequest(void)
+{
+    /* Arrange */
+    CFE_SB_MsgId_t    msgid = CFE_SB_ValueToMsgId(FM_SEND_HK_MID);
+    CFE_MSG_FcnCode_t fcn_code;
+    size_t            length;
+
+    msgid = CFE_SB_ValueToMsgId(FM_SEND_HK_MID);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &msgid, sizeof(msgid), false);
+    fcn_code = 0;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
+    length = sizeof(FM_SendHkCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessPkt(NULL));
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+}
+
+void Test_FM_ProcessPkt_CheckMessageReturnGroundCommand(void)
+{
+    /* Arrange */
+    CFE_SB_MsgId_t    msgid = CFE_SB_ValueToMsgId(FM_CMD_MID);
+    CFE_MSG_FcnCode_t fcn_code;
+
+    fcn_code = -1;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &msgid, sizeof(msgid), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessPkt(NULL));
+
+    /* Assert */
+    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 1);
+    UtAssert_STUB_COUNT(CFE_MSG_GetFcnCode, 1);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CC_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
+}
+
+void Test_FM_ProcessPkt_CheckDefaultSwitchMessage(void)
+{
+    /* Arrange */
+    CFE_SB_MsgId_t msgid = CFE_SB_INVALID_MSG_ID;
+
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &msgid, sizeof(msgid), false);
+
+    /* Act */
+    UtAssert_VOIDCALL(FM_ProcessPkt(NULL));
+
+    /* Assert */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_MID_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
+}
+
+/* * * * * * * * * * * * * *
+ * Add Method Tests
+ * * * * * * * * * * * * * */
+void add_FM_ProcessPkt_tests(void)
+{
+    UtTest_Add(Test_FM_ProcessPkt_CheckMessageReturnHKRequest, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ProcessPkt_ReportHK");
+
+    UtTest_Add(Test_FM_ProcessPkt_CheckMessageReturnGroundCommand, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ProcessPkt_CheckMessageReturnGroundCommand");
+
+    UtTest_Add(Test_FM_ProcessPkt_CheckDefaultSwitchMessage, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ProcessPkt_CheckDefaultSwitchMessage");
+}
+
+/*****************
+ * IsValidCmdPktLength Tests
+ ****************/
+void Test_FM_IsValidCmdPktLength(void)
+{
+    size_t length  = 5;
+    uint32 eventid = 1;
+
+    /* Matching length */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_TRUE(FM_IsValidCmdPktLength(NULL, length, 1, "Cmd Text"));
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+
+    /* Mismatched length */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_FALSE(FM_IsValidCmdPktLength(NULL, length + 1, eventid, "Cmd Text"));
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, eventid);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
+}
+
+/*****************
+ * Bad Length Tests for each command
+ ****************/
+
+void Test_FM_NoopVerifyDispatch(void)
+{
+    size_t length;
+
+    UT_SetDefaultReturnValue(UT_KEY(FM_NoopCmd), true);
+
+    length = 1; /* bad size for any message */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_FALSE(FM_NoopVerifyDispatch(&UT_CmdBuf.Buf));
+
+    length = sizeof(FM_NoopCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_TRUE(FM_NoopVerifyDispatch(&UT_CmdBuf.Buf));
+}
+
+void Test_FM_ResetCountersVerifyDispatch(void)
+{
+    size_t length;
+
+    UT_SetDefaultReturnValue(UT_KEY(FM_ResetCountersCmd), true);
+
+    length = 1; /* bad size for any message */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_FALSE(FM_ResetCountersVerifyDispatch(&UT_CmdBuf.Buf));
+
+    length = sizeof(FM_ResetCountersCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_TRUE(FM_ResetCountersVerifyDispatch(&UT_CmdBuf.Buf));
+}
+
+void Test_FM_CopyFileVerifyDispatch(void)
+{
+    size_t length;
+
+    UT_SetDefaultReturnValue(UT_KEY(FM_CopyFileCmd), true);
+
+    length = 1; /* bad size for any message */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_FALSE(FM_CopyFileVerifyDispatch(&UT_CmdBuf.Buf));
+
+    length = sizeof(FM_CopyFileCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_TRUE(FM_CopyFileVerifyDispatch(&UT_CmdBuf.Buf));
+}
+
+void Test_FM_MoveFileVerifyDispatch(void)
+{
+    size_t length;
+
+    UT_SetDefaultReturnValue(UT_KEY(FM_MoveFileCmd), true);
+
+    length = 1; /* bad size for any message */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_FALSE(FM_MoveFileVerifyDispatch(&UT_CmdBuf.Buf));
+
+    length = sizeof(FM_MoveFileCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_TRUE(FM_MoveFileVerifyDispatch(&UT_CmdBuf.Buf));
+}
+
+void Test_FM_RenameFileVerifyDispatch(void)
+{
+    size_t length;
+
+    UT_SetDefaultReturnValue(UT_KEY(FM_RenameFileCmd), true);
+
+    length = 1; /* bad size for any message */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_FALSE(FM_RenameFileVerifyDispatch(&UT_CmdBuf.Buf));
+
+    length = sizeof(FM_RenameFileCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_TRUE(FM_RenameFileVerifyDispatch(&UT_CmdBuf.Buf));
+}
+
+void Test_FM_DeleteFileVerifyDispatch(void)
+{
+    size_t length;
+
+    UT_SetDefaultReturnValue(UT_KEY(FM_DeleteFileCmd), true);
+
+    length = 1; /* bad size for any message */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_FALSE(FM_DeleteFileVerifyDispatch(&UT_CmdBuf.Buf));
+
+    length = sizeof(FM_DeleteFileCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_TRUE(FM_DeleteFileVerifyDispatch(&UT_CmdBuf.Buf));
+}
+
+void Test_FM_DeleteAllFilesVerifyDispatch(void)
+{
+    size_t length;
+
+    UT_SetDefaultReturnValue(UT_KEY(FM_DeleteAllFilesCmd), true);
+
+    length = 1; /* bad size for any message */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_FALSE(FM_DeleteAllFilesVerifyDispatch(&UT_CmdBuf.Buf));
+
+    length = sizeof(FM_DeleteAllFilesCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_TRUE(FM_DeleteAllFilesVerifyDispatch(&UT_CmdBuf.Buf));
+}
+
+void Test_FM_DecompressFileVerifyDispatch(void)
+{
+    size_t length;
+
+    UT_SetDefaultReturnValue(UT_KEY(FM_DecompressFileCmd), true);
+
+    length = 1; /* bad size for any message */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_FALSE(FM_DecompressFileVerifyDispatch(&UT_CmdBuf.Buf));
+
+    length = sizeof(FM_DecompressFileCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_TRUE(FM_DecompressFileVerifyDispatch(&UT_CmdBuf.Buf));
+}
+
+void Test_FM_ConcatFilesVerifyDispatch(void)
+{
+    size_t length;
+
+    UT_SetDefaultReturnValue(UT_KEY(FM_ConcatFilesCmd), true);
+
+    length = 1; /* bad size for any message */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_FALSE(FM_ConcatFilesVerifyDispatch(&UT_CmdBuf.Buf));
+
+    length = sizeof(FM_ConcatFilesCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_TRUE(FM_ConcatFilesVerifyDispatch(&UT_CmdBuf.Buf));
+}
+
+void Test_FM_GetFileInfoVerifyDispatch(void)
+{
+    size_t length;
+
+    UT_SetDefaultReturnValue(UT_KEY(FM_GetFileInfoCmd), true);
+
+    length = 1; /* bad size for any message */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_FALSE(FM_GetFileInfoVerifyDispatch(&UT_CmdBuf.Buf));
+
+    length = sizeof(FM_GetFileInfoCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_TRUE(FM_GetFileInfoVerifyDispatch(&UT_CmdBuf.Buf));
+}
+
+void Test_FM_GetOpenFilesVerifyDispatch(void)
+{
+    size_t length;
+
+    UT_SetDefaultReturnValue(UT_KEY(FM_GetOpenFilesCmd), true);
+
+    length = 1; /* bad size for any message */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_FALSE(FM_GetOpenFilesVerifyDispatch(&UT_CmdBuf.Buf));
+
+    length = sizeof(FM_GetOpenFilesCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_TRUE(FM_GetOpenFilesVerifyDispatch(&UT_CmdBuf.Buf));
+}
+
+void Test_FM_CreateDirectoryVerifyDispatch(void)
+{
+    size_t length;
+
+    UT_SetDefaultReturnValue(UT_KEY(FM_CreateDirectoryCmd), true);
+
+    length = 1; /* bad size for any message */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_FALSE(FM_CreateDirectoryVerifyDispatch(&UT_CmdBuf.Buf));
+
+    length = sizeof(FM_CreateDirectoryCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_TRUE(FM_CreateDirectoryVerifyDispatch(&UT_CmdBuf.Buf));
+}
+
+void Test_FM_DeleteDirectoryVerifyDispatch(void)
+{
+    size_t length;
+
+    UT_SetDefaultReturnValue(UT_KEY(FM_DeleteDirectoryCmd), true);
+
+    length = 1; /* bad size for any message */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_FALSE(FM_DeleteDirectoryVerifyDispatch(&UT_CmdBuf.Buf));
+
+    length = sizeof(FM_DeleteDirectoryCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_TRUE(FM_DeleteDirectoryVerifyDispatch(&UT_CmdBuf.Buf));
+}
+
+void Test_FM_GetDirListFileVerifyDispatch(void)
+{
+    size_t length;
+
+    UT_SetDefaultReturnValue(UT_KEY(FM_GetDirListFileCmd), true);
+
+    length = 1; /* bad size for any message */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_FALSE(FM_GetDirListFileVerifyDispatch(&UT_CmdBuf.Buf));
+
+    length = sizeof(FM_GetDirListFileCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_TRUE(FM_GetDirListFileVerifyDispatch(&UT_CmdBuf.Buf));
+}
+
+void Test_FM_GetDirListPktVerifyDispatch(void)
+{
+    size_t length;
+
+    UT_SetDefaultReturnValue(UT_KEY(FM_GetDirListPktCmd), true);
+
+    length = 1; /* bad size for any message */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_FALSE(FM_GetDirListPktVerifyDispatch(&UT_CmdBuf.Buf));
+
+    length = sizeof(FM_GetDirListPktCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_TRUE(FM_GetDirListPktVerifyDispatch(&UT_CmdBuf.Buf));
+}
+
+void Test_FM_MonitorFilesystemSpaceVerifyDispatch(void)
+{
+    size_t length;
+
+    UT_SetDefaultReturnValue(UT_KEY(FM_MonitorFilesystemSpaceCmd), true);
+
+    length = 1; /* bad size for any message */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_FALSE(FM_MonitorFilesystemSpaceVerifyDispatch(&UT_CmdBuf.Buf));
+
+    length = sizeof(FM_MonitorFilesystemSpaceCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_TRUE(FM_MonitorFilesystemSpaceVerifyDispatch(&UT_CmdBuf.Buf));
+}
+
+void Test_FM_SetTableStateVerifyDispatch(void)
+{
+    size_t length;
+
+    UT_SetDefaultReturnValue(UT_KEY(FM_SetTableStateCmd), true);
+
+    length = 1; /* bad size for any message */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_FALSE(FM_SetTableStateVerifyDispatch(&UT_CmdBuf.Buf));
+
+    length = sizeof(FM_SetTableStateCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_TRUE(FM_SetTableStateVerifyDispatch(&UT_CmdBuf.Buf));
+}
+
+void Test_FM_SetPermissionsVerifyDispatch(void)
+{
+    size_t length;
+
+    UT_SetDefaultReturnValue(UT_KEY(FM_SetPermissionsCmd), true);
+
+    length = 1; /* bad size for any message */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_FALSE(FM_SetPermissionsVerifyDispatch(&UT_CmdBuf.Buf));
+
+    length = sizeof(FM_SetPermissionsCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_BOOL_TRUE(FM_SetPermissionsVerifyDispatch(&UT_CmdBuf.Buf));
+}
+
+void Test_FM_SendHkVerifyDispatch(void)
+{
+    size_t length;
+
+    length = 1; /* bad size for any message */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_VOIDCALL(FM_SendHkVerifyDispatch(&UT_CmdBuf.Buf));
+
+    length = sizeof(FM_SendHkCmd_t);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
+    UtAssert_VOIDCALL(FM_SendHkVerifyDispatch(&UT_CmdBuf.Buf));
+}
+
+/*
+ * Register the test cases to execute with the unit test tool
+ */
+void UtTest_Setup(void)
+{
+    add_FM_ProcessPkt_tests();
+    add_FM_ProcessCmd_tests();
+
+    UtTest_Add(Test_FM_IsValidCmdPktLength, FM_Test_Setup, FM_Test_Teardown, "Test_FM_IsValidCmdPktLength");
+
+    UtTest_Add(Test_FM_NoopVerifyDispatch, FM_Test_Setup, FM_Test_Teardown, "Test_FM_NoopVerifyDispatch");
+    UtTest_Add(Test_FM_ResetCountersVerifyDispatch, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_ResetCountersVerifyDispatch");
+    UtTest_Add(Test_FM_CopyFileVerifyDispatch, FM_Test_Setup, FM_Test_Teardown, "Test_FM_CopyFileVerifyDispatch");
+
+    UtTest_Add(Test_FM_MoveFileVerifyDispatch, FM_Test_Setup, FM_Test_Teardown, "Test_FM_MoveFileVerifyDispatch");
+
+    UtTest_Add(Test_FM_RenameFileVerifyDispatch, FM_Test_Setup, FM_Test_Teardown, "Test_FM_RenameFileVerifyDispatch");
+    UtTest_Add(Test_FM_DeleteFileVerifyDispatch, FM_Test_Setup, FM_Test_Teardown, "Test_FM_DeleteFileVerifyDispatch");
+    UtTest_Add(Test_FM_DeleteAllFilesVerifyDispatch, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_DeleteAllFilesVerifyDispatch");
+
+    UtTest_Add(Test_FM_DecompressFileVerifyDispatch, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_DecompressFileVerifyDispatch");
+
+    UtTest_Add(Test_FM_ConcatFilesVerifyDispatch, FM_Test_Setup, FM_Test_Teardown, "Test_FM_ConcatFilesVerifyDispatch");
+
+    UtTest_Add(Test_FM_GetFileInfoVerifyDispatch, FM_Test_Setup, FM_Test_Teardown, "Test_FM_GetFileInfoVerifyDispatch");
+
+    UtTest_Add(Test_FM_GetOpenFilesVerifyDispatch, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_GetOpenFilesVerifyDispatch");
+
+    UtTest_Add(Test_FM_CreateDirectoryVerifyDispatch, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_CreateDirectoryVerifyDispatch");
+
+    UtTest_Add(Test_FM_DeleteDirectoryVerifyDispatch, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_DeleteDirectoryVerifyDispatch");
+
+    UtTest_Add(Test_FM_GetDirListFileVerifyDispatch, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_GetDirListFileVerifyDispatch");
+
+    UtTest_Add(Test_FM_GetDirListPktVerifyDispatch, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_GetDirListPktVerifyDispatch");
+
+    UtTest_Add(Test_FM_MonitorFilesystemSpaceVerifyDispatch, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_MonitorFilesystemSpaceVerifyDispatch");
+
+    UtTest_Add(Test_FM_SetTableStateVerifyDispatch, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_SetTableStateVerifyDispatch");
+
+    UtTest_Add(Test_FM_SetPermissionsVerifyDispatch, FM_Test_Setup, FM_Test_Teardown,
+               "Test_FM_SetPermissionsVerifyDispatch");
+
+    UtTest_Add(Test_FM_SendHkVerifyDispatch, FM_Test_Setup, FM_Test_Teardown, "Test_FM_SendHkVerifyDispatch");
+}

--- a/unit-test/stubs/fm_cmd_utils_stubs.c
+++ b/unit-test/stubs/fm_cmd_utils_stubs.c
@@ -26,7 +26,6 @@
 #include "fm_cmd_utils.h"
 #include "utgenstub.h"
 
-void UT_DefaultHandler_FM_IsValidCmdPktLength(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_FM_VerifyChildTask(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_FM_VerifyDirExists(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_FM_VerifyDirNoExist(void *, UT_EntryKey_t, const UT_StubContext_t *);
@@ -129,25 +128,6 @@ void FM_InvokeChildTask(void)
 {
 
     UT_GenStub_Execute(FM_InvokeChildTask, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for FM_IsValidCmdPktLength()
- * ----------------------------------------------------
- */
-bool FM_IsValidCmdPktLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength, uint32 EventID, const char *CmdText)
-{
-    UT_GenStub_SetupReturnBuffer(FM_IsValidCmdPktLength, bool);
-
-    UT_GenStub_AddParam(FM_IsValidCmdPktLength, const CFE_MSG_Message_t *, MsgPtr);
-    UT_GenStub_AddParam(FM_IsValidCmdPktLength, size_t, ExpectedLength);
-    UT_GenStub_AddParam(FM_IsValidCmdPktLength, uint32, EventID);
-    UT_GenStub_AddParam(FM_IsValidCmdPktLength, const char *, CmdText);
-
-    UT_GenStub_Execute(FM_IsValidCmdPktLength, Basic, UT_DefaultHandler_FM_IsValidCmdPktLength);
-
-    return UT_GenStub_GetReturnValue(FM_IsValidCmdPktLength, bool);
 }
 
 /*

--- a/unit-test/stubs/fm_dispatch_stubs.c
+++ b/unit-test/stubs/fm_dispatch_stubs.c
@@ -20,45 +20,51 @@
 /**
  * @file
  *
- * Auto-Generated stub implementations for functions defined in fm_app header
+ * Auto-Generated stub implementations for functions defined in fm_dispatch header
  */
 
-#include "fm_app.h"
+#include "fm_dispatch.h"
 #include "utgenstub.h"
 
 /*
  * ----------------------------------------------------
- * Generated stub function for FM_AppInit()
+ * Generated stub function for FM_IsValidCmdPktLength()
  * ----------------------------------------------------
  */
-int32 FM_AppInit(void)
+bool FM_IsValidCmdPktLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength, uint32 EventID, const char *CmdText)
 {
-    UT_GenStub_SetupReturnBuffer(FM_AppInit, int32);
+    UT_GenStub_SetupReturnBuffer(FM_IsValidCmdPktLength, bool);
 
-    UT_GenStub_Execute(FM_AppInit, Basic, NULL);
+    UT_GenStub_AddParam(FM_IsValidCmdPktLength, const CFE_MSG_Message_t *, MsgPtr);
+    UT_GenStub_AddParam(FM_IsValidCmdPktLength, size_t, ExpectedLength);
+    UT_GenStub_AddParam(FM_IsValidCmdPktLength, uint32, EventID);
+    UT_GenStub_AddParam(FM_IsValidCmdPktLength, const char *, CmdText);
 
-    return UT_GenStub_GetReturnValue(FM_AppInit, int32);
+    UT_GenStub_Execute(FM_IsValidCmdPktLength, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(FM_IsValidCmdPktLength, bool);
 }
 
 /*
  * ----------------------------------------------------
- * Generated stub function for FM_AppMain()
+ * Generated stub function for FM_ProcessCmd()
  * ----------------------------------------------------
  */
-void FM_AppMain(void)
+void FM_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
 {
+    UT_GenStub_AddParam(FM_ProcessCmd, const CFE_SB_Buffer_t *, BufPtr);
 
-    UT_GenStub_Execute(FM_AppMain, Basic, NULL);
+    UT_GenStub_Execute(FM_ProcessCmd, Basic, NULL);
 }
 
 /*
  * ----------------------------------------------------
- * Generated stub function for FM_SendHkCmd()
+ * Generated stub function for FM_ProcessPkt()
  * ----------------------------------------------------
  */
-void FM_SendHkCmd(const CFE_SB_Buffer_t *BufPtr)
+void FM_ProcessPkt(const CFE_SB_Buffer_t *BufPtr)
 {
-    UT_GenStub_AddParam(FM_SendHkCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(FM_ProcessPkt, const CFE_SB_Buffer_t *, BufPtr);
 
-    UT_GenStub_Execute(FM_SendHkCmd, Basic, NULL);
+    UT_GenStub_Execute(FM_ProcessPkt, Basic, NULL);
 }


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/FM/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Move the CMD message input size validation to a separate function, so the command handler does not do this itself.  This allows the handler to focus on the real message action as opposed to the structure of the message itself.

Fixes #89

**Testing performed**
Build and run all tests.  Run FM in CFE and send commands to check behavior.

**Expected behavior changes**
No impact to behavior - improve source code structure/unit separation only

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
