### PR TITLE
Fix #95, Update command handler function message pointers and return

### DIFF
--- a/fsw/src/fm_app.c
+++ b/fsw/src/fm_app.c
@@ -246,7 +246,7 @@ CFE_Status_t FM_AppInit(void)
 /* FM application -- housekeeping request packet processor         */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void FM_SendHkCmd(const CFE_SB_Buffer_t *BufPtr)
+void FM_SendHkCmd(const FM_SendHkCmd_t *BufPtr)
 {
     FM_HousekeepingPkt_Payload_t *PayloadPtr;
 

--- a/fsw/src/fm_app.h
+++ b/fsw/src/fm_app.h
@@ -30,7 +30,7 @@
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* FM -- application global constants                              */
+/* FM -- Macro Definitions                                         */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -42,6 +42,11 @@
  *      message was received or not.
  */
 #define FM_SB_TIMEOUT 1000
+
+/**
+ *  \brief FM Error Codes
+ */
+#define FM_ERROR -1 /**< \brief Generic FM error return code */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -177,7 +182,7 @@ CFE_Status_t FM_AppInit(void);
  *
  *  \sa #FM_SendHkCmd_t, #FM_HousekeepingPkt_t
  */
-void FM_SendHkCmd(const CFE_SB_Buffer_t *BufPtr);
+void FM_SendHkCmd(const FM_SendHkCmd_t *BufPtr);
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */

--- a/fsw/src/fm_cmds.c
+++ b/fsw/src/fm_cmds.c
@@ -53,14 +53,14 @@
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_NoopCmd(const FM_NoopCmd_t *BufPtr)
 {
     const char *CmdText = "No-op";
 
     CFE_EVS_SendEvent(FM_NOOP_CMD_EID, CFE_EVS_EventType_INFORMATION, "%s command: FM version %d.%d.%d.%d", CmdText,
                       FM_MAJOR_VERSION, FM_MINOR_VERSION, FM_REVISION, FM_MISSION_REV);
 
-    return true;
+    return CFE_SUCCESS;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -69,7 +69,7 @@ bool FM_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_ResetCountersCmd(const FM_ResetCountersCmd_t *BufPtr)
 {
     const char *CmdText = "Reset Counters";
 
@@ -83,7 +83,7 @@ bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
     /* Send command completion event (debug) */
     CFE_EVS_SendEvent(FM_RESET_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command", CmdText);
 
-    return true;
+    return CFE_SUCCESS;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -92,10 +92,11 @@ bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_CopyFileCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_CopyFileCmd(const FM_CopyFileCmd_t *BufPtr)
 {
     FM_ChildQueueEntry_t *CmdArgs = NULL;
     const char *          CmdText = "Copy File";
+    CFE_Status_t          Status  = FM_ERROR;
     bool                  CommandResult;
 
     const FM_OvwSourceTargetFilename_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_CopyFileCmd_t);
@@ -143,9 +144,11 @@ bool FM_CopyFileCmd(const CFE_SB_Buffer_t *BufPtr)
 
         /* Invoke lower priority child task */
         FM_InvokeChildTask();
+
+        Status = CFE_SUCCESS;
     }
 
-    return CommandResult;
+    return Status;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -154,10 +157,11 @@ bool FM_CopyFileCmd(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_MoveFileCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_MoveFileCmd(const FM_MoveFileCmd_t *BufPtr)
 {
     FM_ChildQueueEntry_t *CmdArgs = NULL;
     const char *          CmdText = "Move File";
+    CFE_Status_t          Status  = FM_ERROR;
     bool                  CommandResult;
 
     const FM_OvwSourceTargetFilename_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_MoveFileCmd_t);
@@ -206,9 +210,11 @@ bool FM_MoveFileCmd(const CFE_SB_Buffer_t *BufPtr)
 
         /* Invoke lower priority child task */
         FM_InvokeChildTask();
+
+        Status = CFE_SUCCESS;
     }
 
-    return CommandResult;
+    return Status;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -217,10 +223,11 @@ bool FM_MoveFileCmd(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_RenameFileCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_RenameFileCmd(const FM_RenameFileCmd_t *BufPtr)
 {
     FM_ChildQueueEntry_t *CmdArgs = NULL;
     const char *          CmdText = "Rename File";
+    CFE_Status_t          Status  = FM_ERROR;
     bool                  CommandResult;
 
     const FM_SourceTargetFileName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_RenameFileCmd_t);
@@ -256,9 +263,11 @@ bool FM_RenameFileCmd(const CFE_SB_Buffer_t *BufPtr)
 
         /* Invoke lower priority child task */
         FM_InvokeChildTask();
+
+        Status = CFE_SUCCESS;
     }
 
-    return CommandResult;
+    return Status;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -267,10 +276,11 @@ bool FM_RenameFileCmd(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_DeleteFileCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_DeleteFileCmd(const FM_DeleteFileCmd_t *BufPtr)
 {
     FM_ChildQueueEntry_t *CmdArgs = NULL;
     const char *          CmdText = "Delete File";
+    CFE_Status_t          Status  = FM_ERROR;
     bool                  CommandResult;
 
     const FM_SingleFilename_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_DeleteFileCmd_t);
@@ -290,15 +300,17 @@ bool FM_DeleteFileCmd(const CFE_SB_Buffer_t *BufPtr)
         CmdArgs = &FM_GlobalData.ChildQueue[FM_GlobalData.ChildWriteIndex];
 
         /* Set handshake queue command args - might be global or internal CC */
-        CFE_MSG_GetFcnCode(&BufPtr->Msg, &CmdArgs->CommandCode);
+        CFE_MSG_GetFcnCode(&BufPtr->CommandHeader.Msg, &CmdArgs->CommandCode);
         strncpy(CmdArgs->Source1, CmdPtr->Filename, OS_MAX_PATH_LEN - 1);
         CmdArgs->Source1[OS_MAX_PATH_LEN - 1] = '\0';
 
         /* Invoke lower priority child task */
         FM_InvokeChildTask();
+
+        Status = CFE_SUCCESS;
     }
 
-    return CommandResult;
+    return Status;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -307,11 +319,12 @@ bool FM_DeleteFileCmd(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_DeleteAllFilesCmd(const FM_DeleteAllFilesCmd_t *BufPtr)
 {
     const char *          CmdText                     = "Delete All Files";
     char                  DirWithSep[OS_MAX_PATH_LEN] = "\0";
     FM_ChildQueueEntry_t *CmdArgs                     = NULL;
+    CFE_Status_t          Status                      = FM_ERROR;
     bool                  CommandResult;
 
     const FM_DirectoryName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_DeleteAllFilesCmd_t);
@@ -346,9 +359,11 @@ bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 
         /* Invoke lower priority child task */
         FM_InvokeChildTask();
+
+        Status = CFE_SUCCESS;
     }
 
-    return CommandResult;
+    return Status;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -357,10 +372,11 @@ bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_DecompressFileCmd(const FM_DecompressFileCmd_t *BufPtr)
 {
     const char *          CmdText = "Decompress File";
     FM_ChildQueueEntry_t *CmdArgs = NULL;
+    CFE_Status_t          Status  = FM_ERROR;
     bool                  CommandResult;
 
     const FM_SourceTargetFileName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_DecompressFileCmd_t);
@@ -394,21 +410,23 @@ bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr)
 
         /* Invoke lower priority child task */
         FM_InvokeChildTask();
+
+        Status = CFE_SUCCESS;
     }
 
-    return CommandResult;
+    return Status;
 }
-
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* FM command handler -- Concatenate Files                         */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_ConcatFilesCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_ConcatFilesCmd(const FM_ConcatFilesCmd_t *BufPtr)
 {
     const char *          CmdText = "Concat Files";
     FM_ChildQueueEntry_t *CmdArgs = NULL;
+    CFE_Status_t          Status  = FM_ERROR;
     bool                  CommandResult;
 
     const FM_TwoSourceOneTarget_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_ConcatFilesCmd_t);
@@ -450,9 +468,11 @@ bool FM_ConcatFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 
         /* Invoke lower priority child task */
         FM_InvokeChildTask();
+
+        Status = CFE_SUCCESS;
     }
 
-    return CommandResult;
+    return Status;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -461,10 +481,11 @@ bool FM_ConcatFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_GetFileInfoCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_GetFileInfoCmd(const FM_GetFileInfoCmd_t *BufPtr)
 {
     const char *          CmdText       = "Get File Info";
     FM_ChildQueueEntry_t *CmdArgs       = NULL;
+    CFE_Status_t          Status        = FM_ERROR;
     bool                  CommandResult = true;
     uint32                FilenameState = FM_NAME_IS_INVALID;
 
@@ -505,9 +526,11 @@ bool FM_GetFileInfoCmd(const CFE_SB_Buffer_t *BufPtr)
 
         /* Invoke lower priority child task */
         FM_InvokeChildTask();
+
+        Status = CFE_SUCCESS;
     }
 
-    return CommandResult;
+    return Status;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -516,7 +539,7 @@ bool FM_GetFileInfoCmd(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_GetOpenFilesCmd(const FM_GetOpenFilesCmd_t *BufPtr)
 {
     const char *CmdText      = "Get Open Files";
     uint32      NumOpenFiles = 0;
@@ -539,7 +562,7 @@ bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr)
     /* Send command completion event (debug) */
     CFE_EVS_SendEvent(FM_GET_OPEN_FILES_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command", CmdText);
 
-    return true;
+    return CFE_SUCCESS;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -548,10 +571,11 @@ bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_CreateDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_CreateDirectoryCmd(const FM_CreateDirectoryCmd_t *BufPtr)
 {
     FM_ChildQueueEntry_t *CmdArgs = NULL;
     const char *          CmdText = "Create Directory";
+    CFE_Status_t          Status  = FM_ERROR;
     bool                  CommandResult;
 
     const FM_DirectoryName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_CreateDirectoryCmd_t);
@@ -578,9 +602,11 @@ bool FM_CreateDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
 
         /* Invoke lower priority child task */
         FM_InvokeChildTask();
+
+        Status = CFE_SUCCESS;
     }
 
-    return CommandResult;
+    return Status;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -589,10 +615,11 @@ bool FM_CreateDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_DeleteDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_DeleteDirectoryCmd(const FM_DeleteDirectoryCmd_t *BufPtr)
 {
     FM_ChildQueueEntry_t *CmdArgs = NULL;
     const char *          CmdText = "Delete Directory";
+    CFE_Status_t          Status  = FM_ERROR;
     bool                  CommandResult;
 
     const FM_DirectoryName_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_DeleteDirectoryCmd_t);
@@ -619,9 +646,11 @@ bool FM_DeleteDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
 
         /* Invoke lower priority child task */
         FM_InvokeChildTask();
+
+        Status = CFE_SUCCESS;
     }
 
-    return CommandResult;
+    return Status;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -630,12 +659,13 @@ bool FM_DeleteDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_GetDirListFileCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_GetDirListFileCmd(const FM_GetDirListFileCmd_t *BufPtr)
 {
     const char *          CmdText                     = "Directory List to File";
     char                  DirWithSep[OS_MAX_PATH_LEN] = "\0";
     char                  Filename[OS_MAX_PATH_LEN]   = "\0";
     FM_ChildQueueEntry_t *CmdArgs                     = NULL;
+    CFE_Status_t          Status                      = FM_ERROR;
     bool                  CommandResult;
 
     const FM_GetDirectoryToFile_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_GetDirListFileCmd_t);
@@ -692,9 +722,11 @@ bool FM_GetDirListFileCmd(const CFE_SB_Buffer_t *BufPtr)
 
         /* Invoke lower priority child task */
         FM_InvokeChildTask();
+
+        Status = CFE_SUCCESS;
     }
 
-    return CommandResult;
+    return Status;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -703,11 +735,12 @@ bool FM_GetDirListFileCmd(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_GetDirListPktCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_GetDirListPktCmd(const FM_GetDirListPktCmd_t *BufPtr)
 {
     const char *          CmdText                     = "Directory List to Packet";
     char                  DirWithSep[OS_MAX_PATH_LEN] = "\0";
     FM_ChildQueueEntry_t *CmdArgs                     = NULL;
+    CFE_Status_t          Status                      = FM_ERROR;
     bool                  CommandResult;
 
     const FM_GetDirectoryToPkt_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_GetDirListPktCmd_t);
@@ -744,9 +777,11 @@ bool FM_GetDirListPktCmd(const CFE_SB_Buffer_t *BufPtr)
 
         /* Invoke lower priority child task */
         FM_InvokeChildTask();
+
+        Status = CFE_SUCCESS;
     }
 
-    return CommandResult;
+    return Status;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -755,12 +790,12 @@ bool FM_GetDirListPktCmd(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_MonitorFilesystemSpaceCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_MonitorFilesystemSpaceCmd(const FM_MonitorFilesystemSpaceCmd_t *BufPtr)
 {
-    const char *CmdText       = "Get Free Space";
-    bool        CommandResult = true;
-    uint32      i             = 0;
-    int32       OpResult;
+    const char * CmdText = "Get Free Space";
+    uint32       i       = 0;
+    CFE_Status_t Status  = CFE_SUCCESS;
+    int32        OpResult;
 
     const FM_MonitorTableEntry_t *MonitorPtr;
     FM_MonitorReportEntry_t *     ReportPtr;
@@ -768,7 +803,7 @@ bool FM_MonitorFilesystemSpaceCmd(const CFE_SB_Buffer_t *BufPtr)
     /* Verify that we have a pointer to the file system table data */
     if (FM_GlobalData.MonitorTablePtr == NULL)
     {
-        CommandResult = false;
+        Status = CFE_STATUS_INCORRECT_STATE;
 
         CFE_EVS_SendEvent(FM_GET_FREE_SPACE_TBL_ERR_EID, CFE_EVS_EventType_ERROR,
                           "%s error: file system free space table is not loaded", CmdText);
@@ -812,7 +847,7 @@ bool FM_MonitorFilesystemSpaceCmd(const CFE_SB_Buffer_t *BufPtr)
 
                     if (OpResult != CFE_SUCCESS)
                     {
-                        CommandResult = false;
+                        Status = FM_ERROR;
                     }
                 }
             }
@@ -834,7 +869,7 @@ bool FM_MonitorFilesystemSpaceCmd(const CFE_SB_Buffer_t *BufPtr)
         CFE_EVS_SendEvent(FM_MONITOR_FILESYSTEM_SPACE_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command", CmdText);
     }
 
-    return CommandResult;
+    return Status;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -843,17 +878,17 @@ bool FM_MonitorFilesystemSpaceCmd(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_SetTableStateCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_SetTableStateCmd(const FM_SetTableStateCmd_t *BufPtr)
 {
-    const char *CmdText       = "Set Table State";
-    bool        CommandResult = true;
+    const char * CmdText = "Set Table State";
+    CFE_Status_t Status  = CFE_SUCCESS;
 
     const FM_TableIndexAndState_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_SetTableStateCmd_t);
 
     if (FM_GlobalData.MonitorTablePtr == NULL)
     {
         /* File system table has not been loaded */
-        CommandResult = false;
+        Status = CFE_STATUS_INCORRECT_STATE;
 
         CFE_EVS_SendEvent(FM_SET_TABLE_STATE_TBL_ERR_EID, CFE_EVS_EventType_ERROR,
                           "%s error: file system free space table is not loaded", CmdText);
@@ -861,7 +896,7 @@ bool FM_SetTableStateCmd(const CFE_SB_Buffer_t *BufPtr)
     else if (CmdPtr->TableEntryIndex >= FM_TABLE_ENTRY_COUNT)
     {
         /* Table index argument is out of range */
-        CommandResult = false;
+        Status = CFE_STATUS_RANGE_ERROR;
 
         CFE_EVS_SendEvent(FM_SET_TABLE_STATE_ARG_IDX_ERR_EID, CFE_EVS_EventType_ERROR,
                           "%s error: invalid command argument: index = %d", CmdText, (int)CmdPtr->TableEntryIndex);
@@ -870,7 +905,7 @@ bool FM_SetTableStateCmd(const CFE_SB_Buffer_t *BufPtr)
              (CmdPtr->TableEntryState != FM_TABLE_ENTRY_DISABLED))
     {
         /* State argument must be either enabled or disabled */
-        CommandResult = false;
+        Status = CFE_STATUS_RANGE_ERROR;
 
         CFE_EVS_SendEvent(FM_SET_TABLE_STATE_ARG_STATE_ERR_EID, CFE_EVS_EventType_ERROR,
                           "%s error: invalid command argument: state = %d", CmdText, (int)CmdPtr->TableEntryState);
@@ -878,7 +913,7 @@ bool FM_SetTableStateCmd(const CFE_SB_Buffer_t *BufPtr)
     else if (FM_GlobalData.MonitorTablePtr->Entries[CmdPtr->TableEntryIndex].Type == FM_MonitorTableEntry_Type_UNUSED)
     {
         /* Current table entry state must not be unused */
-        CommandResult = false;
+        Status = CFE_STATUS_INCORRECT_STATE;
 
         CFE_EVS_SendEvent(FM_SET_TABLE_STATE_UNUSED_ERR_EID, CFE_EVS_EventType_ERROR,
                           "%s error: cannot modify unused table entry: index = %d", CmdText,
@@ -898,7 +933,7 @@ bool FM_SetTableStateCmd(const CFE_SB_Buffer_t *BufPtr)
                           (int)CmdPtr->TableEntryState);
     }
 
-    return CommandResult;
+    return Status;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -907,10 +942,11 @@ bool FM_SetTableStateCmd(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_SetPermissionsCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_SetPermissionsCmd(const FM_SetPermissionsCmd_t *BufPtr)
 {
     FM_ChildQueueEntry_t *CmdArgs       = NULL;
     const char *          CmdText       = "Set Permissions";
+    CFE_Status_t          Status        = FM_ERROR;
     bool                  CommandResult = true;
     bool                  FilenameState = FM_NAME_IS_INVALID;
 
@@ -941,7 +977,9 @@ bool FM_SetPermissionsCmd(const CFE_SB_Buffer_t *BufPtr)
 
         /* Invoke lower priority child task */
         FM_InvokeChildTask();
+
+        Status = CFE_SUCCESS;
     }
 
-    return CommandResult;
+    return Status;
 }

--- a/fsw/src/fm_cmds.h
+++ b/fsw/src/fm_cmds.h
@@ -25,6 +25,7 @@
 #define FM_CMDS_H
 
 #include "cfe.h"
+#include "fm_msg.h"
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -43,13 +44,12 @@
  *
  *  \param [in]  BufPtr Pointer to Software Bus command packet.
  *
- *  \return Boolean command success response
- *  \retval true  Command successful
- *  \retval false Command not successful
+ *  \return CFE_SUCCESS
+ *  \retval CFE_SUCCESS
  *
  *  \sa #FM_NOOP_CC, #FM_NoopCmd_t
  */
-bool FM_NoopCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t FM_NoopCmd(const FM_NoopCmd_t *BufPtr);
 
 /**
  *  \brief Reset Counters Command Handler Function
@@ -61,13 +61,12 @@ bool FM_NoopCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param [in]  BufPtr Pointer to Software Bus command packet.
  *
- *  \return Boolean command success response
- *  \retval true  Command successful
- *  \retval false Command not successful
+ *  \return CFE_SUCCESS
+ *  \retval CFE_SUCCESS
  *
  *  \sa #FM_RESET_COUNTERS_CC, #FM_ResetCountersCmd_t
  */
-bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t FM_ResetCountersCmd(const FM_ResetCountersCmd_t *BufPtr);
 
 /**
  *  \brief Copy File Command Handler Function
@@ -87,13 +86,13 @@ bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param [in]  BufPtr Pointer to Software Bus command packet.
  *
- *  \return Boolean command success response
- *  \retval true  Command successful
- *  \retval false Command not successful
+ *  \return CFE_SUCCESS on success, or relevant error code on failure
+ *  \retval CFE_SUCCESS  Command successful
+ *  \retval FM_ERROR     Command not successful
  *
  *  \sa #FM_COPY_FILE_CC, #FM_CopyFileCmd_t
  */
-bool FM_CopyFileCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t FM_CopyFileCmd(const FM_CopyFileCmd_t *BufPtr);
 
 /**
  *  \brief Move File Command Handler Function
@@ -106,13 +105,13 @@ bool FM_CopyFileCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param [in]  BufPtr Pointer to Software Bus command packet.
  *
- *  \return Boolean command success response
- *  \retval true  Command successful
- *  \retval false Command not successful
+ *  \return CFE_SUCCESS on success, or relevant error code on failure
+ *  \retval CFE_SUCCESS  Command successful
+ *  \retval FM_ERROR     Command not successful
  *
  *  \sa #FM_MOVE_FILE_CC, #FM_MoveFileCmd_t
  */
-bool FM_MoveFileCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t FM_MoveFileCmd(const FM_MoveFileCmd_t *BufPtr);
 
 /**
  *  \brief Rename File Command Handler Function
@@ -125,13 +124,13 @@ bool FM_MoveFileCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param [in]  BufPtr Pointer to Software Bus command packet.
  *
- *  \return Boolean command success response
- *  \retval true  Command successful
- *  \retval false Command not successful
+ *  \return CFE_SUCCESS on success, or relevant error code on failure
+ *  \retval CFE_SUCCESS  Command successful
+ *  \retval FM_ERROR     Command not successful
  *
  *  \sa #FM_RENAME_FILE_CC, #FM_RenameFileCmd_t
  */
-bool FM_RenameFileCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t FM_RenameFileCmd(const FM_RenameFileCmd_t *BufPtr);
 
 /**
  *  \brief Delete File Command Handler Function
@@ -143,13 +142,13 @@ bool FM_RenameFileCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param [in]  BufPtr Pointer to Software Bus command packet.
  *
- *  \return Boolean command success response
- *  \retval true  Command successful
- *  \retval false Command not successful
+ *  \return CFE_SUCCESS on success, or relevant error code on failure
+ *  \retval CFE_SUCCESS  Command successful
+ *  \retval FM_ERROR     Command not successful
  *
  *  \sa #FM_DELETE_FILE_CC, #FM_DeleteFileCmd_t
  */
-bool FM_DeleteFileCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t FM_DeleteFileCmd(const FM_DeleteFileCmd_t *BufPtr);
 
 /**
  *  \brief Delete All Files Command Handler Function
@@ -169,13 +168,13 @@ bool FM_DeleteFileCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param [in]  BufPtr Pointer to Software Bus command packet.
  *
- *  \return Boolean command success response
- *  \retval true  Command successful
- *  \retval false Command not successful
+ *  \return CFE_SUCCESS on success, or relevant error code on failure
+ *  \retval CFE_SUCCESS  Command successful
+ *  \retval FM_ERROR     Command not successful
  *
  *  \sa #FM_DELETE_ALL_FILES_CC, #FM_DeleteAllFilesCmd_t
  */
-bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t FM_DeleteAllFilesCmd(const FM_DeleteAllFilesCmd_t *BufPtr);
 
 /**
  *  \brief Decompress Files Command Handler Function
@@ -196,13 +195,13 @@ bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param [in]  BufPtr Pointer to Software Bus command packet.
  *
- *  \return Boolean command success response
- *  \retval true  Command successful
- *  \retval false Command not successful
+ *  \return CFE_SUCCESS on success, or relevant error code on failure
+ *  \retval CFE_SUCCESS  Command successful
+ *  \retval FM_ERROR     Command not successful
  *
  *  \sa #FM_DECOMPRESS_FILE_CC, #FM_DecompressFileCmd_t
  */
-bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t FM_DecompressFileCmd(const FM_DecompressFileCmd_t *BufPtr);
 
 /**
  *  \brief Concatenate Files Command Handler Function
@@ -224,13 +223,13 @@ bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param [in]  BufPtr Pointer to Software Bus command packet.
  *
- *  \return Boolean command success response
- *  \retval true  Command successful
- *  \retval false Command not successful
+ *  \return CFE_SUCCESS on success, or relevant error code on failure
+ *  \retval CFE_SUCCESS  Command successful
+ *  \retval FM_ERROR     Command not successful
  *
  *  \sa #FM_CONCAT_FILES_CC, #FM_ConcatFilesCmd_t
  */
-bool FM_ConcatFilesCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t FM_ConcatFilesCmd(const FM_ConcatFilesCmd_t *BufPtr);
 
 /**
  *  \brief Get File Information Command Handler Function
@@ -251,13 +250,13 @@ bool FM_ConcatFilesCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param [in]  BufPtr Pointer to Software Bus command packet.
  *
- *  \return Boolean command success response
- *  \retval true  Command successful
- *  \retval false Command not successful
+ *  \return CFE_SUCCESS on success, or relevant error code on failure
+ *  \retval CFE_SUCCESS  Command successful
+ *  \retval FM_ERROR     Command not successful
  *
  *  \sa #FM_GET_FILE_INFO_CC, #FM_GetFileInfoCmd_t, #FM_FileInfoPkt_t
  */
-bool FM_GetFileInfoCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t FM_GetFileInfoCmd(const FM_GetFileInfoCmd_t *BufPtr);
 
 /**
  *  \brief Get Open Files List Command Handler Function
@@ -270,13 +269,12 @@ bool FM_GetFileInfoCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param [in]  BufPtr Pointer to Software Bus command packet.
  *
- *  \return Boolean command success response
- *  \retval true  Command successful
- *  \retval false Command not successful
+ *  \return CFE_SUCCESS
+ *  \retval CFE_SUCCESS
  *
  *  \sa #FM_GET_OPEN_FILES_CC, #FM_GetOpenFilesCmd_t, #FM_OpenFilesPkt_t
  */
-bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t FM_GetOpenFilesCmd(const FM_GetOpenFilesCmd_t *BufPtr);
 
 /**
  *  \brief Create Directory Command Handler Function
@@ -288,13 +286,13 @@ bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param [in]  BufPtr Pointer to Software Bus command packet.
  *
- *  \return Boolean command success response
- *  \retval true  Command successful
- *  \retval false Command not successful
+ *  \return CFE_SUCCESS on success, or relevant error code on failure
+ *  \retval CFE_SUCCESS  Command successful
+ *  \retval FM_ERROR     Command not successful
  *
  *  \sa #FM_CREATE_DIRECTORY_CC, #FM_CreateDirectoryCmd_t
  */
-bool FM_CreateDirectoryCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t FM_CreateDirectoryCmd(const FM_CreateDirectoryCmd_t *BufPtr);
 
 /**
  *  \brief Delete Directory Command Handler Function
@@ -306,13 +304,13 @@ bool FM_CreateDirectoryCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param [in]  BufPtr Pointer to Software Bus command packet.
  *
- *  \return Boolean command success response
- *  \retval true  Command successful
- *  \retval false Command not successful
+ *  \return CFE_SUCCESS on success, or relevant error code on failure
+ *  \retval CFE_SUCCESS  Command successful
+ *  \retval FM_ERROR     Command not successful
  *
  *  \sa #FM_DELETE_DIRECTORY_CC, #FM_DeleteDirectoryCmd_t
  */
-bool FM_DeleteDirectoryCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t FM_DeleteDirectoryCmd(const FM_DeleteDirectoryCmd_t *BufPtr);
 
 /**
  *  \brief Get Directory List to Packet Command Handler Function
@@ -332,14 +330,14 @@ bool FM_DeleteDirectoryCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param [in]  BufPtr Pointer to Software Bus command packet.
  *
- *  \return Boolean command success response
- *  \retval true  Command successful
- *  \retval false Command not successful
+ *  \return CFE_SUCCESS on success, or relevant error code on failure
+ *  \retval CFE_SUCCESS  Command successful
+ *  \retval FM_ERROR     Command not successful
  *
  *  \sa #FM_GET_DIR_LIST_FILE_CC, #FM_GetDirListFileCmd_t,
  *      #FM_DirListFileStats_t, FM_DirListEntry_t
  */
-bool FM_GetDirListFileCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t FM_GetDirListFileCmd(const FM_GetDirListFileCmd_t *BufPtr);
 
 /**
  *  \brief Get Directory List to Packet Command Handler Function
@@ -360,13 +358,13 @@ bool FM_GetDirListFileCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param [in]  BufPtr Pointer to Software Bus command packet.
  *
- *  \return Boolean command success response
- *  \retval true  Command successful
- *  \retval false Command not successful
+ *  \return CFE_SUCCESS on success, or relevant error code on failure
+ *  \retval CFE_SUCCESS  Command successful
+ *  \retval FM_ERROR     Command not successful
  *
  *  \sa #FM_GET_DIR_LIST_PKT_CC, #FM_GetDirListPktCmd_t, #FM_DirListPkt_t
  */
-bool FM_GetDirListPktCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t FM_GetDirListPktCmd(const FM_GetDirListPktCmd_t *BufPtr);
 
 /**
  *  \brief Monitor Filesystem Command Handler Function
@@ -380,13 +378,14 @@ bool FM_GetDirListPktCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param [in]  BufPtr Pointer to Software Bus command packet.
  *
- *  \return Boolean command success response
- *  \retval true  Command successful
- *  \retval false Command not successful
+ *  \return CFE_SUCCESS on success, or relevant error code on failure
+ *  \retval CFE_SUCCESS                 Command successful
+ *  \retval CFE_STATUS_INCORRECT_STATE  File System Table Pointer is NULL
+ *  \retval FM_ERROR                    Command not successful
  *
  *  \sa #FM_MONITOR_FILESYSTEM_SPACE_CC, #FM_MonitorFilesystemSpaceCmd_t, #FM_MonitorReportPkt_t
  */
-bool FM_MonitorFilesystemSpaceCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t FM_MonitorFilesystemSpaceCmd(const FM_MonitorFilesystemSpaceCmd_t *BufPtr);
 
 /**
  *  \brief Set Table Entry State Command Handler Function
@@ -399,13 +398,14 @@ bool FM_MonitorFilesystemSpaceCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param [in]  BufPtr Pointer to Software Bus command packet.
  *
- *  \return Boolean command success response
- *  \retval true  Command successful
- *  \retval false Command not successful
+ *  \return CFE_SUCCESS on success, or relevant error code on failure
+ *  \retval CFE_SUCCESS                 Command successful
+ *  \retval CFE_STATUS_INCORRECT_STATE  File system table was not loaded yet or Unused Table Entry State
+ *  \retval CFE_STATUS_RANGE_ERROR      Invalid Table Entry Index or Table Entry State
  *
  *  \sa #FM_SET_TABLE_STATE_CC, #FM_SetTableStateCmd_t, #FM_MonitorTableEntry_t
  */
-bool FM_SetTableStateCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t FM_SetTableStateCmd(const FM_SetTableStateCmd_t *BufPtr);
 
 /**
  *  \brief Set File Permissions of a file
@@ -417,12 +417,12 @@ bool FM_SetTableStateCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param [in]  BufPtr Pointer to Software Bus command packet.
  *
- *  \return Boolean command success response
- *  \retval true  Command successful
- *  \retval false Command not successful
+ *  \return CFE_SUCCESS on success, or relevant error code on failure
+ *  \retval CFE_SUCCESS  Command successful
+ *  \retval FM_ERROR     Command not successful
  *
  *  \sa #FM_SET_PERMISSIONS_CC, #FM_SetPermissionsCmd_t, #FM_SET_PERM_CMD_EID, #FM_SET_PERM_ERR_EID
  */
-bool FM_SetPermissionsCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t FM_SetPermissionsCmd(const FM_SetPermissionsCmd_t *BufPtr);
 
 #endif

--- a/fsw/src/fm_compression.h
+++ b/fsw/src/fm_compression.h
@@ -28,6 +28,7 @@
 #ifndef FM_COMPRESSION_H
 #define FM_COMPRESSION_H
 
+#include <cfe_error.h>
 #include <common_types.h>
 #include <fm_platform_cfg.h>
 

--- a/fsw/src/fm_dispatch.c
+++ b/fsw/src/fm_dispatch.c
@@ -72,12 +72,12 @@ bool FM_IsValidCmdPktLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLeng
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_NoopVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_NoopVerifyDispatch(const FM_NoopCmd_t *BufPtr)
 {
     /* Verify message length */
-    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_NoopCmd_t), FM_NOOP_PKT_ERR_EID, "No-op"))
+    if (!FM_IsValidCmdPktLength(&BufPtr->CommandHeader.Msg, sizeof(FM_NoopCmd_t), FM_NOOP_PKT_ERR_EID, "No-op"))
     {
-        return false;
+        return CFE_STATUS_VALIDATION_FAILURE;
     }
 
     return FM_NoopCmd(BufPtr);
@@ -89,12 +89,13 @@ bool FM_NoopVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_ResetCountersVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_ResetCountersVerifyDispatch(const FM_ResetCountersCmd_t *BufPtr)
 {
     /* Verify message length */
-    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_ResetCountersCmd_t), FM_RESET_PKT_ERR_EID, "Reset Counters"))
+    if (!FM_IsValidCmdPktLength(&BufPtr->CommandHeader.Msg, sizeof(FM_ResetCountersCmd_t), FM_RESET_PKT_ERR_EID,
+                                "Reset Counters"))
     {
-        return false;
+        return CFE_STATUS_VALIDATION_FAILURE;
     }
 
     return FM_ResetCountersCmd(BufPtr);
@@ -106,12 +107,12 @@ bool FM_ResetCountersVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_CopyFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_CopyFileVerifyDispatch(const FM_CopyFileCmd_t *BufPtr)
 {
     /* Verify command packet length */
-    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_CopyFileCmd_t), FM_COPY_PKT_ERR_EID, "Copy File"))
+    if (!FM_IsValidCmdPktLength(&BufPtr->CommandHeader.Msg, sizeof(FM_CopyFileCmd_t), FM_COPY_PKT_ERR_EID, "Copy File"))
     {
-        return false;
+        return CFE_STATUS_VALIDATION_FAILURE;
     }
 
     return FM_CopyFileCmd(BufPtr);
@@ -123,12 +124,12 @@ bool FM_CopyFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_MoveFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_MoveFileVerifyDispatch(const FM_MoveFileCmd_t *BufPtr)
 {
     /* Verify command packet length */
-    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_MoveFileCmd_t), FM_MOVE_PKT_ERR_EID, "Move File"))
+    if (!FM_IsValidCmdPktLength(&BufPtr->CommandHeader.Msg, sizeof(FM_MoveFileCmd_t), FM_MOVE_PKT_ERR_EID, "Move File"))
     {
-        return false;
+        return CFE_STATUS_VALIDATION_FAILURE;
     }
 
     return FM_MoveFileCmd(BufPtr);
@@ -140,12 +141,13 @@ bool FM_MoveFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_RenameFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_RenameFileVerifyDispatch(const FM_RenameFileCmd_t *BufPtr)
 {
     /* Verify command packet length */
-    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_RenameFileCmd_t), FM_RENAME_PKT_ERR_EID, "Rename File"))
+    if (!FM_IsValidCmdPktLength(&BufPtr->CommandHeader.Msg, sizeof(FM_RenameFileCmd_t), FM_RENAME_PKT_ERR_EID,
+                                "Rename File"))
     {
-        return false;
+        return CFE_STATUS_VALIDATION_FAILURE;
     }
 
     return FM_RenameFileCmd(BufPtr);
@@ -157,12 +159,13 @@ bool FM_RenameFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_DeleteFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_DeleteFileVerifyDispatch(const FM_DeleteFileCmd_t *BufPtr)
 {
     /* Verify command packet length */
-    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DeleteFileCmd_t), FM_DELETE_PKT_ERR_EID, "Delete File"))
+    if (!FM_IsValidCmdPktLength(&BufPtr->CommandHeader.Msg, sizeof(FM_DeleteFileCmd_t), FM_DELETE_PKT_ERR_EID,
+                                "Delete File"))
     {
-        return false;
+        return CFE_STATUS_VALIDATION_FAILURE;
     }
 
     return FM_DeleteFileCmd(BufPtr);
@@ -174,13 +177,13 @@ bool FM_DeleteFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_DeleteAllFilesVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_DeleteAllFilesVerifyDispatch(const FM_DeleteAllFilesCmd_t *BufPtr)
 {
     /* Verify message length */
-    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DeleteAllFilesCmd_t), FM_DELETE_ALL_PKT_ERR_EID,
+    if (!FM_IsValidCmdPktLength(&BufPtr->CommandHeader.Msg, sizeof(FM_DeleteAllFilesCmd_t), FM_DELETE_ALL_PKT_ERR_EID,
                                 "Delete All Files"))
     {
-        return false;
+        return CFE_STATUS_VALIDATION_FAILURE;
     }
 
     return FM_DeleteAllFilesCmd(BufPtr);
@@ -192,12 +195,13 @@ bool FM_DeleteAllFilesVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_DecompressFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_DecompressFileVerifyDispatch(const FM_DecompressFileCmd_t *BufPtr)
 {
     /* Verify command packet length */
-    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DecompressFileCmd_t), FM_DECOM_PKT_ERR_EID, "Decompress File"))
+    if (!FM_IsValidCmdPktLength(&BufPtr->CommandHeader.Msg, sizeof(FM_DecompressFileCmd_t), FM_DECOM_PKT_ERR_EID,
+                                "Decompress File"))
     {
-        return false;
+        return CFE_STATUS_VALIDATION_FAILURE;
     }
 
     return FM_DecompressFileCmd(BufPtr);
@@ -209,12 +213,13 @@ bool FM_DecompressFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_ConcatFilesVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_ConcatFilesVerifyDispatch(const FM_ConcatFilesCmd_t *BufPtr)
 {
     /* Verify command packet length */
-    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_ConcatFilesCmd_t), FM_CONCAT_PKT_ERR_EID, "Concat Files"))
+    if (!FM_IsValidCmdPktLength(&BufPtr->CommandHeader.Msg, sizeof(FM_ConcatFilesCmd_t), FM_CONCAT_PKT_ERR_EID,
+                                "Concat Files"))
     {
-        return false;
+        return CFE_STATUS_VALIDATION_FAILURE;
     }
 
     return FM_ConcatFilesCmd(BufPtr);
@@ -226,13 +231,13 @@ bool FM_ConcatFilesVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_GetFileInfoVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_GetFileInfoVerifyDispatch(const FM_GetFileInfoCmd_t *BufPtr)
 {
     /* Verify command packet length */
-    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_GetFileInfoCmd_t), FM_GET_FILE_INFO_PKT_ERR_EID,
+    if (!FM_IsValidCmdPktLength(&BufPtr->CommandHeader.Msg, sizeof(FM_GetFileInfoCmd_t), FM_GET_FILE_INFO_PKT_ERR_EID,
                                 "Get File Info"))
     {
-        return false;
+        return CFE_STATUS_VALIDATION_FAILURE;
     }
 
     return FM_GetFileInfoCmd(BufPtr);
@@ -244,13 +249,13 @@ bool FM_GetFileInfoVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_GetOpenFilesVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_GetOpenFilesVerifyDispatch(const FM_GetOpenFilesCmd_t *BufPtr)
 {
     /* Verify command packet length */
-    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_GetOpenFilesCmd_t), FM_GET_OPEN_FILES_PKT_ERR_EID,
+    if (!FM_IsValidCmdPktLength(&BufPtr->CommandHeader.Msg, sizeof(FM_GetOpenFilesCmd_t), FM_GET_OPEN_FILES_PKT_ERR_EID,
                                 "Get Open Files"))
     {
-        return false;
+        return CFE_STATUS_VALIDATION_FAILURE;
     }
 
     return FM_GetOpenFilesCmd(BufPtr);
@@ -262,13 +267,13 @@ bool FM_GetOpenFilesVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_CreateDirectoryVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_CreateDirectoryVerifyDispatch(const FM_CreateDirectoryCmd_t *BufPtr)
 {
     /* Verify command packet length */
-    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_CreateDirectoryCmd_t), FM_CREATE_DIR_PKT_ERR_EID,
+    if (!FM_IsValidCmdPktLength(&BufPtr->CommandHeader.Msg, sizeof(FM_CreateDirectoryCmd_t), FM_CREATE_DIR_PKT_ERR_EID,
                                 "Create Directory"))
     {
-        return false;
+        return CFE_STATUS_VALIDATION_FAILURE;
     }
 
     return FM_CreateDirectoryCmd(BufPtr);
@@ -280,13 +285,13 @@ bool FM_CreateDirectoryVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_DeleteDirectoryVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_DeleteDirectoryVerifyDispatch(const FM_DeleteDirectoryCmd_t *BufPtr)
 {
     /* Verify command packet length */
-    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_DeleteDirectoryCmd_t), FM_DELETE_DIR_PKT_ERR_EID,
+    if (!FM_IsValidCmdPktLength(&BufPtr->CommandHeader.Msg, sizeof(FM_DeleteDirectoryCmd_t), FM_DELETE_DIR_PKT_ERR_EID,
                                 "Delete Directory"))
     {
-        return false;
+        return CFE_STATUS_VALIDATION_FAILURE;
     }
 
     return FM_DeleteDirectoryCmd(BufPtr);
@@ -298,13 +303,13 @@ bool FM_DeleteDirectoryVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_GetDirListFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_GetDirListFileVerifyDispatch(const FM_GetDirListFileCmd_t *BufPtr)
 {
     /* Verify command packet length */
-    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_GetDirListFileCmd_t), FM_GET_DIR_FILE_PKT_ERR_EID,
+    if (!FM_IsValidCmdPktLength(&BufPtr->CommandHeader.Msg, sizeof(FM_GetDirListFileCmd_t), FM_GET_DIR_FILE_PKT_ERR_EID,
                                 "Directory List to File"))
     {
-        return false;
+        return CFE_STATUS_VALIDATION_FAILURE;
     }
 
     return FM_GetDirListFileCmd(BufPtr);
@@ -316,13 +321,13 @@ bool FM_GetDirListFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_GetDirListPktVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_GetDirListPktVerifyDispatch(const FM_GetDirListPktCmd_t *BufPtr)
 {
     /* Verify command packet length */
-    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_GetDirListPktCmd_t), FM_GET_DIR_PKT_PKT_ERR_EID,
+    if (!FM_IsValidCmdPktLength(&BufPtr->CommandHeader.Msg, sizeof(FM_GetDirListPktCmd_t), FM_GET_DIR_PKT_PKT_ERR_EID,
                                 "Directory List to Packet"))
     {
-        return false;
+        return CFE_STATUS_VALIDATION_FAILURE;
     }
 
     return FM_GetDirListPktCmd(BufPtr);
@@ -334,13 +339,13 @@ bool FM_GetDirListPktVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_MonitorFilesystemSpaceVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_MonitorFilesystemSpaceVerifyDispatch(const FM_MonitorFilesystemSpaceCmd_t *BufPtr)
 {
     /* Verify command packet length */
-    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_MonitorFilesystemSpaceCmd_t), FM_GET_FREE_SPACE_PKT_ERR_EID,
-                                "Get Free Space"))
+    if (!FM_IsValidCmdPktLength(&BufPtr->CommandHeader.Msg, sizeof(FM_MonitorFilesystemSpaceCmd_t),
+                                FM_GET_FREE_SPACE_PKT_ERR_EID, "Get Free Space"))
     {
-        return false;
+        return CFE_STATUS_VALIDATION_FAILURE;
     }
 
     return FM_MonitorFilesystemSpaceCmd(BufPtr);
@@ -352,13 +357,13 @@ bool FM_MonitorFilesystemSpaceVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_SetTableStateVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_SetTableStateVerifyDispatch(const FM_SetTableStateCmd_t *BufPtr)
 {
     /* Verify command packet length */
-    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_SetTableStateCmd_t), FM_SET_TABLE_STATE_PKT_ERR_EID,
-                                "Set Table State"))
+    if (!FM_IsValidCmdPktLength(&BufPtr->CommandHeader.Msg, sizeof(FM_SetTableStateCmd_t),
+                                FM_SET_TABLE_STATE_PKT_ERR_EID, "Set Table State"))
     {
-        return false;
+        return CFE_STATUS_VALIDATION_FAILURE;
     }
 
     return FM_SetTableStateCmd(BufPtr);
@@ -370,12 +375,13 @@ bool FM_SetTableStateVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-bool FM_SetPermissionsVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_SetPermissionsVerifyDispatch(const FM_SetPermissionsCmd_t *BufPtr)
 {
     /* Verify command packet length */
-    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_SetPermissionsCmd_t), FM_SET_PERM_ERR_EID, "Set Permissions"))
+    if (!FM_IsValidCmdPktLength(&BufPtr->CommandHeader.Msg, sizeof(FM_SetPermissionsCmd_t), FM_SET_PERM_ERR_EID,
+                                "Set Permissions"))
     {
-        return false;
+        return CFE_STATUS_VALIDATION_FAILURE;
     }
 
     return FM_SetPermissionsCmd(BufPtr);
@@ -387,10 +393,10 @@ bool FM_SetPermissionsVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-void FM_SendHkVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+void FM_SendHkVerifyDispatch(const FM_SendHkCmd_t *BufPtr)
 {
     /* Verify command packet length */
-    if (!FM_IsValidCmdPktLength(&BufPtr->Msg, sizeof(FM_SendHkCmd_t), FM_HK_REQ_ERR_EID, "HK Request"))
+    if (!FM_IsValidCmdPktLength(&BufPtr->CommandHeader.Msg, sizeof(FM_SendHkCmd_t), FM_HK_REQ_ERR_EID, "HK Request"))
     {
         return;
     }
@@ -414,7 +420,7 @@ void FM_ProcessPkt(const CFE_SB_Buffer_t *BufPtr)
     {
         /* Housekeeping request */
         case FM_SEND_HK_MID:
-            FM_SendHkVerifyDispatch(BufPtr);
+            FM_SendHkVerifyDispatch((FM_SendHkCmd_t *)BufPtr);
             break;
 
         /* FM ground commands */
@@ -437,7 +443,7 @@ void FM_ProcessPkt(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void FM_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    bool              Result;
+    CFE_Status_t      Status      = FM_ERROR;
     CFE_MSG_FcnCode_t CommandCode = 0;
 
     CFE_MSG_GetFcnCode(&BufPtr->Msg, &CommandCode);
@@ -446,85 +452,84 @@ void FM_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
     switch (CommandCode)
     {
         case FM_NOOP_CC:
-            Result = FM_NoopVerifyDispatch(BufPtr);
+            Status = FM_NoopVerifyDispatch((FM_NoopCmd_t *)BufPtr);
             break;
 
         case FM_RESET_COUNTERS_CC:
-            Result = FM_ResetCountersVerifyDispatch(BufPtr);
+            Status = FM_ResetCountersVerifyDispatch((FM_ResetCountersCmd_t *)BufPtr);
             break;
 
         case FM_COPY_FILE_CC:
-            Result = FM_CopyFileVerifyDispatch(BufPtr);
+            Status = FM_CopyFileVerifyDispatch((FM_CopyFileCmd_t *)BufPtr);
             break;
 
         case FM_MOVE_FILE_CC:
-            Result = FM_MoveFileVerifyDispatch(BufPtr);
+            Status = FM_MoveFileVerifyDispatch((FM_MoveFileCmd_t *)BufPtr);
             break;
 
         case FM_RENAME_FILE_CC:
-            Result = FM_RenameFileVerifyDispatch(BufPtr);
+            Status = FM_RenameFileVerifyDispatch((FM_RenameFileCmd_t *)BufPtr);
             break;
 
         case FM_DELETE_FILE_CC:
-            Result = FM_DeleteFileVerifyDispatch(BufPtr);
+            Status = FM_DeleteFileVerifyDispatch((FM_DeleteFileCmd_t *)BufPtr);
             break;
 
         case FM_DELETE_ALL_FILES_CC:
-            Result = FM_DeleteAllFilesVerifyDispatch(BufPtr);
+            Status = FM_DeleteAllFilesVerifyDispatch((FM_DeleteAllFilesCmd_t *)BufPtr);
             break;
 
         case FM_DECOMPRESS_FILE_CC:
-            Result = FM_DecompressFileVerifyDispatch(BufPtr);
+            Status = FM_DecompressFileVerifyDispatch((FM_DecompressFileCmd_t *)BufPtr);
             break;
 
         case FM_CONCAT_FILES_CC:
-            Result = FM_ConcatFilesVerifyDispatch(BufPtr);
+            Status = FM_ConcatFilesVerifyDispatch((FM_ConcatFilesCmd_t *)BufPtr);
             break;
 
         case FM_GET_FILE_INFO_CC:
-            Result = FM_GetFileInfoVerifyDispatch(BufPtr);
+            Status = FM_GetFileInfoVerifyDispatch((FM_GetFileInfoCmd_t *)BufPtr);
             break;
 
         case FM_GET_OPEN_FILES_CC:
-            Result = FM_GetOpenFilesVerifyDispatch(BufPtr);
+            Status = FM_GetOpenFilesVerifyDispatch((FM_GetOpenFilesCmd_t *)BufPtr);
             break;
 
         case FM_CREATE_DIRECTORY_CC:
-            Result = FM_CreateDirectoryVerifyDispatch(BufPtr);
+            Status = FM_CreateDirectoryVerifyDispatch((FM_CreateDirectoryCmd_t *)BufPtr);
             break;
 
         case FM_DELETE_DIRECTORY_CC:
-            Result = FM_DeleteDirectoryVerifyDispatch(BufPtr);
+            Status = FM_DeleteDirectoryVerifyDispatch((FM_DeleteDirectoryCmd_t *)BufPtr);
             break;
 
         case FM_GET_DIR_LIST_FILE_CC:
-            Result = FM_GetDirListFileVerifyDispatch(BufPtr);
+            Status = FM_GetDirListFileVerifyDispatch((FM_GetDirListFileCmd_t *)BufPtr);
             break;
 
         case FM_GET_DIR_LIST_PKT_CC:
-            Result = FM_GetDirListPktVerifyDispatch(BufPtr);
+            Status = FM_GetDirListPktVerifyDispatch((FM_GetDirListPktCmd_t *)BufPtr);
             break;
 
         case FM_MONITOR_FILESYSTEM_SPACE_CC:
-            Result = FM_MonitorFilesystemSpaceVerifyDispatch(BufPtr);
+            Status = FM_MonitorFilesystemSpaceVerifyDispatch((FM_MonitorFilesystemSpaceCmd_t *)BufPtr);
             break;
 
         case FM_SET_TABLE_STATE_CC:
-            Result = FM_SetTableStateVerifyDispatch(BufPtr);
+            Status = FM_SetTableStateVerifyDispatch((FM_SetTableStateCmd_t *)BufPtr);
             break;
 
         case FM_SET_PERMISSIONS_CC:
-            Result = FM_SetPermissionsVerifyDispatch(BufPtr);
+            Status = FM_SetPermissionsVerifyDispatch((FM_SetPermissionsCmd_t *)BufPtr);
             break;
 
         default:
-            Result = false;
             CFE_EVS_SendEvent(FM_CC_ERR_EID, CFE_EVS_EventType_ERROR, "Main loop error: invalid command code: cc = %d",
                               CommandCode);
             break;
     }
 
-    if (Result)
+    if (Status == CFE_SUCCESS)
     {
         /* Increment command success counter */
         if (CommandCode != FM_RESET_COUNTERS_CC)

--- a/fsw/src/fm_dispatch.h
+++ b/fsw/src/fm_dispatch.h
@@ -80,24 +80,24 @@ bool FM_IsValidCmdPktLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLeng
  * Internal dispatch function for each command -
  * These are declared here so they can be directly invoked by the unit test for coverage
  */
-bool FM_NoopVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
-bool FM_ResetCountersVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
-bool FM_CopyFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
-bool FM_MoveFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
-bool FM_RenameFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
-bool FM_DeleteFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
-bool FM_DeleteAllFilesVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
-bool FM_DecompressFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
-bool FM_ConcatFilesVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
-bool FM_GetFileInfoVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
-bool FM_GetOpenFilesVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
-bool FM_CreateDirectoryVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
-bool FM_DeleteDirectoryVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
-bool FM_GetDirListFileVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
-bool FM_GetDirListPktVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
-bool FM_MonitorFilesystemSpaceVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
-bool FM_SetTableStateVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
-bool FM_SetPermissionsVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
-void FM_SendHkVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t FM_NoopVerifyDispatch(const FM_NoopCmd_t *BufPtr);
+CFE_Status_t FM_ResetCountersVerifyDispatch(const FM_ResetCountersCmd_t *BufPtr);
+CFE_Status_t FM_CopyFileVerifyDispatch(const FM_CopyFileCmd_t *BufPtr);
+CFE_Status_t FM_MoveFileVerifyDispatch(const FM_MoveFileCmd_t *BufPtr);
+CFE_Status_t FM_RenameFileVerifyDispatch(const FM_RenameFileCmd_t *BufPtr);
+CFE_Status_t FM_DeleteFileVerifyDispatch(const FM_DeleteFileCmd_t *BufPtr);
+CFE_Status_t FM_DeleteAllFilesVerifyDispatch(const FM_DeleteAllFilesCmd_t *BufPtr);
+CFE_Status_t FM_DecompressFileVerifyDispatch(const FM_DecompressFileCmd_t *BufPtr);
+CFE_Status_t FM_ConcatFilesVerifyDispatch(const FM_ConcatFilesCmd_t *BufPtr);
+CFE_Status_t FM_GetFileInfoVerifyDispatch(const FM_GetFileInfoCmd_t *BufPtr);
+CFE_Status_t FM_GetOpenFilesVerifyDispatch(const FM_GetOpenFilesCmd_t *BufPtr);
+CFE_Status_t FM_CreateDirectoryVerifyDispatch(const FM_CreateDirectoryCmd_t *BufPtr);
+CFE_Status_t FM_DeleteDirectoryVerifyDispatch(const FM_DeleteDirectoryCmd_t *BufPtr);
+CFE_Status_t FM_GetDirListFileVerifyDispatch(const FM_GetDirListFileCmd_t *BufPtr);
+CFE_Status_t FM_GetDirListPktVerifyDispatch(const FM_GetDirListPktCmd_t *BufPtr);
+CFE_Status_t FM_MonitorFilesystemSpaceVerifyDispatch(const FM_MonitorFilesystemSpaceCmd_t *BufPtr);
+CFE_Status_t FM_SetTableStateVerifyDispatch(const FM_SetTableStateCmd_t *BufPtr);
+CFE_Status_t FM_SetPermissionsVerifyDispatch(const FM_SetPermissionsCmd_t *BufPtr);
+void         FM_SendHkVerifyDispatch(const FM_SendHkCmd_t *BufPtr);
 
 #endif

--- a/unit-test/fm_cmds_tests.c
+++ b/unit-test/fm_cmds_tests.c
@@ -65,12 +65,12 @@ void Test_FM_NoopCmd_Success(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "%%s command: FM version %%d.%%d.%%d.%%d");
 
-    bool Result = FM_NoopCmd(&UT_CmdBuf.Buf);
+    CFE_Status_t Result = FM_NoopCmd(&UT_CmdBuf.NoopCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == true, "FM_NoopCmd returned true");
+    UtAssert_True(Result == CFE_SUCCESS, "FM_NoopCmd returned CFE_SUCCESS");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
 
@@ -94,9 +94,9 @@ void add_FM_NoopCmd_tests(void)
 
 void Test_FM_ResetCountersCmd_Success(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    bool  Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "%%s command");
 
     FM_GlobalData.CommandCounter      = 1;
@@ -105,12 +105,12 @@ void Test_FM_ResetCountersCmd_Success(void)
     FM_GlobalData.ChildCmdErrCounter  = 1;
     FM_GlobalData.ChildCmdWarnCounter = 1;
 
-    Result = FM_ResetCountersCmd(&UT_CmdBuf.Buf);
+    Result = FM_ResetCountersCmd(&UT_CmdBuf.ResetCountersCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == true, "FM_ResetCountersCmd returned true");
+    UtAssert_True(Result == CFE_SUCCESS, "FM_ResetCountersCmd returned CFE_SUCCESS");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
 
@@ -141,7 +141,7 @@ void add_FM_ResetCountersCmd_tests(void)
 void Test_FM_CopyFileCmd_Success(void)
 {
     FM_OvwSourceTargetFilename_Payload_t *CmdPtr;
-    bool                                  Result;
+    CFE_Status_t                          Result;
 
     CmdPtr = &UT_CmdBuf.CopyFileCmd.Payload;
 
@@ -156,12 +156,12 @@ void Test_FM_CopyFileCmd_Success(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_CopyFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_CopyFileCmd(&UT_CmdBuf.CopyFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == true, "FM_CopyFileCmd returned true");
+    UtAssert_True(Result == CFE_SUCCESS, "FM_CopyFileCmd returned CFE_SUCCESS");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_COPY_FILE_CC);
@@ -169,7 +169,7 @@ void Test_FM_CopyFileCmd_Success(void)
 
 void Test_FM_CopyFileCmd_BadOverwrite(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -180,12 +180,12 @@ void Test_FM_CopyFileCmd_BadOverwrite(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_CopyFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_CopyFileCmd(&UT_CmdBuf.CopyFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_CopyFileCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_CopyFileCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -193,7 +193,7 @@ void Test_FM_CopyFileCmd_BadOverwrite(void)
 
 void Test_FM_CopyFileCmd_SourceNotExist(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -204,12 +204,12 @@ void Test_FM_CopyFileCmd_SourceNotExist(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_CopyFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_CopyFileCmd(&UT_CmdBuf.CopyFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_CopyFileCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_CopyFileCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -217,7 +217,7 @@ void Test_FM_CopyFileCmd_SourceNotExist(void)
 
 void Test_FM_CopyFileCmd_NoOverwriteTargetExists(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -228,12 +228,12 @@ void Test_FM_CopyFileCmd_NoOverwriteTargetExists(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_CopyFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_CopyFileCmd(&UT_CmdBuf.CopyFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_CopyFileCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_CopyFileCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -242,7 +242,7 @@ void Test_FM_CopyFileCmd_NoOverwriteTargetExists(void)
 void Test_FM_CopyFileCmd_OverwriteFileOpen(void)
 {
     FM_OvwSourceTargetFilename_Payload_t *CmdPtr;
-    bool                                  Result;
+    CFE_Status_t                          Result;
 
     CmdPtr = &UT_CmdBuf.CopyFileCmd.Payload;
 
@@ -256,12 +256,12 @@ void Test_FM_CopyFileCmd_OverwriteFileOpen(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_CopyFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_CopyFileCmd(&UT_CmdBuf.CopyFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_CopyFileCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_CopyFileCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -269,7 +269,7 @@ void Test_FM_CopyFileCmd_OverwriteFileOpen(void)
 
 void Test_FM_CopyFileCmd_NoChildTask(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -280,12 +280,12 @@ void Test_FM_CopyFileCmd_NoChildTask(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
 
-    Result = FM_CopyFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_CopyFileCmd(&UT_CmdBuf.CopyFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_CopyFileCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_CopyFileCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -315,7 +315,7 @@ void add_FM_CopyFileCmd_tests(void)
 
 void Test_FM_MoveFileCmd_Success(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -326,12 +326,12 @@ void Test_FM_MoveFileCmd_Success(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_MoveFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_MoveFileCmd(&UT_CmdBuf.MoveFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == true, "FM_MoveFileCmd returned true");
+    UtAssert_True(Result == CFE_SUCCESS, "FM_MoveFileCmd returned CFE_SUCCESS");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_MOVE_FILE_CC);
@@ -339,7 +339,7 @@ void Test_FM_MoveFileCmd_Success(void)
 
 void Test_FM_MoveFileCmd_BadOverwrite(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -350,12 +350,12 @@ void Test_FM_MoveFileCmd_BadOverwrite(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_MoveFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_MoveFileCmd(&UT_CmdBuf.MoveFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_MoveFileCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_MoveFileCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -363,7 +363,7 @@ void Test_FM_MoveFileCmd_BadOverwrite(void)
 
 void Test_FM_MoveFileCmd_SourceNotExist(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -374,12 +374,12 @@ void Test_FM_MoveFileCmd_SourceNotExist(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_MoveFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_MoveFileCmd(&UT_CmdBuf.MoveFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_MoveFileCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_MoveFileCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -387,7 +387,7 @@ void Test_FM_MoveFileCmd_SourceNotExist(void)
 
 void Test_FM_MoveFileCmd_NoOverwriteTargetExists(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -398,12 +398,12 @@ void Test_FM_MoveFileCmd_NoOverwriteTargetExists(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_MoveFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_MoveFileCmd(&UT_CmdBuf.MoveFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_MoveFileCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_MoveFileCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -412,7 +412,7 @@ void Test_FM_MoveFileCmd_NoOverwriteTargetExists(void)
 void Test_FM_MoveFileCmd_OverwriteFileOpen(void)
 {
     FM_OvwSourceTargetFilename_Payload_t *CmdPtr;
-    bool                                  Result;
+    CFE_Status_t                          Result;
 
     CmdPtr = &UT_CmdBuf.MoveFileCmd.Payload;
 
@@ -426,12 +426,12 @@ void Test_FM_MoveFileCmd_OverwriteFileOpen(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_MoveFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_MoveFileCmd(&UT_CmdBuf.MoveFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_MoveFileCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_MoveFileCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -439,7 +439,7 @@ void Test_FM_MoveFileCmd_OverwriteFileOpen(void)
 
 void Test_FM_MoveFileCmd_NoChildTask(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -450,12 +450,12 @@ void Test_FM_MoveFileCmd_NoChildTask(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
 
-    Result = FM_MoveFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_MoveFileCmd(&UT_CmdBuf.MoveFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_MoveFileCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_MoveFileCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -486,7 +486,7 @@ void add_FM_MoveFileCmd_tests(void)
 void Test_FM_RenameFileCmd_Success(void)
 {
     FM_SourceTargetFileName_Payload_t *CmdPtr;
-    bool                               Result;
+    CFE_Status_t                       Result;
 
     CmdPtr = &UT_CmdBuf.RenameFileCmd.Payload;
 
@@ -500,12 +500,12 @@ void Test_FM_RenameFileCmd_Success(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_RenameFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_RenameFileCmd(&UT_CmdBuf.RenameFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == true, "FM_RenameFileCmd returned true");
+    UtAssert_True(Result == CFE_SUCCESS, "FM_RenameFileCmd returned CFE_SUCCESS");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_RENAME_FILE_CC);
@@ -513,7 +513,7 @@ void Test_FM_RenameFileCmd_Success(void)
 
 void Test_FM_RenameFileCmd_SourceNotExist(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -522,12 +522,12 @@ void Test_FM_RenameFileCmd_SourceNotExist(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_RenameFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_RenameFileCmd(&UT_CmdBuf.RenameFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_RenameFileCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_RenameFileCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -535,7 +535,7 @@ void Test_FM_RenameFileCmd_SourceNotExist(void)
 
 void Test_FM_RenameFileCmd_TargetExists(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -544,12 +544,12 @@ void Test_FM_RenameFileCmd_TargetExists(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_RenameFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_RenameFileCmd(&UT_CmdBuf.RenameFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_RenameFileCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_RenameFileCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -557,7 +557,7 @@ void Test_FM_RenameFileCmd_TargetExists(void)
 
 void Test_FM_RenameFileCmd_NoChildTask(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -566,12 +566,12 @@ void Test_FM_RenameFileCmd_NoChildTask(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
 
-    Result = FM_RenameFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_RenameFileCmd(&UT_CmdBuf.RenameFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_RenameFileCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_RenameFileCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -596,7 +596,7 @@ void add_FM_RenameFileCmd_tests(void)
 
 void Test_FM_DeleteFileCmd_Success(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -607,12 +607,12 @@ void Test_FM_DeleteFileCmd_Success(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileClosed), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_DeleteFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_DeleteFileCmd(&UT_CmdBuf.DeleteFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == true, "FM_DeleteFileCmd returned true");
+    UtAssert_True(Result == CFE_SUCCESS, "FM_DeleteFileCmd returned CFE_SUCCESS");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_DELETE_FILE_CC);
@@ -620,7 +620,7 @@ void Test_FM_DeleteFileCmd_Success(void)
 
 void Test_FM_DeleteFileCmd_FileNotClosed(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -631,12 +631,12 @@ void Test_FM_DeleteFileCmd_FileNotClosed(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileClosed), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_DeleteFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_DeleteFileCmd(&UT_CmdBuf.DeleteFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_DeleteFileCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_DeleteFileCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -644,7 +644,7 @@ void Test_FM_DeleteFileCmd_FileNotClosed(void)
 
 void Test_FM_DeleteFileCmd_NoChildTask(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -655,12 +655,12 @@ void Test_FM_DeleteFileCmd_NoChildTask(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileClosed), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
 
-    Result = FM_DeleteFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_DeleteFileCmd(&UT_CmdBuf.DeleteFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_DeleteFileCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_DeleteFileCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -683,7 +683,7 @@ void add_FM_DeleteFileCmd_tests(void)
 void Test_FM_DeleteAllFilesCmd_Success(void)
 {
     FM_DirectoryName_Payload_t *CmdPtr;
-    bool                        Result;
+    CFE_Status_t                Result;
 
     CmdPtr = &UT_CmdBuf.DeleteAllFilesCmd.Payload;
 
@@ -695,12 +695,12 @@ void Test_FM_DeleteAllFilesCmd_Success(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_DeleteAllFilesCmd(&UT_CmdBuf.Buf);
+    Result = FM_DeleteAllFilesCmd(&UT_CmdBuf.DeleteAllFilesCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == true, "FM_DeleteAllFilesCmd returned true");
+    UtAssert_True(Result == CFE_SUCCESS, "FM_DeleteAllFilesCmd returned CFE_SUCCESS");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_DELETE_ALL_FILES_CC);
@@ -708,7 +708,7 @@ void Test_FM_DeleteAllFilesCmd_Success(void)
 
 void Test_FM_DeleteAllFilesCmd_DirNoExist(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -716,12 +716,12 @@ void Test_FM_DeleteAllFilesCmd_DirNoExist(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_DeleteAllFilesCmd(&UT_CmdBuf.Buf);
+    Result = FM_DeleteAllFilesCmd(&UT_CmdBuf.DeleteAllFilesCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_DeleteAllFilesCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_DeleteAllFilesCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -730,7 +730,7 @@ void Test_FM_DeleteAllFilesCmd_DirNoExist(void)
 void Test_FM_DeleteAllFilesCmd_NoChildTask(void)
 {
     FM_DirectoryName_Payload_t *CmdPtr;
-    bool                        Result;
+    CFE_Status_t                Result;
 
     CmdPtr = &UT_CmdBuf.DeleteAllFilesCmd.Payload;
 
@@ -741,12 +741,12 @@ void Test_FM_DeleteAllFilesCmd_NoChildTask(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
 
-    Result = FM_DeleteAllFilesCmd(&UT_CmdBuf.Buf);
+    Result = FM_DeleteAllFilesCmd(&UT_CmdBuf.DeleteAllFilesCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_DeleteAllFilesCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_DeleteAllFilesCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -769,7 +769,7 @@ void add_FM_DeleteAllFilesCmd_tests(void)
 
 void Test_FM_DecompressFileCmd_Success(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -778,12 +778,12 @@ void Test_FM_DecompressFileCmd_Success(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_DecompressFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_DecompressFileCmd(&UT_CmdBuf.DecompressFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == true, "FM_DecompressFileCmd returned true");
+    UtAssert_True(Result == CFE_SUCCESS, "FM_DecompressFileCmd returned CFE_SUCCESS");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_DECOMPRESS_FILE_CC);
@@ -791,7 +791,7 @@ void Test_FM_DecompressFileCmd_Success(void)
 
 void Test_FM_DecompressFileCmd_SourceFileOpen(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -800,12 +800,12 @@ void Test_FM_DecompressFileCmd_SourceFileOpen(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_DecompressFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_DecompressFileCmd(&UT_CmdBuf.DecompressFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_DecompressFileCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_DecompressFileCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -813,7 +813,7 @@ void Test_FM_DecompressFileCmd_SourceFileOpen(void)
 
 void Test_FM_DecompressFileCmd_TargetFileExists(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -822,12 +822,12 @@ void Test_FM_DecompressFileCmd_TargetFileExists(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_DecompressFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_DecompressFileCmd(&UT_CmdBuf.DecompressFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_DecompressFileCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_DecompressFileCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -835,7 +835,7 @@ void Test_FM_DecompressFileCmd_TargetFileExists(void)
 
 void Test_FM_DecompressFileCmd_NoChildTask(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -844,12 +844,12 @@ void Test_FM_DecompressFileCmd_NoChildTask(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
 
-    Result = FM_DecompressFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_DecompressFileCmd(&UT_CmdBuf.DecompressFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_DecompressFileCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_DecompressFileCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -876,7 +876,7 @@ void add_FM_DecompressFileCmd_tests(void)
 void Test_FM_ConcatFilesCmd_Success(void)
 {
     FM_TwoSourceOneTarget_Payload_t *CmdPtr;
-    bool                             Result;
+    CFE_Status_t                     Result;
 
     CmdPtr = &UT_CmdBuf.ConcatFilesCmd.Payload;
 
@@ -891,12 +891,12 @@ void Test_FM_ConcatFilesCmd_Success(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_ConcatFilesCmd(&UT_CmdBuf.Buf);
+    Result = FM_ConcatFilesCmd(&UT_CmdBuf.ConcatFilesCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == true, "FM_ConcatFilesCmd returned true");
+    UtAssert_True(Result == CFE_SUCCESS, "FM_ConcatFilesCmd returned CFE_SUCCESS");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_CONCAT_FILES_CC);
@@ -904,7 +904,7 @@ void Test_FM_ConcatFilesCmd_Success(void)
 
 void Test_FM_ConcatFilesCmd_SourceFile1NotClosed(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -913,11 +913,11 @@ void Test_FM_ConcatFilesCmd_SourceFile1NotClosed(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result                       = FM_ConcatFilesCmd(&UT_CmdBuf.Buf);
+    Result                       = FM_ConcatFilesCmd(&UT_CmdBuf.ConcatFilesCmd);
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_ConcatFilesCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_ConcatFilesCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -925,7 +925,7 @@ void Test_FM_ConcatFilesCmd_SourceFile1NotClosed(void)
 
 void Test_FM_ConcatFilesCmd_SourceFile2NotClosed(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -935,11 +935,11 @@ void Test_FM_ConcatFilesCmd_SourceFile2NotClosed(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result                       = FM_ConcatFilesCmd(&UT_CmdBuf.Buf);
+    Result                       = FM_ConcatFilesCmd(&UT_CmdBuf.ConcatFilesCmd);
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_ConcatFilesCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_ConcatFilesCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -947,7 +947,7 @@ void Test_FM_ConcatFilesCmd_SourceFile2NotClosed(void)
 
 void Test_FM_ConcatFilesCmd_TargetFileExists(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -956,11 +956,11 @@ void Test_FM_ConcatFilesCmd_TargetFileExists(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result                       = FM_ConcatFilesCmd(&UT_CmdBuf.Buf);
+    Result                       = FM_ConcatFilesCmd(&UT_CmdBuf.ConcatFilesCmd);
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_ConcatFilesCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_ConcatFilesCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -968,7 +968,7 @@ void Test_FM_ConcatFilesCmd_TargetFileExists(void)
 
 void Test_FM_ConcatFilesCmd_NoChildTask(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -977,11 +977,11 @@ void Test_FM_ConcatFilesCmd_NoChildTask(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
 
-    Result                       = FM_ConcatFilesCmd(&UT_CmdBuf.Buf);
+    Result                       = FM_ConcatFilesCmd(&UT_CmdBuf.ConcatFilesCmd);
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_ConcatFilesCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_ConcatFilesCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -1011,7 +1011,7 @@ void add_FM_ConcatFilesCmd_tests(void)
 void Test_FM_GetFileInfoCmd_Success(void)
 {
     FM_FilenameAndCRC_Payload_t *CmdPtr;
-    bool                         Result;
+    CFE_Status_t                 Result;
 
     CmdPtr = &UT_CmdBuf.GetFileInfoCmd.Payload;
 
@@ -1023,12 +1023,12 @@ void Test_FM_GetFileInfoCmd_Success(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyNameValid), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_GetFileInfoCmd(&UT_CmdBuf.Buf);
+    Result = FM_GetFileInfoCmd(&UT_CmdBuf.GetFileInfoCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == true, "FM_GetFileInfoCmd returned true");
+    UtAssert_True(Result == CFE_SUCCESS, "FM_GetFileInfoCmd returned CFE_SUCCESS");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_GET_FILE_INFO_CC);
@@ -1036,7 +1036,7 @@ void Test_FM_GetFileInfoCmd_Success(void)
 
 void Test_FM_GetFileInfoCmd_InvalidName(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -1044,12 +1044,12 @@ void Test_FM_GetFileInfoCmd_InvalidName(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyNameValid), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_GetFileInfoCmd(&UT_CmdBuf.Buf);
+    Result = FM_GetFileInfoCmd(&UT_CmdBuf.GetFileInfoCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_GetFileInfoCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_GetFileInfoCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -1057,7 +1057,7 @@ void Test_FM_GetFileInfoCmd_InvalidName(void)
 
 void Test_FM_GetFileInfoCmd_NoChildTask(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -1065,12 +1065,12 @@ void Test_FM_GetFileInfoCmd_NoChildTask(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyNameValid), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
 
-    Result = FM_GetFileInfoCmd(&UT_CmdBuf.Buf);
+    Result = FM_GetFileInfoCmd(&UT_CmdBuf.GetFileInfoCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_GetFileInfoCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_GetFileInfoCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -1097,12 +1097,12 @@ void Test_FM_GetOpenFilesCmd_Success(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "%%s command");
 
-    bool Result = FM_GetOpenFilesCmd(&UT_CmdBuf.Buf);
+    CFE_Status_t Result = FM_GetOpenFilesCmd(&UT_CmdBuf.GetOpenFilesCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == true, "FM_GetOpenFilesCmd returned true");
+    UtAssert_True(Result == CFE_SUCCESS, "FM_GetOpenFilesCmd returned CFE_SUCCESS");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
 
@@ -1127,7 +1127,7 @@ void add_FM_GetOpenFilesCmd_tests(void)
 void Test_FM_CreateDirectoryCmd_Success(void)
 {
     FM_DirectoryName_Payload_t *CmdPtr;
-    bool                        Result;
+    CFE_Status_t                Result;
 
     CmdPtr = &UT_CmdBuf.CreateDirectoryCmd.Payload;
 
@@ -1138,12 +1138,12 @@ void Test_FM_CreateDirectoryCmd_Success(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_CreateDirectoryCmd(&UT_CmdBuf.Buf);
+    Result = FM_CreateDirectoryCmd(&UT_CmdBuf.CreateDirectoryCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == true, "FM_CreateDirectoryCmd returned true");
+    UtAssert_True(Result == CFE_SUCCESS, "FM_CreateDirectoryCmd returned CFE_SUCCESS");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_CREATE_DIRECTORY_CC);
@@ -1151,7 +1151,7 @@ void Test_FM_CreateDirectoryCmd_Success(void)
 
 void Test_FM_CreateDirectoryCmd_DirExists(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -1159,12 +1159,12 @@ void Test_FM_CreateDirectoryCmd_DirExists(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirNoExist), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_CreateDirectoryCmd(&UT_CmdBuf.Buf);
+    Result = FM_CreateDirectoryCmd(&UT_CmdBuf.CreateDirectoryCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_CreateDirectoryCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_CreateDirectoryCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -1172,7 +1172,7 @@ void Test_FM_CreateDirectoryCmd_DirExists(void)
 
 void Test_FM_CreateDirectoryCmd_NoChildTask(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -1180,12 +1180,12 @@ void Test_FM_CreateDirectoryCmd_NoChildTask(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirNoExist), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
 
-    Result = FM_CreateDirectoryCmd(&UT_CmdBuf.Buf);
+    Result = FM_CreateDirectoryCmd(&UT_CmdBuf.CreateDirectoryCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_CreateDirectoryCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_CreateDirectoryCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -1210,7 +1210,7 @@ void add_FM_CreateDirectoryCmd_tests(void)
 void Test_FM_DeleteDirectoryCmd_Success(void)
 {
     FM_DirectoryName_Payload_t *CmdPtr;
-    bool                        Result;
+    CFE_Status_t                Result;
 
     CmdPtr = &UT_CmdBuf.DeleteDirectoryCmd.Payload;
 
@@ -1221,12 +1221,12 @@ void Test_FM_DeleteDirectoryCmd_Success(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_DeleteDirectoryCmd(&UT_CmdBuf.Buf);
+    Result = FM_DeleteDirectoryCmd(&UT_CmdBuf.DeleteDirectoryCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == true, "FM_DeleteDirectoryCmd returned true");
+    UtAssert_True(Result == CFE_SUCCESS, "FM_DeleteDirectoryCmd returned CFE_SUCCESS");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_DELETE_DIRECTORY_CC);
@@ -1234,7 +1234,7 @@ void Test_FM_DeleteDirectoryCmd_Success(void)
 
 void Test_FM_DeleteDirectoryCmd_DirNoExist(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -1242,12 +1242,12 @@ void Test_FM_DeleteDirectoryCmd_DirNoExist(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_DeleteDirectoryCmd(&UT_CmdBuf.Buf);
+    Result = FM_DeleteDirectoryCmd(&UT_CmdBuf.DeleteDirectoryCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_DeleteDirectoryCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_DeleteDirectoryCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -1255,7 +1255,7 @@ void Test_FM_DeleteDirectoryCmd_DirNoExist(void)
 
 void Test_FM_DeleteDirectoryCmd_NoChildTask(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -1263,12 +1263,12 @@ void Test_FM_DeleteDirectoryCmd_NoChildTask(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
 
-    Result = FM_DeleteDirectoryCmd(&UT_CmdBuf.Buf);
+    Result = FM_DeleteDirectoryCmd(&UT_CmdBuf.DeleteDirectoryCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_DeleteDirectoryCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_DeleteDirectoryCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -1293,7 +1293,7 @@ void add_FM_DeleteDirectoryCmd_tests(void)
 void Test_FM_GetDirListFileCmd_Success(void)
 {
     FM_GetDirectoryToFile_Payload_t *CmdPtr;
-    bool                             Result;
+    CFE_Status_t                     Result;
 
     CmdPtr = &UT_CmdBuf.GetDirListFileCmd.Payload;
 
@@ -1306,12 +1306,12 @@ void Test_FM_GetDirListFileCmd_Success(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_GetDirListFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_GetDirListFileCmd(&UT_CmdBuf.GetDirListFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == true, "FM_GetDirListFileCmd returned true");
+    UtAssert_True(Result == CFE_SUCCESS, "FM_GetDirListFileCmd returned CFE_SUCCESS");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_GET_DIR_LIST_FILE_CC);
@@ -1320,7 +1320,7 @@ void Test_FM_GetDirListFileCmd_Success(void)
 void Test_FM_GetDirListFileCmd_SuccessDefaultPath(void)
 {
     FM_GetDirectoryToFile_Payload_t *CmdPtr;
-    bool                             Result;
+    CFE_Status_t                     Result;
 
     CmdPtr = &UT_CmdBuf.GetDirListFileCmd.Payload;
 
@@ -1333,12 +1333,12 @@ void Test_FM_GetDirListFileCmd_SuccessDefaultPath(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_GetDirListFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_GetDirListFileCmd(&UT_CmdBuf.GetDirListFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == true, "FM_GetDirListFileCmd returned true");
+    UtAssert_True(Result == CFE_SUCCESS, "FM_GetDirListFileCmd returned CFE_SUCCESS");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_GET_DIR_LIST_FILE_CC);
@@ -1346,7 +1346,7 @@ void Test_FM_GetDirListFileCmd_SuccessDefaultPath(void)
 
 void Test_FM_GetDirListFileCmd_SourceNotExist(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -1355,12 +1355,12 @@ void Test_FM_GetDirListFileCmd_SourceNotExist(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_GetDirListFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_GetDirListFileCmd(&UT_CmdBuf.GetDirListFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_GetDirListFileCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_GetDirListFileCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -1369,7 +1369,7 @@ void Test_FM_GetDirListFileCmd_SourceNotExist(void)
 void Test_FM_GetDirListFileCmd_TargetFileOpen(void)
 {
     FM_GetDirectoryToFile_Payload_t *CmdPtr;
-    bool                             Result;
+    CFE_Status_t                     Result;
 
     CmdPtr = &UT_CmdBuf.GetDirListFileCmd.Payload;
 
@@ -1383,12 +1383,12 @@ void Test_FM_GetDirListFileCmd_TargetFileOpen(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_GetDirListFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_GetDirListFileCmd(&UT_CmdBuf.GetDirListFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_GetDirListFileCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_GetDirListFileCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -1397,7 +1397,7 @@ void Test_FM_GetDirListFileCmd_TargetFileOpen(void)
 void Test_FM_GetDirListFileCmd_NoChildTask(void)
 {
     FM_GetDirectoryToFile_Payload_t *CmdPtr;
-    bool                             Result;
+    CFE_Status_t                     Result;
 
     CmdPtr = &UT_CmdBuf.GetDirListFileCmd.Payload;
 
@@ -1411,12 +1411,12 @@ void Test_FM_GetDirListFileCmd_NoChildTask(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyFileNotOpen), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
 
-    Result = FM_GetDirListFileCmd(&UT_CmdBuf.Buf);
+    Result = FM_GetDirListFileCmd(&UT_CmdBuf.GetDirListFileCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_GetDirListFileCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_GetDirListFileCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -1446,7 +1446,7 @@ void add_FM_GetDirListFileCmd_tests(void)
 void Test_FM_GetDirListPktCmd_Success(void)
 {
     FM_GetDirectoryToPkt_Payload_t *CmdPtr;
-    bool                            Result;
+    CFE_Status_t                    Result;
 
     CmdPtr = &UT_CmdBuf.GetDirListPktCmd.Payload;
 
@@ -1458,12 +1458,12 @@ void Test_FM_GetDirListPktCmd_Success(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_GetDirListPktCmd(&UT_CmdBuf.Buf);
+    Result = FM_GetDirListPktCmd(&UT_CmdBuf.GetDirListPktCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == true, "FM_GetDirListPktCmd returned true");
+    UtAssert_True(Result == CFE_SUCCESS, "FM_GetDirListPktCmd returned CFE_SUCCESS");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_GET_DIR_LIST_PKT_CC);
@@ -1471,7 +1471,7 @@ void Test_FM_GetDirListPktCmd_Success(void)
 
 void Test_FM_GetDirListPktCmd_SourceNotExist(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -1479,12 +1479,12 @@ void Test_FM_GetDirListPktCmd_SourceNotExist(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_GetDirListPktCmd(&UT_CmdBuf.Buf);
+    Result = FM_GetDirListPktCmd(&UT_CmdBuf.GetDirListPktCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_GetDirListPktCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_GetDirListPktCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -1492,7 +1492,7 @@ void Test_FM_GetDirListPktCmd_SourceNotExist(void)
 
 void Test_FM_GetDirListPktCmd_NoChildTask(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     FM_GlobalData.ChildWriteIndex           = 0;
     FM_GlobalData.ChildQueue[0].CommandCode = 0;
@@ -1500,12 +1500,12 @@ void Test_FM_GetDirListPktCmd_NoChildTask(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), false);
 
-    Result = FM_GetDirListPktCmd(&UT_CmdBuf.Buf);
+    Result = FM_GetDirListPktCmd(&UT_CmdBuf.GetDirListPktCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_GetDirListPktCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_GetDirListPktCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -1569,7 +1569,7 @@ void Test_FM_MonitorFilesystemSpaceCmd_Success(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyDirExists), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    UtAssert_BOOL_TRUE(FM_MonitorFilesystemSpaceCmd(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_MonitorFilesystemSpaceCmd(&UT_CmdBuf.GetFreeSpaceCmd), CFE_SUCCESS);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_MONITOR_FILESYSTEM_SPACE_CMD_EID);
@@ -1604,7 +1604,7 @@ void Test_FM_MonitorFilesystemSpaceCmd_NullFreeSpaceTable(void)
 
     FM_GlobalData.MonitorTablePtr = NULL;
 
-    UtAssert_BOOL_FALSE(FM_MonitorFilesystemSpaceCmd(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_MonitorFilesystemSpaceCmd(&UT_CmdBuf.GetFreeSpaceCmd), CFE_STATUS_INCORRECT_STATE);
 
     call_count_CFE_EVS_SendEvent  = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     call_count_CFE_SB_TransmitMsg = UT_GetStubCount(UT_KEY(CFE_SB_TransmitMsg));
@@ -1644,7 +1644,7 @@ void Test_FM_MonitorFilesystemSpaceCmd_ImplCallFails(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_GetVolumeFreeSpace), CFE_STATUS_EXTERNAL_RESOURCE_FAIL);
 
     /* Assert */
-    UtAssert_BOOL_FALSE(FM_MonitorFilesystemSpaceCmd(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_MonitorFilesystemSpaceCmd(&UT_CmdBuf.GetFreeSpaceCmd), FM_ERROR);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1686,7 +1686,7 @@ void Test_FM_MonitorFilesystemSpaceCmd_NotImpl(void)
     FM_GlobalData.MonitorTablePtr = &Table;
 
     /* Assert */
-    UtAssert_BOOL_FALSE(FM_MonitorFilesystemSpaceCmd(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_MonitorFilesystemSpaceCmd(&UT_CmdBuf.GetFreeSpaceCmd), FM_ERROR);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1745,7 +1745,7 @@ void Test_FM_SetTableStateCmd_Success(void)
     Table.Entries[0].Type         = FM_MonitorTableEntry_Type_VOLUME_FREE_SPACE;
     FM_GlobalData.MonitorTablePtr = &Table;
 
-    UtAssert_BOOL_TRUE(FM_SetTableStateCmd(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_SetTableStateCmd(&UT_CmdBuf.SetTableStateCmd), CFE_SUCCESS);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_SET_TABLE_STATE_CMD_EID);
@@ -1763,7 +1763,7 @@ void Test_FM_SetTableStateCmd_Success(void)
 void Test_FM_SetTableStateCmd_NullFreeSpaceTable(void)
 {
     FM_TableIndexAndState_Payload_t *CmdPtr;
-    bool                             Result;
+    CFE_Status_t                     Result;
 
     CmdPtr = &UT_CmdBuf.SetTableStateCmd.Payload;
 
@@ -1777,12 +1777,12 @@ void Test_FM_SetTableStateCmd_NullFreeSpaceTable(void)
 
     FM_GlobalData.MonitorTablePtr = NULL;
 
-    Result = FM_SetTableStateCmd(&UT_CmdBuf.Buf);
+    Result = FM_SetTableStateCmd(&UT_CmdBuf.SetTableStateCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_SetTableStateCmd returned false");
+    UtAssert_True(Result == CFE_STATUS_INCORRECT_STATE, "FM_SetTableStateCmd returned CFE_STATUS_INCORRECT_STATE");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_SET_TABLE_STATE_TBL_ERR_EID);
@@ -1798,7 +1798,7 @@ void Test_FM_SetTableStateCmd_TableEntryIndexTooLarge(void)
 {
     FM_TableIndexAndState_Payload_t *CmdPtr;
     FM_MonitorTable_t                Table;
-    bool                             Result;
+    CFE_Status_t                     Result;
 
     CmdPtr = &UT_CmdBuf.SetTableStateCmd.Payload;
 
@@ -1814,10 +1814,10 @@ void Test_FM_SetTableStateCmd_TableEntryIndexTooLarge(void)
 
     FM_GlobalData.MonitorTablePtr = &Table;
 
-    Result = FM_SetTableStateCmd(&UT_CmdBuf.Buf);
+    Result = FM_SetTableStateCmd(&UT_CmdBuf.SetTableStateCmd);
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_SetTableStateCmd returned false");
+    UtAssert_True(Result == CFE_STATUS_RANGE_ERROR, "FM_SetTableStateCmd returned CFE_STATUS_RANGE_ERROR");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_SET_TABLE_STATE_ARG_IDX_ERR_EID);
@@ -1835,7 +1835,7 @@ void Test_FM_SetTableStateCmd_BadNewState(void)
 {
     FM_TableIndexAndState_Payload_t *CmdPtr;
     FM_MonitorTable_t                Table;
-    bool                             Result;
+    CFE_Status_t                     Result;
 
     CmdPtr = &UT_CmdBuf.SetTableStateCmd.Payload;
 
@@ -1851,10 +1851,10 @@ void Test_FM_SetTableStateCmd_BadNewState(void)
 
     FM_GlobalData.MonitorTablePtr = &Table;
 
-    Result = FM_SetTableStateCmd(&UT_CmdBuf.Buf);
+    Result = FM_SetTableStateCmd(&UT_CmdBuf.SetTableStateCmd);
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_SetTableStateCmd returned false");
+    UtAssert_True(Result == CFE_STATUS_RANGE_ERROR, "FM_SetTableStateCmd returned CFE_STATUS_RANGE_ERROR");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_SET_TABLE_STATE_ARG_STATE_ERR_EID);
@@ -1887,7 +1887,7 @@ void Test_FM_SetTableStateCmd_BadCurrentState(void)
 
     FM_GlobalData.MonitorTablePtr = &Table;
 
-    UtAssert_BOOL_FALSE(FM_SetTableStateCmd(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_SetTableStateCmd(&UT_CmdBuf.SetTableStateCmd), CFE_STATUS_INCORRECT_STATE);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_SET_TABLE_STATE_UNUSED_ERR_EID);
@@ -1925,7 +1925,7 @@ void add_FM_SetTableStateCmd_tests(void)
 void Test_FM_SetPermissionsCmd_Success(void)
 {
     FM_FilenameAndMode_Payload_t *CmdPtr;
-    bool                          Result;
+    CFE_Status_t                  Result;
 
     CmdPtr = &UT_CmdBuf.SetPermissionsCmd.Payload;
 
@@ -1934,12 +1934,12 @@ void Test_FM_SetPermissionsCmd_Success(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyNameValid), true);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_SetPermissionsCmd(&UT_CmdBuf.Buf);
+    Result = FM_SetPermissionsCmd(&UT_CmdBuf.SetPermissionsCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == true, "FM_SetPermissionsCmd returned true");
+    UtAssert_True(Result == CFE_SUCCESS, "FM_SetPermissionsCmd returned CFE_SUCCESS");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, FM_SET_PERMISSIONS_CC);
@@ -1947,17 +1947,17 @@ void Test_FM_SetPermissionsCmd_Success(void)
 
 void Test_FM_SetPermissionsCmd_BadName(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyNameValid), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_SetPermissionsCmd(&UT_CmdBuf.Buf);
+    Result = FM_SetPermissionsCmd(&UT_CmdBuf.SetPermissionsCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_SetPermissionsCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_SetPermissionsCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);
@@ -1965,17 +1965,17 @@ void Test_FM_SetPermissionsCmd_BadName(void)
 
 void Test_FM_SetPermissionsCmd_NoChildTask(void)
 {
-    bool Result;
+    CFE_Status_t Result;
 
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyNameValid), false);
     UT_SetDefaultReturnValue(UT_KEY(FM_VerifyChildTask), true);
 
-    Result = FM_SetPermissionsCmd(&UT_CmdBuf.Buf);
+    Result = FM_SetPermissionsCmd(&UT_CmdBuf.SetPermissionsCmd);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
-    UtAssert_True(Result == false, "FM_SetPermissionsCmd returned false");
+    UtAssert_True(Result == FM_ERROR, "FM_SetPermissionsCmd returned FM_ERROR");
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
     UtAssert_INT32_EQ(FM_GlobalData.ChildQueue[0].CommandCode, 0);

--- a/unit-test/fm_dispatch_tests.c
+++ b/unit-test/fm_dispatch_tests.c
@@ -63,7 +63,7 @@ void Test_FM_ProcessCmd_NoopCmdCCReturn(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     length = sizeof(FM_NoopCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_NoopCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_NoopCmd), CFE_SUCCESS);
 
     /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
@@ -85,7 +85,7 @@ void Test_FM_ProcessCmd_ResetCountersCCReturn(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     length = sizeof(FM_ResetCountersCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_ResetCountersCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_ResetCountersCmd), CFE_SUCCESS);
 
     /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
@@ -107,7 +107,7 @@ void Test_FM_ProcessCmd_CopyFileCCReturn(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     length = sizeof(FM_CopyFileCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_CopyFileCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_CopyFileCmd), CFE_SUCCESS);
 
     /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
@@ -129,7 +129,7 @@ void Test_FM_ProcessCmd_MoveFileCCReturn(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     length = sizeof(FM_MoveFileCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_MoveFileCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_MoveFileCmd), CFE_SUCCESS);
 
     /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
@@ -151,7 +151,7 @@ void Test_FM_ProcessCmd_RenameFileCCReturn(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     length = sizeof(FM_RenameFileCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_RenameFileCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_RenameFileCmd), CFE_SUCCESS);
 
     /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
@@ -173,7 +173,7 @@ void Test_FM_ProcessCmd_DeleteFileCCReturn(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     length = sizeof(FM_DeleteFileCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_DeleteFileCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_DeleteFileCmd), CFE_SUCCESS);
 
     /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
@@ -195,7 +195,7 @@ void Test_FM_ProcessCmd_DeleteAllFilesCCReturn(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     length = sizeof(FM_DeleteAllFilesCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_DeleteAllFilesCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_DeleteAllFilesCmd), CFE_SUCCESS);
 
     /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
@@ -217,7 +217,7 @@ void Test_FM_ProcessCmd_DecompressFileCCReturn(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     length = sizeof(FM_DecompressFileCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_DecompressFileCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_DecompressFileCmd), CFE_SUCCESS);
 
     /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
@@ -239,7 +239,7 @@ void Test_FM_ProcessCmd_ConcatFilesCCReturn(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     length = sizeof(FM_ConcatFilesCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_ConcatFilesCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_ConcatFilesCmd), CFE_SUCCESS);
 
     /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
@@ -261,7 +261,7 @@ void Test_FM_ProcessCmd_GetFileInfoCCReturn(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     length = sizeof(FM_GetFileInfoCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_GetFileInfoCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_GetFileInfoCmd), CFE_SUCCESS);
 
     /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
@@ -283,7 +283,7 @@ void Test_FM_ProcessCmd_GetOpenFilesCCReturn(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     length = sizeof(FM_GetOpenFilesCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_GetOpenFilesCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_GetOpenFilesCmd), CFE_SUCCESS);
 
     /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
@@ -305,7 +305,7 @@ void Test_FM_ProcessCmd_CreateDirectoryCCReturn(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     length = sizeof(FM_CreateDirectoryCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_CreateDirectoryCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_CreateDirectoryCmd), CFE_SUCCESS);
 
     /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
@@ -327,7 +327,7 @@ void Test_FM_ProcessCmd_DeleteDirectoryCCReturn(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     length = sizeof(FM_DeleteDirectoryCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_DeleteDirectoryCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_DeleteDirectoryCmd), CFE_SUCCESS);
 
     /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
@@ -349,7 +349,7 @@ void Test_FM_ProcessCmd_GetDirListFileCCReturn(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     length = sizeof(FM_GetDirListFileCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_GetDirListFileCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_GetDirListFileCmd), CFE_SUCCESS);
 
     /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
@@ -371,7 +371,7 @@ void Test_FM_ProcessCmd_GetDirListPktCCReturn(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     length = sizeof(FM_GetDirListPktCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_GetDirListPktCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_GetDirListPktCmd), CFE_SUCCESS);
 
     /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
@@ -393,7 +393,7 @@ void Test_FM_ProcessCmd_MonitorFilesystemSpaceCCReturn(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     length = sizeof(FM_MonitorFilesystemSpaceCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_MonitorFilesystemSpaceCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_MonitorFilesystemSpaceCmd), CFE_SUCCESS);
 
     /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
@@ -415,7 +415,7 @@ void Test_FM_ProcessCmd_SetTableStateCCReturn(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     length = sizeof(FM_SetTableStateCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_SetTableStateCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_SetTableStateCmd), CFE_SUCCESS);
 
     /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
@@ -437,7 +437,7 @@ void Test_FM_ProcessCmd_SetPermissionsCCReturn(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &fcn_code, sizeof(fcn_code), false);
     length = sizeof(FM_SetPermissionsCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UT_SetDefaultReturnValue(UT_KEY(FM_SetPermissionsCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_SetPermissionsCmd), CFE_SUCCESS);
 
     /* Act */
     UtAssert_VOIDCALL(FM_ProcessCmd(NULL));
@@ -632,270 +632,271 @@ void Test_FM_NoopVerifyDispatch(void)
 {
     size_t length;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_NoopCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_NoopCmd), CFE_SUCCESS);
 
     length = 1; /* bad size for any message */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_FALSE(FM_NoopVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_NoopVerifyDispatch(&UT_CmdBuf.NoopCmd), CFE_STATUS_VALIDATION_FAILURE);
 
     length = sizeof(FM_NoopCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_TRUE(FM_NoopVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_NoopVerifyDispatch(&UT_CmdBuf.NoopCmd), CFE_SUCCESS);
 }
 
 void Test_FM_ResetCountersVerifyDispatch(void)
 {
     size_t length;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_ResetCountersCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_ResetCountersCmd), CFE_SUCCESS);
 
     length = 1; /* bad size for any message */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_FALSE(FM_ResetCountersVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_ResetCountersVerifyDispatch(&UT_CmdBuf.ResetCountersCmd), CFE_STATUS_VALIDATION_FAILURE);
 
     length = sizeof(FM_ResetCountersCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_TRUE(FM_ResetCountersVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_ResetCountersVerifyDispatch(&UT_CmdBuf.ResetCountersCmd), CFE_SUCCESS);
 }
 
 void Test_FM_CopyFileVerifyDispatch(void)
 {
     size_t length;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_CopyFileCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_CopyFileCmd), CFE_SUCCESS);
 
     length = 1; /* bad size for any message */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_FALSE(FM_CopyFileVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_CopyFileVerifyDispatch(&UT_CmdBuf.CopyFileCmd), CFE_STATUS_VALIDATION_FAILURE);
 
     length = sizeof(FM_CopyFileCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_TRUE(FM_CopyFileVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_CopyFileVerifyDispatch(&UT_CmdBuf.CopyFileCmd), CFE_SUCCESS);
 }
 
 void Test_FM_MoveFileVerifyDispatch(void)
 {
     size_t length;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_MoveFileCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_MoveFileCmd), CFE_SUCCESS);
 
     length = 1; /* bad size for any message */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_FALSE(FM_MoveFileVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_MoveFileVerifyDispatch(&UT_CmdBuf.MoveFileCmd), CFE_STATUS_VALIDATION_FAILURE);
 
     length = sizeof(FM_MoveFileCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_TRUE(FM_MoveFileVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_MoveFileVerifyDispatch(&UT_CmdBuf.MoveFileCmd), CFE_SUCCESS);
 }
 
 void Test_FM_RenameFileVerifyDispatch(void)
 {
     size_t length;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_RenameFileCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_RenameFileCmd), CFE_SUCCESS);
 
     length = 1; /* bad size for any message */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_FALSE(FM_RenameFileVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_RenameFileVerifyDispatch(&UT_CmdBuf.RenameFileCmd), CFE_STATUS_VALIDATION_FAILURE);
 
     length = sizeof(FM_RenameFileCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_TRUE(FM_RenameFileVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_RenameFileVerifyDispatch(&UT_CmdBuf.RenameFileCmd), CFE_SUCCESS);
 }
 
 void Test_FM_DeleteFileVerifyDispatch(void)
 {
     size_t length;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_DeleteFileCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_DeleteFileCmd), CFE_SUCCESS);
 
     length = 1; /* bad size for any message */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_FALSE(FM_DeleteFileVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_DeleteFileVerifyDispatch(&UT_CmdBuf.DeleteFileCmd), CFE_STATUS_VALIDATION_FAILURE);
 
     length = sizeof(FM_DeleteFileCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_TRUE(FM_DeleteFileVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_DeleteFileVerifyDispatch(&UT_CmdBuf.DeleteFileCmd), CFE_SUCCESS);
 }
 
 void Test_FM_DeleteAllFilesVerifyDispatch(void)
 {
     size_t length;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_DeleteAllFilesCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_DeleteAllFilesCmd), CFE_SUCCESS);
 
     length = 1; /* bad size for any message */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_FALSE(FM_DeleteAllFilesVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_DeleteAllFilesVerifyDispatch(&UT_CmdBuf.DeleteAllFilesCmd), CFE_STATUS_VALIDATION_FAILURE);
 
     length = sizeof(FM_DeleteAllFilesCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_TRUE(FM_DeleteAllFilesVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_DeleteAllFilesVerifyDispatch(&UT_CmdBuf.DeleteAllFilesCmd), CFE_SUCCESS);
 }
 
 void Test_FM_DecompressFileVerifyDispatch(void)
 {
     size_t length;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_DecompressFileCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_DecompressFileCmd), CFE_SUCCESS);
 
     length = 1; /* bad size for any message */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_FALSE(FM_DecompressFileVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_DecompressFileVerifyDispatch(&UT_CmdBuf.DecompressFileCmd), CFE_STATUS_VALIDATION_FAILURE);
 
     length = sizeof(FM_DecompressFileCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_TRUE(FM_DecompressFileVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_DecompressFileVerifyDispatch(&UT_CmdBuf.DecompressFileCmd), CFE_SUCCESS);
 }
 
 void Test_FM_ConcatFilesVerifyDispatch(void)
 {
     size_t length;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_ConcatFilesCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_ConcatFilesCmd), CFE_SUCCESS);
 
     length = 1; /* bad size for any message */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_FALSE(FM_ConcatFilesVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_ConcatFilesVerifyDispatch(&UT_CmdBuf.ConcatFilesCmd), CFE_STATUS_VALIDATION_FAILURE);
 
     length = sizeof(FM_ConcatFilesCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_TRUE(FM_ConcatFilesVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_ConcatFilesVerifyDispatch(&UT_CmdBuf.ConcatFilesCmd), CFE_SUCCESS);
 }
 
 void Test_FM_GetFileInfoVerifyDispatch(void)
 {
     size_t length;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_GetFileInfoCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_GetFileInfoCmd), CFE_SUCCESS);
 
     length = 1; /* bad size for any message */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_FALSE(FM_GetFileInfoVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_GetFileInfoVerifyDispatch(&UT_CmdBuf.GetFileInfoCmd), CFE_STATUS_VALIDATION_FAILURE);
 
     length = sizeof(FM_GetFileInfoCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_TRUE(FM_GetFileInfoVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_GetFileInfoVerifyDispatch(&UT_CmdBuf.GetFileInfoCmd), CFE_SUCCESS);
 }
 
 void Test_FM_GetOpenFilesVerifyDispatch(void)
 {
     size_t length;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_GetOpenFilesCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_GetOpenFilesCmd), CFE_SUCCESS);
 
     length = 1; /* bad size for any message */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_FALSE(FM_GetOpenFilesVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_GetOpenFilesVerifyDispatch(&UT_CmdBuf.GetOpenFilesCmd), CFE_STATUS_VALIDATION_FAILURE);
 
     length = sizeof(FM_GetOpenFilesCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_TRUE(FM_GetOpenFilesVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_GetOpenFilesVerifyDispatch(&UT_CmdBuf.GetOpenFilesCmd), CFE_SUCCESS);
 }
 
 void Test_FM_CreateDirectoryVerifyDispatch(void)
 {
     size_t length;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_CreateDirectoryCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_CreateDirectoryCmd), CFE_SUCCESS);
 
     length = 1; /* bad size for any message */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_FALSE(FM_CreateDirectoryVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_CreateDirectoryVerifyDispatch(&UT_CmdBuf.CreateDirectoryCmd), CFE_STATUS_VALIDATION_FAILURE);
 
     length = sizeof(FM_CreateDirectoryCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_TRUE(FM_CreateDirectoryVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_CreateDirectoryVerifyDispatch(&UT_CmdBuf.CreateDirectoryCmd), CFE_SUCCESS);
 }
 
 void Test_FM_DeleteDirectoryVerifyDispatch(void)
 {
     size_t length;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_DeleteDirectoryCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_DeleteDirectoryCmd), CFE_SUCCESS);
 
     length = 1; /* bad size for any message */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_FALSE(FM_DeleteDirectoryVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_DeleteDirectoryVerifyDispatch(&UT_CmdBuf.DeleteDirectoryCmd), CFE_STATUS_VALIDATION_FAILURE);
 
     length = sizeof(FM_DeleteDirectoryCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_TRUE(FM_DeleteDirectoryVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_DeleteDirectoryVerifyDispatch(&UT_CmdBuf.DeleteDirectoryCmd), CFE_SUCCESS);
 }
 
 void Test_FM_GetDirListFileVerifyDispatch(void)
 {
     size_t length;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_GetDirListFileCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_GetDirListFileCmd), CFE_SUCCESS);
 
     length = 1; /* bad size for any message */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_FALSE(FM_GetDirListFileVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_GetDirListFileVerifyDispatch(&UT_CmdBuf.GetDirListFileCmd), CFE_STATUS_VALIDATION_FAILURE);
 
     length = sizeof(FM_GetDirListFileCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_TRUE(FM_GetDirListFileVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_GetDirListFileVerifyDispatch(&UT_CmdBuf.GetDirListFileCmd), CFE_SUCCESS);
 }
 
 void Test_FM_GetDirListPktVerifyDispatch(void)
 {
     size_t length;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_GetDirListPktCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_GetDirListPktCmd), CFE_SUCCESS);
 
     length = 1; /* bad size for any message */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_FALSE(FM_GetDirListPktVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_GetDirListPktVerifyDispatch(&UT_CmdBuf.GetDirListPktCmd), CFE_STATUS_VALIDATION_FAILURE);
 
     length = sizeof(FM_GetDirListPktCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_TRUE(FM_GetDirListPktVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_GetDirListPktVerifyDispatch(&UT_CmdBuf.GetDirListPktCmd), CFE_SUCCESS);
 }
 
 void Test_FM_MonitorFilesystemSpaceVerifyDispatch(void)
 {
     size_t length;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_MonitorFilesystemSpaceCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_MonitorFilesystemSpaceCmd), CFE_SUCCESS);
 
     length = 1; /* bad size for any message */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_FALSE(FM_MonitorFilesystemSpaceVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_MonitorFilesystemSpaceVerifyDispatch(&UT_CmdBuf.GetFreeSpaceCmd),
+                      CFE_STATUS_VALIDATION_FAILURE);
 
     length = sizeof(FM_MonitorFilesystemSpaceCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_TRUE(FM_MonitorFilesystemSpaceVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_MonitorFilesystemSpaceVerifyDispatch(&UT_CmdBuf.GetFreeSpaceCmd), CFE_SUCCESS);
 }
 
 void Test_FM_SetTableStateVerifyDispatch(void)
 {
     size_t length;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_SetTableStateCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_SetTableStateCmd), CFE_SUCCESS);
 
     length = 1; /* bad size for any message */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_FALSE(FM_SetTableStateVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_SetTableStateVerifyDispatch(&UT_CmdBuf.SetTableStateCmd), CFE_STATUS_VALIDATION_FAILURE);
 
     length = sizeof(FM_SetTableStateCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_TRUE(FM_SetTableStateVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_SetTableStateVerifyDispatch(&UT_CmdBuf.SetTableStateCmd), CFE_SUCCESS);
 }
 
 void Test_FM_SetPermissionsVerifyDispatch(void)
 {
     size_t length;
 
-    UT_SetDefaultReturnValue(UT_KEY(FM_SetPermissionsCmd), true);
+    UT_SetDefaultReturnValue(UT_KEY(FM_SetPermissionsCmd), CFE_SUCCESS);
 
     length = 1; /* bad size for any message */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_FALSE(FM_SetPermissionsVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_SetPermissionsVerifyDispatch(&UT_CmdBuf.SetPermissionsCmd), CFE_STATUS_VALIDATION_FAILURE);
 
     length = sizeof(FM_SetPermissionsCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_BOOL_TRUE(FM_SetPermissionsVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_INT32_EQ(FM_SetPermissionsVerifyDispatch(&UT_CmdBuf.SetPermissionsCmd), CFE_SUCCESS);
 }
 
 void Test_FM_SendHkVerifyDispatch(void)
@@ -904,11 +905,11 @@ void Test_FM_SendHkVerifyDispatch(void)
 
     length = 1; /* bad size for any message */
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_VOIDCALL(FM_SendHkVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(FM_SendHkVerifyDispatch(&UT_CmdBuf.SendHkCmd));
 
     length = sizeof(FM_SendHkCmd_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &length, sizeof(length), false);
-    UtAssert_VOIDCALL(FM_SendHkVerifyDispatch(&UT_CmdBuf.Buf));
+    UtAssert_VOIDCALL(FM_SendHkVerifyDispatch(&UT_CmdBuf.SendHkCmd));
 }
 
 /*

--- a/unit-test/stubs/fm_app_stubs.c
+++ b/unit-test/stubs/fm_app_stubs.c
@@ -56,9 +56,9 @@ void FM_AppMain(void)
  * Generated stub function for FM_SendHkCmd()
  * ----------------------------------------------------
  */
-void FM_SendHkCmd(const CFE_SB_Buffer_t *BufPtr)
+void FM_SendHkCmd(const FM_SendHkCmd_t *BufPtr)
 {
-    UT_GenStub_AddParam(FM_SendHkCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(FM_SendHkCmd, const FM_SendHkCmd_t *, BufPtr);
 
     UT_GenStub_Execute(FM_SendHkCmd, Basic, NULL);
 }

--- a/unit-test/stubs/fm_cmds_stubs.c
+++ b/unit-test/stubs/fm_cmds_stubs.c
@@ -31,15 +31,15 @@
  * Generated stub function for FM_ConcatFilesCmd()
  * ----------------------------------------------------
  */
-bool FM_ConcatFilesCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_ConcatFilesCmd(const FM_ConcatFilesCmd_t *BufPtr)
 {
-    UT_GenStub_SetupReturnBuffer(FM_ConcatFilesCmd, bool);
+    UT_GenStub_SetupReturnBuffer(FM_ConcatFilesCmd, CFE_Status_t);
 
-    UT_GenStub_AddParam(FM_ConcatFilesCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(FM_ConcatFilesCmd, const FM_ConcatFilesCmd_t *, BufPtr);
 
     UT_GenStub_Execute(FM_ConcatFilesCmd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_ConcatFilesCmd, bool);
+    return UT_GenStub_GetReturnValue(FM_ConcatFilesCmd, CFE_Status_t);
 }
 
 /*
@@ -47,15 +47,15 @@ bool FM_ConcatFilesCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for FM_CopyFileCmd()
  * ----------------------------------------------------
  */
-bool FM_CopyFileCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_CopyFileCmd(const FM_CopyFileCmd_t *BufPtr)
 {
-    UT_GenStub_SetupReturnBuffer(FM_CopyFileCmd, bool);
+    UT_GenStub_SetupReturnBuffer(FM_CopyFileCmd, CFE_Status_t);
 
-    UT_GenStub_AddParam(FM_CopyFileCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(FM_CopyFileCmd, const FM_CopyFileCmd_t *, BufPtr);
 
     UT_GenStub_Execute(FM_CopyFileCmd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_CopyFileCmd, bool);
+    return UT_GenStub_GetReturnValue(FM_CopyFileCmd, CFE_Status_t);
 }
 
 /*
@@ -63,15 +63,15 @@ bool FM_CopyFileCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for FM_CreateDirectoryCmd()
  * ----------------------------------------------------
  */
-bool FM_CreateDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_CreateDirectoryCmd(const FM_CreateDirectoryCmd_t *BufPtr)
 {
-    UT_GenStub_SetupReturnBuffer(FM_CreateDirectoryCmd, bool);
+    UT_GenStub_SetupReturnBuffer(FM_CreateDirectoryCmd, CFE_Status_t);
 
-    UT_GenStub_AddParam(FM_CreateDirectoryCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(FM_CreateDirectoryCmd, const FM_CreateDirectoryCmd_t *, BufPtr);
 
     UT_GenStub_Execute(FM_CreateDirectoryCmd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_CreateDirectoryCmd, bool);
+    return UT_GenStub_GetReturnValue(FM_CreateDirectoryCmd, CFE_Status_t);
 }
 
 /*
@@ -79,15 +79,15 @@ bool FM_CreateDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for FM_DecompressFileCmd()
  * ----------------------------------------------------
  */
-bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_DecompressFileCmd(const FM_DecompressFileCmd_t *BufPtr)
 {
-    UT_GenStub_SetupReturnBuffer(FM_DecompressFileCmd, bool);
+    UT_GenStub_SetupReturnBuffer(FM_DecompressFileCmd, CFE_Status_t);
 
-    UT_GenStub_AddParam(FM_DecompressFileCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(FM_DecompressFileCmd, const FM_DecompressFileCmd_t *, BufPtr);
 
     UT_GenStub_Execute(FM_DecompressFileCmd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_DecompressFileCmd, bool);
+    return UT_GenStub_GetReturnValue(FM_DecompressFileCmd, CFE_Status_t);
 }
 
 /*
@@ -95,15 +95,15 @@ bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for FM_DeleteAllFilesCmd()
  * ----------------------------------------------------
  */
-bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_DeleteAllFilesCmd(const FM_DeleteAllFilesCmd_t *BufPtr)
 {
-    UT_GenStub_SetupReturnBuffer(FM_DeleteAllFilesCmd, bool);
+    UT_GenStub_SetupReturnBuffer(FM_DeleteAllFilesCmd, CFE_Status_t);
 
-    UT_GenStub_AddParam(FM_DeleteAllFilesCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(FM_DeleteAllFilesCmd, const FM_DeleteAllFilesCmd_t *, BufPtr);
 
     UT_GenStub_Execute(FM_DeleteAllFilesCmd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_DeleteAllFilesCmd, bool);
+    return UT_GenStub_GetReturnValue(FM_DeleteAllFilesCmd, CFE_Status_t);
 }
 
 /*
@@ -111,15 +111,15 @@ bool FM_DeleteAllFilesCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for FM_DeleteDirectoryCmd()
  * ----------------------------------------------------
  */
-bool FM_DeleteDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_DeleteDirectoryCmd(const FM_DeleteDirectoryCmd_t *BufPtr)
 {
-    UT_GenStub_SetupReturnBuffer(FM_DeleteDirectoryCmd, bool);
+    UT_GenStub_SetupReturnBuffer(FM_DeleteDirectoryCmd, CFE_Status_t);
 
-    UT_GenStub_AddParam(FM_DeleteDirectoryCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(FM_DeleteDirectoryCmd, const FM_DeleteDirectoryCmd_t *, BufPtr);
 
     UT_GenStub_Execute(FM_DeleteDirectoryCmd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_DeleteDirectoryCmd, bool);
+    return UT_GenStub_GetReturnValue(FM_DeleteDirectoryCmd, CFE_Status_t);
 }
 
 /*
@@ -127,15 +127,15 @@ bool FM_DeleteDirectoryCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for FM_DeleteFileCmd()
  * ----------------------------------------------------
  */
-bool FM_DeleteFileCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_DeleteFileCmd(const FM_DeleteFileCmd_t *BufPtr)
 {
-    UT_GenStub_SetupReturnBuffer(FM_DeleteFileCmd, bool);
+    UT_GenStub_SetupReturnBuffer(FM_DeleteFileCmd, CFE_Status_t);
 
-    UT_GenStub_AddParam(FM_DeleteFileCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(FM_DeleteFileCmd, const FM_DeleteFileCmd_t *, BufPtr);
 
     UT_GenStub_Execute(FM_DeleteFileCmd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_DeleteFileCmd, bool);
+    return UT_GenStub_GetReturnValue(FM_DeleteFileCmd, CFE_Status_t);
 }
 
 /*
@@ -143,15 +143,15 @@ bool FM_DeleteFileCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for FM_GetDirListFileCmd()
  * ----------------------------------------------------
  */
-bool FM_GetDirListFileCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_GetDirListFileCmd(const FM_GetDirListFileCmd_t *BufPtr)
 {
-    UT_GenStub_SetupReturnBuffer(FM_GetDirListFileCmd, bool);
+    UT_GenStub_SetupReturnBuffer(FM_GetDirListFileCmd, CFE_Status_t);
 
-    UT_GenStub_AddParam(FM_GetDirListFileCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(FM_GetDirListFileCmd, const FM_GetDirListFileCmd_t *, BufPtr);
 
     UT_GenStub_Execute(FM_GetDirListFileCmd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_GetDirListFileCmd, bool);
+    return UT_GenStub_GetReturnValue(FM_GetDirListFileCmd, CFE_Status_t);
 }
 
 /*
@@ -159,15 +159,15 @@ bool FM_GetDirListFileCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for FM_GetDirListPktCmd()
  * ----------------------------------------------------
  */
-bool FM_GetDirListPktCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_GetDirListPktCmd(const FM_GetDirListPktCmd_t *BufPtr)
 {
-    UT_GenStub_SetupReturnBuffer(FM_GetDirListPktCmd, bool);
+    UT_GenStub_SetupReturnBuffer(FM_GetDirListPktCmd, CFE_Status_t);
 
-    UT_GenStub_AddParam(FM_GetDirListPktCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(FM_GetDirListPktCmd, const FM_GetDirListPktCmd_t *, BufPtr);
 
     UT_GenStub_Execute(FM_GetDirListPktCmd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_GetDirListPktCmd, bool);
+    return UT_GenStub_GetReturnValue(FM_GetDirListPktCmd, CFE_Status_t);
 }
 
 /*
@@ -175,15 +175,15 @@ bool FM_GetDirListPktCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for FM_GetFileInfoCmd()
  * ----------------------------------------------------
  */
-bool FM_GetFileInfoCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_GetFileInfoCmd(const FM_GetFileInfoCmd_t *BufPtr)
 {
-    UT_GenStub_SetupReturnBuffer(FM_GetFileInfoCmd, bool);
+    UT_GenStub_SetupReturnBuffer(FM_GetFileInfoCmd, CFE_Status_t);
 
-    UT_GenStub_AddParam(FM_GetFileInfoCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(FM_GetFileInfoCmd, const FM_GetFileInfoCmd_t *, BufPtr);
 
     UT_GenStub_Execute(FM_GetFileInfoCmd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_GetFileInfoCmd, bool);
+    return UT_GenStub_GetReturnValue(FM_GetFileInfoCmd, CFE_Status_t);
 }
 
 /*
@@ -191,15 +191,15 @@ bool FM_GetFileInfoCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for FM_GetOpenFilesCmd()
  * ----------------------------------------------------
  */
-bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_GetOpenFilesCmd(const FM_GetOpenFilesCmd_t *BufPtr)
 {
-    UT_GenStub_SetupReturnBuffer(FM_GetOpenFilesCmd, bool);
+    UT_GenStub_SetupReturnBuffer(FM_GetOpenFilesCmd, CFE_Status_t);
 
-    UT_GenStub_AddParam(FM_GetOpenFilesCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(FM_GetOpenFilesCmd, const FM_GetOpenFilesCmd_t *, BufPtr);
 
     UT_GenStub_Execute(FM_GetOpenFilesCmd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_GetOpenFilesCmd, bool);
+    return UT_GenStub_GetReturnValue(FM_GetOpenFilesCmd, CFE_Status_t);
 }
 
 /*
@@ -207,15 +207,15 @@ bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for FM_MonitorFilesystemSpaceCmd()
  * ----------------------------------------------------
  */
-bool FM_MonitorFilesystemSpaceCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_MonitorFilesystemSpaceCmd(const FM_MonitorFilesystemSpaceCmd_t *BufPtr)
 {
-    UT_GenStub_SetupReturnBuffer(FM_MonitorFilesystemSpaceCmd, bool);
+    UT_GenStub_SetupReturnBuffer(FM_MonitorFilesystemSpaceCmd, CFE_Status_t);
 
-    UT_GenStub_AddParam(FM_MonitorFilesystemSpaceCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(FM_MonitorFilesystemSpaceCmd, const FM_MonitorFilesystemSpaceCmd_t *, BufPtr);
 
     UT_GenStub_Execute(FM_MonitorFilesystemSpaceCmd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_MonitorFilesystemSpaceCmd, bool);
+    return UT_GenStub_GetReturnValue(FM_MonitorFilesystemSpaceCmd, CFE_Status_t);
 }
 
 /*
@@ -223,15 +223,15 @@ bool FM_MonitorFilesystemSpaceCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for FM_MoveFileCmd()
  * ----------------------------------------------------
  */
-bool FM_MoveFileCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_MoveFileCmd(const FM_MoveFileCmd_t *BufPtr)
 {
-    UT_GenStub_SetupReturnBuffer(FM_MoveFileCmd, bool);
+    UT_GenStub_SetupReturnBuffer(FM_MoveFileCmd, CFE_Status_t);
 
-    UT_GenStub_AddParam(FM_MoveFileCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(FM_MoveFileCmd, const FM_MoveFileCmd_t *, BufPtr);
 
     UT_GenStub_Execute(FM_MoveFileCmd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_MoveFileCmd, bool);
+    return UT_GenStub_GetReturnValue(FM_MoveFileCmd, CFE_Status_t);
 }
 
 /*
@@ -239,15 +239,15 @@ bool FM_MoveFileCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for FM_NoopCmd()
  * ----------------------------------------------------
  */
-bool FM_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_NoopCmd(const FM_NoopCmd_t *BufPtr)
 {
-    UT_GenStub_SetupReturnBuffer(FM_NoopCmd, bool);
+    UT_GenStub_SetupReturnBuffer(FM_NoopCmd, CFE_Status_t);
 
-    UT_GenStub_AddParam(FM_NoopCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(FM_NoopCmd, const FM_NoopCmd_t *, BufPtr);
 
     UT_GenStub_Execute(FM_NoopCmd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_NoopCmd, bool);
+    return UT_GenStub_GetReturnValue(FM_NoopCmd, CFE_Status_t);
 }
 
 /*
@@ -255,15 +255,15 @@ bool FM_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for FM_RenameFileCmd()
  * ----------------------------------------------------
  */
-bool FM_RenameFileCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_RenameFileCmd(const FM_RenameFileCmd_t *BufPtr)
 {
-    UT_GenStub_SetupReturnBuffer(FM_RenameFileCmd, bool);
+    UT_GenStub_SetupReturnBuffer(FM_RenameFileCmd, CFE_Status_t);
 
-    UT_GenStub_AddParam(FM_RenameFileCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(FM_RenameFileCmd, const FM_RenameFileCmd_t *, BufPtr);
 
     UT_GenStub_Execute(FM_RenameFileCmd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_RenameFileCmd, bool);
+    return UT_GenStub_GetReturnValue(FM_RenameFileCmd, CFE_Status_t);
 }
 
 /*
@@ -271,15 +271,15 @@ bool FM_RenameFileCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for FM_ResetCountersCmd()
  * ----------------------------------------------------
  */
-bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_ResetCountersCmd(const FM_ResetCountersCmd_t *BufPtr)
 {
-    UT_GenStub_SetupReturnBuffer(FM_ResetCountersCmd, bool);
+    UT_GenStub_SetupReturnBuffer(FM_ResetCountersCmd, CFE_Status_t);
 
-    UT_GenStub_AddParam(FM_ResetCountersCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(FM_ResetCountersCmd, const FM_ResetCountersCmd_t *, BufPtr);
 
     UT_GenStub_Execute(FM_ResetCountersCmd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_ResetCountersCmd, bool);
+    return UT_GenStub_GetReturnValue(FM_ResetCountersCmd, CFE_Status_t);
 }
 
 /*
@@ -287,15 +287,15 @@ bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for FM_SetPermissionsCmd()
  * ----------------------------------------------------
  */
-bool FM_SetPermissionsCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_SetPermissionsCmd(const FM_SetPermissionsCmd_t *BufPtr)
 {
-    UT_GenStub_SetupReturnBuffer(FM_SetPermissionsCmd, bool);
+    UT_GenStub_SetupReturnBuffer(FM_SetPermissionsCmd, CFE_Status_t);
 
-    UT_GenStub_AddParam(FM_SetPermissionsCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(FM_SetPermissionsCmd, const FM_SetPermissionsCmd_t *, BufPtr);
 
     UT_GenStub_Execute(FM_SetPermissionsCmd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_SetPermissionsCmd, bool);
+    return UT_GenStub_GetReturnValue(FM_SetPermissionsCmd, CFE_Status_t);
 }
 
 /*
@@ -303,13 +303,13 @@ bool FM_SetPermissionsCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for FM_SetTableStateCmd()
  * ----------------------------------------------------
  */
-bool FM_SetTableStateCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t FM_SetTableStateCmd(const FM_SetTableStateCmd_t *BufPtr)
 {
-    UT_GenStub_SetupReturnBuffer(FM_SetTableStateCmd, bool);
+    UT_GenStub_SetupReturnBuffer(FM_SetTableStateCmd, CFE_Status_t);
 
-    UT_GenStub_AddParam(FM_SetTableStateCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(FM_SetTableStateCmd, const FM_SetTableStateCmd_t *, BufPtr);
 
     UT_GenStub_Execute(FM_SetTableStateCmd, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_SetTableStateCmd, bool);
+    return UT_GenStub_GetReturnValue(FM_SetTableStateCmd, CFE_Status_t);
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #95
  - Updated the command handler functions to use their specific command message types `(FM_NoopCmd_t,` `FM_ResetCountersCmd_t` etc.) rather than the generic `CFE_SB_Buffer_t.`
  - Converted return types of the command handler functions and other relevant functions to `CFE_Status_t` (also changed their `status`/`result` variables to `CFE_Status_t)`
  - Added a general error return code `FM_ERROR`
  - Used some of the new, more specific, CFE error return types:
    - Converted the previous `false` returns from failures during `FM_IsValidCmdPktLength()` in the dispatch routines to the new CFE return code `CFE_STATUS_VALIDATION_FAILURE`
    - `CFE_STATUS_INCORRECT_STATE` and `CFE_STATUS_RANGE_ERROR` in suitable locations instead of just using `FM_ERROR`

Question: _Does something need to be done in terms of deprecation due to the change to the API (the `FM_SendHkCmd()` `BufPtr` parameter type has changed)?_

**Testing performed**
GitHub CI actions (incl. Build and Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
Behavior largely unchanged.
Compiler error is now thrown if the command handler functions are invoked with *any* type other than their own specific command type.
Using a defined set of error return macros and the `CFE_Status_t` return type improves code clarity and makes FM more consistent with cFE and the other cFS apps.

**Contributor Info**
Avi Weiss @thnkslprpt