### PR TITLE
Fix #97, Remove redundant use of "dummy" in test code

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -3,14 +3,14 @@ name: CodeQl Analysis
 on:
   push:
   pull_request:
-  
+
 
 jobs:
   codeql:
     name: Codeql Analysis
     uses: nasa/cFS/.github/workflows/codeql-reusable.yml@main
     with:
-      component-path: apps/fm 
+      component-path: apps/fm
       prep: 'make prep; make -C build/tools/elf2cfetbl'
       make: 'make -C build/native/default_cpu1/apps/fm'
       setup: |

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -9,4 +9,3 @@ jobs:
   format-check:
     name: Run format check
     uses: nasa/cFS/.github/workflows/format-check.yml@main
-    

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,4 +10,4 @@ jobs:
     name: Run cppcheck
     uses: nasa/cFS/.github/workflows/static-analysis.yml@main
     with:
-      strict-dir-list: './fsw'    
+      strict-dir-list: './fsw'

--- a/unit-test/fm_child_tests.c
+++ b/unit-test/fm_child_tests.c
@@ -589,7 +589,7 @@ void Test_FM_ChildDeleteAllFilesCmd_DirOpenNotSuccess(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "source1", .Source2 = "source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryOpen), !OS_SUCCESS);
 
@@ -610,7 +610,7 @@ void Test_FM_ChildDeleteAllFilesCmd_DirReadNotSuccess(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "source1", .Source2 = "source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryRead), !OS_SUCCESS);
 
@@ -631,7 +631,7 @@ void Test_FM_ChildDeleteAllFilesCmd_DirEntryThisDirectory(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "source1", .Source2 = "source2"};
     os_dirent_t direntry = {.FileName = FM_THIS_DIRECTORY};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
@@ -656,7 +656,7 @@ void Test_FM_ChildDeleteAllFilesCmd_DirEntryParentDirectory(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "source1", .Source2 = "source2"};
     os_dirent_t direntry = {.FileName = FM_PARENT_DIRECTORY};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
@@ -681,8 +681,8 @@ void Test_FM_ChildDeleteAllFilesCmd_PathFilenameLengthGreaterMaxPthLen(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_ALL_FILES_CC,
-                                        .Source1     = "dummy_source1",
-                                        .Source2     = "dummy_source2HasAReallyLongNameSomeSayTheNameIs42Characters"};
+                                        .Source1     = "source1",
+                                        .Source2     = "source2HasAReallyReallyLongNameSomeSayTheNameIs42Characters"};
     os_dirent_t          direntry    = {.FileName = "ThisDirectory"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
@@ -709,7 +709,7 @@ void Test_FM_ChildDeleteAllFilesCmd_InvalidFilenameState(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "source1", .Source2 = "source2"};
     os_dirent_t direntry = {.FileName = "ThisDirectory"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
@@ -737,7 +737,7 @@ void Test_FM_ChildDeleteAllFilesCmd_NotInUseFilenameState(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "source1", .Source2 = "source2"};
     os_dirent_t direntry = {.FileName = "ThisDirectory"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
@@ -765,7 +765,7 @@ void Test_FM_ChildDeleteAllFilesCmd_DirectoryFilenameState(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "source1", .Source2 = "source2"};
     os_dirent_t direntry = {.FileName = "ThisDirectory"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
@@ -793,7 +793,7 @@ void Test_FM_ChildDeleteAllFilesCmd_OpenFilenameState(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "source1", .Source2 = "source2"};
     os_dirent_t direntry = {.FileName = "ThisDirectory"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
@@ -821,7 +821,7 @@ void Test_FM_ChildDeleteAllFilesCmd_ClosedFilename_OSRmNotSuccess(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "source1", .Source2 = "source2"};
     os_dirent_t direntry = {.FileName = "ThisDirectory"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
@@ -851,7 +851,7 @@ void Test_FM_ChildDeleteAllFilesCmd_ClosedFilename_OSrmSuccess(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "source1", .Source2 = "source2"};
     os_dirent_t direntry = {.FileName = "ThisDirectory"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
@@ -879,7 +879,7 @@ void Test_FM_ChildDeleteAllFilesCmd_FilenameStateDefaultReturn(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_DELETE_ALL_FILES_CC, .Source1 = "source1", .Source2 = "source2"};
     os_dirent_t direntry = {.FileName = "ThisDirectory"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
@@ -952,8 +952,7 @@ void Test_FM_ChildDecompressFileCmd_FSDecompressNotSuccess(void)
 void Test_FM_ChildConcatFilesCmd_OSCpNotSuccess(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_CONCAT_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_CONCAT_FILES_CC, .Source1 = "source1", .Source2 = "source2"};
 
     FM_GlobalData.ChildCurrentCC = 1;
     UT_SetDefaultReturnValue(UT_KEY(OS_cp), !OS_SUCCESS);
@@ -973,8 +972,7 @@ void Test_FM_ChildConcatFilesCmd_OSCpNotSuccess(void)
 void Test_FM_ChildConcatFilesCmd_OSOpenCreateSourceNotSuccess(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_CONCAT_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_CONCAT_FILES_CC, .Source1 = "source1", .Source2 = "source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), !OS_SUCCESS);
 
@@ -995,8 +993,7 @@ void Test_FM_ChildConcatFilesCmd_OSOpenCreateSourceNotSuccess(void)
 void Test_FM_ChildConcatFilesCmd_OSOpenCreateTargetNotSuccess(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_CONCAT_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_CONCAT_FILES_CC, .Source1 = "source1", .Source2 = "source2"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_OpenCreate), 2, !OS_SUCCESS);
 
@@ -1018,8 +1015,7 @@ void Test_FM_ChildConcatFilesCmd_OSOpenCreateTargetNotSuccess(void)
 void Test_FM_ChildConcatFilesCmd_OSReadBytesZero(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_CONCAT_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_CONCAT_FILES_CC, .Source1 = "source1", .Source2 = "source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_read), 0);
 
@@ -1042,8 +1038,7 @@ void Test_FM_ChildConcatFilesCmd_OSReadBytesZero(void)
 void Test_FM_ChildConcatFilesCmd_OSReadBytesLessThanZero(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_CONCAT_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_CONCAT_FILES_CC, .Source1 = "source1", .Source2 = "source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_read), -1);
 
@@ -1066,8 +1061,7 @@ void Test_FM_ChildConcatFilesCmd_OSReadBytesLessThanZero(void)
 void Test_FM_ChildConcatFilesCmd_BytesWrittenNotEqualBytesRead(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_CONCAT_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_CONCAT_FILES_CC, .Source1 = "source1", .Source2 = "source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_read), 1);
     UT_SetDefaultReturnValue(UT_KEY(OS_write), 0);
@@ -1091,8 +1085,7 @@ void Test_FM_ChildConcatFilesCmd_BytesWrittenNotEqualBytesRead(void)
 void Test_FM_ChildConcatFilesCmd_CopyInProgressTrueLoopCountEqualChildFileLoopCount(void)
 {
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_CONCAT_FILES_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+    FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_CONCAT_FILES_CC, .Source1 = "source1", .Source2 = "source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_read), 1);
     UT_SetDefaultReturnValue(UT_KEY(OS_write), 1);
@@ -1122,8 +1115,8 @@ void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualIgnoreCRC(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode   = FM_GET_FILE_INFO_CC,
-                                        .Source1       = "dummy_source1",
-                                        .Source2       = "dummy_source2",
+                                        .Source1       = "source1",
+                                        .Source2       = "source2",
                                         .FileInfoCRC   = FM_IGNORE_CRC,
                                         .FileInfoState = FM_NAME_IS_FILE_CLOSED};
 
@@ -1143,8 +1136,8 @@ void Test_FM_ChildFileInfoCmd_FileInfoStateIsNotFileClosed(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode   = FM_GET_FILE_INFO_CC,
-                                        .Source1       = "dummy_source1",
-                                        .Source2       = "dummy_source2",
+                                        .Source1       = "source1",
+                                        .Source2       = "source2",
                                         .FileInfoCRC   = CFE_ES_CrcType_CRC_8,
                                         .FileInfoState = FM_NAME_IS_FILE_OPEN};
 
@@ -1166,8 +1159,8 @@ void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualMission8(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode   = FM_GET_FILE_INFO_CC,
-                                        .Source1       = "dummy_source1",
-                                        .Source2       = "dummy_source2",
+                                        .Source1       = "source1",
+                                        .Source2       = "source2",
                                         .FileInfoCRC   = CFE_ES_CrcType_CRC_8,
                                         .FileInfoState = FM_NAME_IS_FILE_CLOSED};
 
@@ -1191,8 +1184,8 @@ void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualMission16(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode   = FM_GET_FILE_INFO_CC,
-                                        .Source1       = "dummy_source1",
-                                        .Source2       = "dummy_source2",
+                                        .Source1       = "source1",
+                                        .Source2       = "source2",
                                         .FileInfoCRC   = CFE_ES_CrcType_CRC_16,
                                         .FileInfoState = FM_NAME_IS_FILE_CLOSED};
 
@@ -1216,8 +1209,8 @@ void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualMission32(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode   = FM_GET_FILE_INFO_CC,
-                                        .Source1       = "dummy_source1",
-                                        .Source2       = "dummy_source2",
+                                        .Source1       = "source1",
+                                        .Source2       = "source2",
                                         .FileInfoCRC   = CFE_ES_CrcType_CRC_32,
                                         .FileInfoState = FM_NAME_IS_FILE_CLOSED};
 
@@ -1241,8 +1234,8 @@ void Test_FM_ChildFileInfoCmd_FileInfoCRCNotEqualToAnyMissionES(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode   = FM_GET_FILE_INFO_CC,
-                                        .Source1       = "dummy_source1",
-                                        .Source2       = "dummy_source2",
+                                        .Source1       = "source1",
+                                        .Source2       = "source2",
                                         .FileInfoCRC   = -1,
                                         .FileInfoState = FM_NAME_IS_FILE_CLOSED};
 
@@ -1264,8 +1257,8 @@ void Test_FM_ChildFileInfoCmd_OSOpenCreateTrueBytesReadZero(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode   = FM_GET_FILE_INFO_CC,
-                                        .Source1       = "dummy_source1",
-                                        .Source2       = "dummy_source2",
+                                        .Source1       = "source1",
+                                        .Source2       = "source2",
                                         .FileInfoCRC   = CFE_ES_CrcType_CRC_16,
                                         .FileInfoState = FM_NAME_IS_FILE_CLOSED};
 
@@ -1289,8 +1282,8 @@ void Test_FM_ChildFileInfoCmd_BytesReadLessThanZero(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode   = FM_GET_FILE_INFO_CC,
-                                        .Source1       = "dummy_source1",
-                                        .Source2       = "dummy_source2",
+                                        .Source1       = "source1",
+                                        .Source2       = "source2",
                                         .FileInfoCRC   = CFE_ES_CrcType_CRC_16,
                                         .FileInfoState = FM_NAME_IS_FILE_CLOSED};
 
@@ -1316,8 +1309,8 @@ void Test_FM_ChildFileInfoCmd_BytesReadGreaterThanZero(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode   = FM_GET_FILE_INFO_CC,
-                                        .Source1       = "dummy_source1",
-                                        .Source2       = "dummy_source2",
+                                        .Source1       = "source1",
+                                        .Source2       = "source2",
                                         .FileInfoCRC   = CFE_ES_CrcType_CRC_8,
                                         .FileInfoState = FM_NAME_IS_FILE_CLOSED};
 
@@ -1533,7 +1526,7 @@ void Test_FM_ChildDirListFileCmd_ChildDirListFileInitFalse(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_GET_DIR_LIST_FILE_CC, .Source1 = "dummy_source1", .Target = "dummy_target"};
+        .CommandCode = FM_GET_DIR_LIST_FILE_CC, .Source1 = "source1", .Target = "target"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), !OS_SUCCESS);
 
@@ -1555,7 +1548,7 @@ void Test_FM_ChildDirListFileCmd_ChildDirListFileInitTrue(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_GET_DIR_LIST_FILE_CC, .Source1 = "dummy_source1", .Target = "dummy_target"};
+        .CommandCode = FM_GET_DIR_LIST_FILE_CC, .Source1 = "source1", .Target = "target"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryRead), !OS_SUCCESS);
 
@@ -1580,7 +1573,7 @@ void Test_FM_ChildDirListPktCmd_OSDirOpenNotSuccess(void)
 {
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_GET_DIR_LIST_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_GET_DIR_LIST_PKT_CC, .Source1 = "source1", .Source2 = "source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryOpen), !OS_SUCCESS);
 
@@ -1602,7 +1595,7 @@ void Test_FM_ChildDirListPktCmd_OSDirReadNotSuccess(void)
 
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_GET_DIR_LIST_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_GET_DIR_LIST_PKT_CC, .Source1 = "source1", .Source2 = "source2"};
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryRead), !OS_SUCCESS);
 
@@ -1628,7 +1621,7 @@ void Test_FM_ChildDirListPktCmd_DirEntryNameThisDirectory(void)
 
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_GET_DIR_LIST_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_GET_DIR_LIST_PKT_CC, .Source1 = "source1", .Source2 = "source2"};
     os_dirent_t direntry = {.FileName = FM_THIS_DIRECTORY};
 
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
@@ -1656,7 +1649,7 @@ void Test_FM_ChildDirListPktCmd_DirEntryNameParentDirectory(void)
 
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_GET_DIR_LIST_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_GET_DIR_LIST_PKT_CC, .Source1 = "source1", .Source2 = "source2"};
     os_dirent_t direntry = {.FileName = FM_PARENT_DIRECTORY};
 
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
@@ -1683,11 +1676,9 @@ void Test_FM_ChildDirListPktCmd_DirListOffsetNotExceeded(void)
     FM_DirListPkt_Payload_t *ReportPtr;
 
     /* Arrange */
-    FM_ChildQueueEntry_t queue_entry = {.CommandCode   = FM_GET_DIR_LIST_PKT_CC,
-                                        .Source1       = "dummy_source1",
-                                        .Source2       = "dummy_source2",
-                                        .DirListOffset = 1};
-    os_dirent_t          direntry    = {.FileName = "filename"};
+    FM_ChildQueueEntry_t queue_entry = {
+        .CommandCode = FM_GET_DIR_LIST_PKT_CC, .Source1 = "source1", .Source2 = "source2", .DirListOffset = 1};
+    os_dirent_t direntry = {.FileName = "filename"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);
     UT_SetDataBuffer(UT_KEY(OS_DirectoryRead), &direntry, sizeof(direntry), false);
@@ -1716,7 +1707,7 @@ void Test_FM_ChildDirListPktCmd_DirListOffsetExceeded(void)
 
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {
-        .CommandCode = FM_GET_DIR_LIST_PKT_CC, .Source1 = "dummy_source1", .Source2 = "dummy_source2"};
+        .CommandCode = FM_GET_DIR_LIST_PKT_CC, .Source1 = "source1", .Source2 = "source2"};
     os_dirent_t direntry[FM_DIR_LIST_PKT_ENTRIES + 1];
 
     /* Unit under test doesn't really care if the entry name is empty */
@@ -1750,8 +1741,8 @@ void Test_FM_ChildDirListPktCmd_PathAndEntryLengthGreaterMaxPathLength(void)
 
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DELETE_ALL_FILES_CC,
-                                        .Source1     = "dummy_source1",
-                                        .Source2 = "dummy_source2_has_a_long_name_to_make_path_length_longer_than_64"};
+                                        .Source1     = "source1",
+                                        .Source2 = "source2_has_quite_a_long_name_to_make_path_length_longer_than_64"};
     os_dirent_t          direntry    = {.FileName = "direntry_long"};
 
     UT_SetDeferredRetcode(UT_KEY(OS_DirectoryRead), 2, !OS_SUCCESS);

--- a/unit-test/fm_cmds_tests.c
+++ b/unit-test/fm_cmds_tests.c
@@ -1463,23 +1463,23 @@ void Test_FM_MonitorFilesystemSpaceCmd_Success(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "%%s command");
 
-    FM_MonitorTable_t DummyTable;
+    FM_MonitorTable_t Table;
     uint64            RefVal1;
     uint64            RefVal2;
 
     RefVal1 = 20;
     RefVal2 = 10;
 
-    memset(&DummyTable, 0, sizeof(DummyTable));
+    memset(&Table, 0, sizeof(Table));
 
-    DummyTable.Entries[0].Type    = FM_MonitorTableEntry_Type_VOLUME_FREE_SPACE;
-    DummyTable.Entries[0].Enabled = FM_TABLE_ENTRY_ENABLED;
-    DummyTable.Entries[1].Type    = FM_MonitorTableEntry_Type_DIRECTORY_ESTIMATE;
-    DummyTable.Entries[1].Enabled = FM_TABLE_ENTRY_ENABLED;
-    DummyTable.Entries[2].Type    = FM_MonitorTableEntry_Type_VOLUME_FREE_SPACE;
-    DummyTable.Entries[2].Enabled = FM_TABLE_ENTRY_DISABLED;
+    Table.Entries[0].Type    = FM_MonitorTableEntry_Type_VOLUME_FREE_SPACE;
+    Table.Entries[0].Enabled = FM_TABLE_ENTRY_ENABLED;
+    Table.Entries[1].Type    = FM_MonitorTableEntry_Type_DIRECTORY_ESTIMATE;
+    Table.Entries[1].Enabled = FM_TABLE_ENTRY_ENABLED;
+    Table.Entries[2].Type    = FM_MonitorTableEntry_Type_VOLUME_FREE_SPACE;
+    Table.Entries[2].Enabled = FM_TABLE_ENTRY_DISABLED;
 
-    FM_GlobalData.MonitorTablePtr = &DummyTable;
+    FM_GlobalData.MonitorTablePtr = &Table;
 
     UT_SetHandlerFunction(UT_KEY(FM_GetVolumeFreeSpace), UT_Handler_MonitorSpace, &RefVal1);
     UT_SetHandlerFunction(UT_KEY(FM_GetDirectorySpaceEstimate), UT_Handler_MonitorSpace, &RefVal2);
@@ -1550,13 +1550,13 @@ void Test_FM_MonitorFilesystemSpaceCmd_ImplCallFails(void)
              "Could not get file system free space for %%s. Returned 0x%%08X");
     snprintf(ExpectedEventString2, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "%%s command");
 
-    FM_MonitorTable_t DummyTable;
+    FM_MonitorTable_t Table;
 
-    memset(&DummyTable, 0, sizeof(DummyTable));
-    DummyTable.Entries[0].Type    = FM_MonitorTableEntry_Type_VOLUME_FREE_SPACE;
-    DummyTable.Entries[0].Enabled = true;
+    memset(&Table, 0, sizeof(Table));
+    Table.Entries[0].Type    = FM_MonitorTableEntry_Type_VOLUME_FREE_SPACE;
+    Table.Entries[0].Enabled = true;
 
-    FM_GlobalData.MonitorTablePtr = &DummyTable;
+    FM_GlobalData.MonitorTablePtr = &Table;
 
     UT_SetDefaultReturnValue(UT_KEY(FM_GetVolumeFreeSpace), CFE_STATUS_EXTERNAL_RESOURCE_FAIL);
 
@@ -1594,13 +1594,13 @@ void Test_FM_MonitorFilesystemSpaceCmd_NotImpl(void)
              "Could not get file system free space for %%s. Returned 0x%%08X");
     snprintf(ExpectedEventString2, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "%%s command");
 
-    FM_MonitorTable_t DummyTable;
+    FM_MonitorTable_t Table;
 
-    memset(&DummyTable, 0, sizeof(DummyTable));
-    DummyTable.Entries[0].Type    = 142;
-    DummyTable.Entries[0].Enabled = true;
+    memset(&Table, 0, sizeof(Table));
+    Table.Entries[0].Type    = 142;
+    Table.Entries[0].Enabled = true;
 
-    FM_GlobalData.MonitorTablePtr = &DummyTable;
+    FM_GlobalData.MonitorTablePtr = &Table;
 
     /* Assert */
     UtAssert_BOOL_FALSE(FM_MonitorFilesystemSpaceCmd(&UT_CmdBuf.Buf));
@@ -1656,12 +1656,12 @@ void Test_FM_SetTableStateCmd_Success(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "%%s command: index = %%d, state = %%d");
 
-    FM_MonitorTable_t DummyTable;
+    FM_MonitorTable_t Table;
 
-    memset(&DummyTable, 0, sizeof(DummyTable));
+    memset(&Table, 0, sizeof(Table));
 
-    DummyTable.Entries[0].Type    = FM_MonitorTableEntry_Type_VOLUME_FREE_SPACE;
-    FM_GlobalData.MonitorTablePtr = &DummyTable;
+    Table.Entries[0].Type         = FM_MonitorTableEntry_Type_VOLUME_FREE_SPACE;
+    FM_GlobalData.MonitorTablePtr = &Table;
 
     UtAssert_BOOL_TRUE(FM_SetTableStateCmd(&UT_CmdBuf.Buf));
 
@@ -1725,11 +1725,11 @@ void Test_FM_SetTableStateCmd_TableEntryIndexTooLarge(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "%%s error: invalid command argument: index = %%d");
 
-    FM_MonitorTable_t DummyTable;
+    FM_MonitorTable_t Table;
 
-    memset(&DummyTable, 0, sizeof(DummyTable));
+    memset(&Table, 0, sizeof(Table));
 
-    FM_GlobalData.MonitorTablePtr = &DummyTable;
+    FM_GlobalData.MonitorTablePtr = &Table;
 
     bool Result = FM_SetTableStateCmd(&UT_CmdBuf.Buf);
 
@@ -1762,11 +1762,11 @@ void Test_FM_SetTableStateCmd_BadNewState(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "%%s error: invalid command argument: state = %%d");
 
-    FM_MonitorTable_t DummyTable;
+    FM_MonitorTable_t Table;
 
-    memset(&DummyTable, 0, sizeof(DummyTable));
+    memset(&Table, 0, sizeof(Table));
 
-    FM_GlobalData.MonitorTablePtr = &DummyTable;
+    FM_GlobalData.MonitorTablePtr = &Table;
 
     bool Result = FM_SetTableStateCmd(&UT_CmdBuf.Buf);
 
@@ -1799,11 +1799,11 @@ void Test_FM_SetTableStateCmd_BadCurrentState(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "%%s error: cannot modify unused table entry: index = %%d");
 
-    FM_MonitorTable_t DummyTable;
+    FM_MonitorTable_t Table;
 
-    memset(&DummyTable, 0, sizeof(DummyTable));
+    memset(&Table, 0, sizeof(Table));
 
-    FM_GlobalData.MonitorTablePtr = &DummyTable;
+    FM_GlobalData.MonitorTablePtr = &Table;
 
     UtAssert_BOOL_FALSE(FM_SetTableStateCmd(&UT_CmdBuf.Buf));
 

--- a/unit-test/fm_tbl_tests.c
+++ b/unit-test/fm_tbl_tests.c
@@ -87,28 +87,28 @@ void Test_FM_TableInit_Fail(void)
 
 void Test_FM_ValidateTable_Success(void)
 {
-    FM_MonitorTable_t DummyTable;
+    FM_MonitorTable_t Table;
 
     for (int i = 0; i < FM_TABLE_ENTRY_COUNT; i++)
     {
         if ((i & 2) == 0)
         {
-            DummyTable.Entries[i].Type = FM_MonitorTableEntry_Type_VOLUME_FREE_SPACE;
+            Table.Entries[i].Type = FM_MonitorTableEntry_Type_VOLUME_FREE_SPACE;
         }
         else
         {
-            DummyTable.Entries[i].Type = FM_MonitorTableEntry_Type_DIRECTORY_ESTIMATE;
+            Table.Entries[i].Type = FM_MonitorTableEntry_Type_DIRECTORY_ESTIMATE;
             ;
         }
         if ((i & 1) == 0)
         {
-            DummyTable.Entries[i].Enabled = FM_TABLE_ENTRY_DISABLED;
+            Table.Entries[i].Enabled = FM_TABLE_ENTRY_DISABLED;
         }
         else
         {
-            DummyTable.Entries[i].Enabled = FM_TABLE_ENTRY_ENABLED;
+            Table.Entries[i].Enabled = FM_TABLE_ENTRY_ENABLED;
         }
-        snprintf(DummyTable.Entries[i].Name, OS_MAX_PATH_LEN, "Test");
+        snprintf(Table.Entries[i].Name, OS_MAX_PATH_LEN, "Test");
     }
 
     int32 strCmpResult;
@@ -116,7 +116,7 @@ void Test_FM_ValidateTable_Success(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Free Space Table verify results: good entries = %%d, bad = %%d, unused = %%d");
 
-    int32 Result = FM_ValidateTable(&DummyTable);
+    int32 Result = FM_ValidateTable(&Table);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -161,29 +161,29 @@ void Test_FM_ValidateTable_NullTable(void)
 
 void Test_FM_ValidateTable_UnusedEntry(void)
 {
-    FM_MonitorTable_t DummyTable;
+    FM_MonitorTable_t Table;
 
     for (int i = 0; i < FM_TABLE_ENTRY_COUNT; i++)
     {
-        DummyTable.Entries[i].Type = FM_MonitorTableEntry_Type_VOLUME_FREE_SPACE;
+        Table.Entries[i].Type = FM_MonitorTableEntry_Type_VOLUME_FREE_SPACE;
         if ((i % 2) == 0)
         {
-            DummyTable.Entries[i].Enabled = FM_TABLE_ENTRY_DISABLED;
+            Table.Entries[i].Enabled = FM_TABLE_ENTRY_DISABLED;
         }
         else
         {
-            DummyTable.Entries[i].Enabled = FM_TABLE_ENTRY_ENABLED;
+            Table.Entries[i].Enabled = FM_TABLE_ENTRY_ENABLED;
         }
-        snprintf(DummyTable.Entries[i].Name, OS_MAX_PATH_LEN, "Test");
+        snprintf(Table.Entries[i].Name, OS_MAX_PATH_LEN, "Test");
     }
-    DummyTable.Entries[0].Type = FM_MonitorTableEntry_Type_UNUSED;
+    Table.Entries[0].Type = FM_MonitorTableEntry_Type_UNUSED;
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Free Space Table verify results: good entries = %%d, bad = %%d, unused = %%d");
 
-    int32 Result = FM_ValidateTable(&DummyTable);
+    int32 Result = FM_ValidateTable(&Table);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -203,25 +203,25 @@ void Test_FM_ValidateTable_UnusedEntry(void)
 
 void Test_FM_ValidateTable_BadEntryState(void)
 {
-    FM_MonitorTable_t DummyTable;
+    FM_MonitorTable_t Table;
 
     for (int i = 0; i < FM_TABLE_ENTRY_COUNT; i++)
     {
-        DummyTable.Entries[i].Type = FM_MonitorTableEntry_Type_VOLUME_FREE_SPACE;
+        Table.Entries[i].Type = FM_MonitorTableEntry_Type_VOLUME_FREE_SPACE;
         if ((i % 2) == 0)
         {
-            DummyTable.Entries[i].Enabled = FM_TABLE_ENTRY_DISABLED;
+            Table.Entries[i].Enabled = FM_TABLE_ENTRY_DISABLED;
         }
         else
         {
-            DummyTable.Entries[i].Enabled = FM_TABLE_ENTRY_ENABLED;
+            Table.Entries[i].Enabled = FM_TABLE_ENTRY_ENABLED;
         }
 
-        snprintf(DummyTable.Entries[i].Name, OS_MAX_PATH_LEN, "Test");
+        snprintf(Table.Entries[i].Name, OS_MAX_PATH_LEN, "Test");
     }
 
-    DummyTable.Entries[0].Type = 99;
-    DummyTable.Entries[1].Type = 99;
+    Table.Entries[0].Type = 99;
+    Table.Entries[1].Type = 99;
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -232,7 +232,7 @@ void Test_FM_ValidateTable_BadEntryState(void)
     snprintf(ExpectedEventString2, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Free Space Table verify results: good entries = %%d, bad = %%d, unused = %%d");
 
-    int32 Result = FM_ValidateTable(&DummyTable);
+    int32 Result = FM_ValidateTable(&Table);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -260,20 +260,20 @@ void Test_FM_ValidateTable_BadEntryState(void)
 
 void Test_FM_ValidateTable_EmptyName(void)
 {
-    FM_MonitorTable_t DummyTable;
+    FM_MonitorTable_t Table;
 
     for (int i = 0; i < FM_TABLE_ENTRY_COUNT; i++)
     {
-        DummyTable.Entries[i].Type = FM_MonitorTableEntry_Type_VOLUME_FREE_SPACE;
+        Table.Entries[i].Type = FM_MonitorTableEntry_Type_VOLUME_FREE_SPACE;
         if ((i % 2) == 0)
         {
-            DummyTable.Entries[i].Enabled = FM_TABLE_ENTRY_DISABLED;
+            Table.Entries[i].Enabled = FM_TABLE_ENTRY_DISABLED;
         }
         else
         {
-            DummyTable.Entries[i].Enabled = FM_TABLE_ENTRY_ENABLED;
+            Table.Entries[i].Enabled = FM_TABLE_ENTRY_ENABLED;
         }
-        DummyTable.Entries[i].Name[0] = '\0';
+        Table.Entries[i].Name[0] = '\0';
     }
 
     int32 strCmpResult;
@@ -285,7 +285,7 @@ void Test_FM_ValidateTable_EmptyName(void)
     snprintf(ExpectedEventString2, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Free Space Table verify results: good entries = %%d, bad = %%d, unused = %%d");
 
-    int32 Result = FM_ValidateTable(&DummyTable);
+    int32 Result = FM_ValidateTable(&Table);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -313,25 +313,25 @@ void Test_FM_ValidateTable_EmptyName(void)
 
 void Test_FM_ValidateTable_NameTooLong(void)
 {
-    FM_MonitorTable_t DummyTable;
+    FM_MonitorTable_t Table;
 
     for (int i = 0; i < FM_TABLE_ENTRY_COUNT; i++)
     {
-        DummyTable.Entries[i].Type = FM_MonitorTableEntry_Type_VOLUME_FREE_SPACE;
+        Table.Entries[i].Type = FM_MonitorTableEntry_Type_VOLUME_FREE_SPACE;
         if ((i % 2) == 0)
         {
-            DummyTable.Entries[i].Enabled = FM_TABLE_ENTRY_DISABLED;
+            Table.Entries[i].Enabled = FM_TABLE_ENTRY_DISABLED;
         }
         else
         {
-            DummyTable.Entries[i].Enabled = FM_TABLE_ENTRY_ENABLED;
+            Table.Entries[i].Enabled = FM_TABLE_ENTRY_ENABLED;
         }
 
-        snprintf(DummyTable.Entries[i].Name, OS_MAX_PATH_LEN, "Test");
+        snprintf(Table.Entries[i].Name, OS_MAX_PATH_LEN, "Test");
     }
 
-    memset(DummyTable.Entries[0].Name, 'A', sizeof(DummyTable.Entries[0].Name));
-    memset(DummyTable.Entries[1].Name, 'A', sizeof(DummyTable.Entries[1].Name));
+    memset(Table.Entries[0].Name, 'A', sizeof(Table.Entries[0].Name));
+    memset(Table.Entries[1].Name, 'A', sizeof(Table.Entries[1].Name));
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -342,7 +342,7 @@ void Test_FM_ValidateTable_NameTooLong(void)
     snprintf(ExpectedEventString2, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Free Space Table verify results: good entries = %%d, bad = %%d, unused = %%d");
 
-    int32 Result = FM_ValidateTable(&DummyTable);
+    int32 Result = FM_ValidateTable(&Table);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -370,11 +370,11 @@ void Test_FM_ValidateTable_NameTooLong(void)
 
 void Test_FM_AcquireTablePointers_Success(void)
 {
-    FM_MonitorTable_t DummyTable;
+    FM_MonitorTable_t Table;
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), CFE_SUCCESS);
 
-    FM_GlobalData.MonitorTablePtr = &DummyTable;
+    FM_GlobalData.MonitorTablePtr = &Table;
 
     FM_AcquireTablePointers();
 
@@ -383,11 +383,11 @@ void Test_FM_AcquireTablePointers_Success(void)
 
 void Test_FM_AcquireTablePointers_Fail(void)
 {
-    FM_MonitorTable_t DummyTable;
+    FM_MonitorTable_t Table;
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), CFE_TBL_ERR_NEVER_LOADED);
 
-    FM_GlobalData.MonitorTablePtr = &DummyTable;
+    FM_GlobalData.MonitorTablePtr = &Table;
 
     FM_AcquireTablePointers();
 
@@ -396,9 +396,9 @@ void Test_FM_AcquireTablePointers_Fail(void)
 
 void Test_FM_ReleaseTablePointers(void)
 {
-    FM_MonitorTable_t DummyTable;
+    FM_MonitorTable_t Table;
 
-    FM_GlobalData.MonitorTablePtr = &DummyTable;
+    FM_GlobalData.MonitorTablePtr = &Table;
 
     FM_ReleaseTablePointers();
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #97
  - Redundant use of the word "dummy" in test code variables/text has been removed

**Testing performed**
GitHub CI actions all passing successfully (incl. unit tests etc.)

**Expected behavior changes**
No change to behavior.
Test code is simpler and cleaner when redundant qualifiers are removed.

**Contributor Info**
Avi Weiss @thnkslprpt