### PR TITLE
Fix #99, Convert `int32` return codes and variables to `CFE_Status_t`

### DIFF
--- a/fsw/inc/fm_msg.h
+++ b/fsw/inc/fm_msg.h
@@ -103,7 +103,6 @@ typedef struct
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 
     FM_OvwSourceTargetFilename_Payload_t Payload; /**< \brief Command payload */
-
 } FM_MoveFileCmd_t;
 
 /**
@@ -608,7 +607,6 @@ typedef enum
      * used by a given file.
      */
     FM_MonitorTableEntry_Type_DIRECTORY_ESTIMATE = 2
-
 } FM_MonitorTableEntry_Type_t;
 
 /**
@@ -636,7 +634,6 @@ typedef struct
      * See description of the FM_MonitorTableEntry_Type_t for how this is to be set
      */
     char Name[OS_MAX_PATH_LEN];
-
 } FM_MonitorTableEntry_t;
 
 /**

--- a/fsw/src/fm_app.c
+++ b/fsw/src/fm_app.c
@@ -66,7 +66,7 @@ void FM_AppMain(void)
 {
     uint32           RunStatus = CFE_ES_RunStatus_APP_RUN;
     CFE_SB_Buffer_t *BufPtr    = NULL;
-    int32            Result    = CFE_SUCCESS;
+    CFE_Status_t     Result    = CFE_SUCCESS;
 
     /* Performance Log (start time counter) */
     CFE_ES_PerfLogEntry(FM_APPMAIN_PERF_ID);
@@ -165,10 +165,10 @@ void FM_AppMain(void)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 FM_AppInit(void)
+CFE_Status_t FM_AppInit(void)
 {
-    const char *ErrText = "Initialization error:";
-    int32       Result  = CFE_SUCCESS;
+    const char * ErrText = "Initialization error:";
+    CFE_Status_t Result  = CFE_SUCCESS;
 
     /* Initialize global data  */
     memset(&FM_GlobalData, 0, sizeof(FM_GlobalData));

--- a/fsw/src/fm_app.h
+++ b/fsw/src/fm_app.h
@@ -111,7 +111,6 @@ typedef struct
      * This depends on the compression option and may be NULL
      */
     FM_Compressor_State_t *CompressorStatePtr;
-
 } FM_GlobalData_t;
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -159,7 +158,7 @@ void FM_AppMain(void);
  *
  *  \sa #CFE_EVS_Register, #CFE_SB_CreatePipe, #CFE_SB_Subscribe
  */
-int32 FM_AppInit(void);
+CFE_Status_t FM_AppInit(void);
 
 /**
  *  \brief Housekeeping Request Command Handler

--- a/fsw/src/fm_child.c
+++ b/fsw/src/fm_child.c
@@ -54,12 +54,12 @@
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 FM_ChildInit(void)
+CFE_Status_t FM_ChildInit(void)
 {
-    int32  TaskTextLen               = OS_MAX_PATH_LEN;
-    char   TaskText[OS_MAX_PATH_LEN] = "\0";
-    int32  Result                    = CFE_SUCCESS;
-    uint32 TaskEID                   = 0;
+    int32        TaskTextLen               = OS_MAX_PATH_LEN;
+    char         TaskText[OS_MAX_PATH_LEN] = "\0";
+    CFE_Status_t Result                    = CFE_SUCCESS;
+    uint32       TaskEID                   = 0;
 
     /* Create counting semaphore (given by parent to wake-up child) */
     Result = OS_CountSemCreate(&FM_GlobalData.ChildSemaphore, FM_CHILD_SEM_NAME, 0, 0);
@@ -137,8 +137,8 @@ void FM_ChildTask(void)
 
 void FM_ChildLoop(void)
 {
-    const char *TaskText = "Child Task termination error: ";
-    int32       Result   = CFE_SUCCESS;
+    const char * TaskText = "Child Task termination error: ";
+    CFE_Status_t Result   = CFE_SUCCESS;
 
     while (Result == CFE_SUCCESS)
     {
@@ -587,8 +587,8 @@ void FM_ChildDeleteAllFilesCmd(FM_ChildQueueEntry_t *CmdArgs)
 
 void FM_ChildDecompressFileCmd(const FM_ChildQueueEntry_t *CmdArgs)
 {
-    const char *CmdText    = "Decompress File";
-    int32       CFE_Status = CFE_SUCCESS;
+    const char * CmdText    = "Decompress File";
+    CFE_Status_t CFE_Status = CFE_SUCCESS;
 
     /* Report current child task activity */
     FM_GlobalData.ChildCurrentCC = CmdArgs->CommandCode;

--- a/fsw/src/fm_child.h
+++ b/fsw/src/fm_child.h
@@ -49,7 +49,7 @@
  *
  *  \sa #FM_AppInit
  */
-int32 FM_ChildInit(void);
+CFE_Status_t FM_ChildInit(void);
 
 /**
  *  \brief Child Task Entry Point Function

--- a/fsw/src/fm_cmd_utils.c
+++ b/fsw/src/fm_cmd_utils.c
@@ -531,11 +531,11 @@ void FM_AppendPathSep(char *Directory, uint32 BufferSize)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 FM_GetVolumeFreeSpace(const char *FileSys, uint64 *BlockCount, uint64 *ByteCount)
+CFE_Status_t FM_GetVolumeFreeSpace(const char *FileSys, uint64 *BlockCount, uint64 *ByteCount)
 {
     OS_statvfs_t  FileStats;
     osal_status_t OS_Status;
-    int32         Result;
+    CFE_Status_t  Result;
 
     /* Get file system free space */
     OS_Status = OS_FileSysStatVolume(FileSys, &FileStats);
@@ -563,13 +563,13 @@ int32 FM_GetVolumeFreeSpace(const char *FileSys, uint64 *BlockCount, uint64 *Byt
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 FM_GetDirectorySpaceEstimate(const char *Directory, uint64 *BlockCount, uint64 *ByteCount)
+CFE_Status_t FM_GetDirectorySpaceEstimate(const char *Directory, uint64 *BlockCount, uint64 *ByteCount)
 {
     osal_id_t     DirId;
     os_dirent_t   DirEntry;
     os_fstat_t    FileStat;
     osal_status_t OS_Status;
-    int32         Result;
+    CFE_Status_t  Result;
     char          FullPath[OS_MAX_PATH_LEN];
     uint64        TotalBytes;
     size_t        DirLen;

--- a/fsw/src/fm_cmd_utils.h
+++ b/fsw/src/fm_cmd_utils.h
@@ -374,7 +374,7 @@ void FM_AppendPathSep(char *Directory, uint32 BufferSize);
  *  \returns Status code
  *  \retval CFE_SUCCESS if successful
  */
-int32 FM_GetVolumeFreeSpace(const char *FileSys, uint64 *BlockCount, uint64 *ByteCount);
+CFE_Status_t FM_GetVolumeFreeSpace(const char *FileSys, uint64 *BlockCount, uint64 *ByteCount);
 
 /**
  *  \brief Estimate the disk space used by files in a specified directory
@@ -398,6 +398,6 @@ int32 FM_GetVolumeFreeSpace(const char *FileSys, uint64 *BlockCount, uint64 *Byt
  *  \returns Status code
  *  \retval CFE_SUCCESS if successful
  */
-int32 FM_GetDirectorySpaceEstimate(const char *Directory, uint64 *BlockCount, uint64 *ByteCount);
+CFE_Status_t FM_GetDirectorySpaceEstimate(const char *Directory, uint64 *BlockCount, uint64 *ByteCount);
 
 #endif

--- a/fsw/src/fm_compression.h
+++ b/fsw/src/fm_compression.h
@@ -31,6 +31,8 @@
 #include <common_types.h>
 #include <fm_platform_cfg.h>
 
+#include "cfe.h"
+
 /**
  * @brief The state object for a compressor
  *
@@ -56,7 +58,7 @@ typedef struct FM_Decompressor_State FM_Decompressor_State_t;
  * @returns Status code
  * @retval #CFE_SUCCESS if successful
  */
-int32 FM_CompressionService_Init(void);
+CFE_Status_t FM_CompressionService_Init(void);
 
 /**
  * @brief Abstract file decompression routine
@@ -71,7 +73,7 @@ int32 FM_CompressionService_Init(void);
  * @returns Status code
  * @retval #CFE_SUCCESS if decompression was successful
  */
-int32 FM_Decompress_Impl(FM_Decompressor_State_t *State, const char *SrcFileName, const char *DstFileName);
+CFE_Status_t FM_Decompress_Impl(FM_Decompressor_State_t *State, const char *SrcFileName, const char *DstFileName);
 
 /**
  * @brief Abstract file compression routine
@@ -86,6 +88,6 @@ int32 FM_Decompress_Impl(FM_Decompressor_State_t *State, const char *SrcFileName
  * @returns Status code
  * @retval #CFE_SUCCESS if decompression was successful
  */
-int32 FM_Compress_Impl(FM_Compressor_State_t *State, const char *SrcFileName, const char *DstFileName);
+CFE_Status_t FM_Compress_Impl(FM_Compressor_State_t *State, const char *SrcFileName, const char *DstFileName);
 
 #endif

--- a/fsw/src/fm_compression_fslib.c
+++ b/fsw/src/fm_compression_fslib.c
@@ -51,19 +51,19 @@ struct FM_Decompressor_State
  */
 static FM_Decompressor_State_t FM_FSLIB_DecompressState;
 
-int32 FM_CompressionService_Init(void)
+CFE_Status_t FM_CompressionService_Init(void)
 {
     memset(&FM_FSLIB_DecompressState, 0, sizeof(FM_FSLIB_DecompressState));
     FM_GlobalData.DecompressorStatePtr = &FM_FSLIB_DecompressState;
     return CFE_SUCCESS;
 }
 
-int32 FM_Decompress_Impl(FM_Decompressor_State_t *State, const char *SrcFileName, const char *DstFileName)
+CFE_Status_t FM_Decompress_Impl(FM_Decompressor_State_t *State, const char *SrcFileName, const char *DstFileName)
 {
     return FS_LIB_Decompress(&State->LibState, SrcFileName, DstFileName);
 }
 
-int32 FM_Compress_Impl(FM_Compressor_State_t *State, const char *SrcFileName, const char *DstFileName)
+CFE_Status_t FM_Compress_Impl(FM_Compressor_State_t *State, const char *SrcFileName, const char *DstFileName)
 {
     return CFE_STATUS_NOT_IMPLEMENTED;
 }

--- a/fsw/src/fm_compression_none.c
+++ b/fsw/src/fm_compression_none.c
@@ -30,17 +30,17 @@
 
 #include "fm_compression.h"
 
-int32 FM_CompressionService_Init(void)
+CFE_Status_t FM_CompressionService_Init(void)
 {
     return CFE_SUCCESS;
 }
 
-int32 FM_Decompress_Impl(FM_Decompressor_State_t *State, const char *SrcFileName, const char *DstFileName)
+CFE_Status_t FM_Decompress_Impl(FM_Decompressor_State_t *State, const char *SrcFileName, const char *DstFileName)
 {
     return CFE_STATUS_NOT_IMPLEMENTED;
 }
 
-int32 FM_Compress_Impl(FM_Compressor_State_t *State, const char *SrcFileName, const char *DstFileName)
+CFE_Status_t FM_Compress_Impl(FM_Compressor_State_t *State, const char *SrcFileName, const char *DstFileName)
 {
     return CFE_STATUS_NOT_IMPLEMENTED;
 }

--- a/fsw/src/fm_compression_zlib.c
+++ b/fsw/src/fm_compression_zlib.c
@@ -30,17 +30,17 @@
 
 #include "fm_compression.h"
 
-int32 FM_CompressionService_Init(void)
+CFE_Status_t FM_CompressionService_Init(void)
 {
     return CFE_SUCCESS;
 }
 
-int32 FM_Decompress_Impl(FM_Decompressor_State_t *State, const char *SrcFileName, const char *DstFileName)
+CFE_Status_t FM_Decompress_Impl(FM_Decompressor_State_t *State, const char *SrcFileName, const char *DstFileName)
 {
     return CFE_STATUS_NOT_IMPLEMENTED;
 }
 
-int32 FM_Compress_Impl(FM_Compressor_State_t *State, const char *SrcFileName, const char *DstFileName)
+CFE_Status_t FM_Compress_Impl(FM_Compressor_State_t *State, const char *SrcFileName, const char *DstFileName)
 {
     return CFE_STATUS_NOT_IMPLEMENTED;
 }

--- a/fsw/src/fm_tbl.c
+++ b/fsw/src/fm_tbl.c
@@ -38,9 +38,9 @@
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 FM_TableInit(void)
+CFE_Status_t FM_TableInit(void)
 {
-    int32 Status;
+    CFE_Status_t Status;
 
     /* Initialize file system free space table pointer */
     FM_GlobalData.MonitorTablePtr = NULL;
@@ -68,11 +68,11 @@ int32 FM_TableInit(void)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 FM_ValidateTable(FM_MonitorTable_t *TablePtr)
+CFE_Status_t FM_ValidateTable(FM_MonitorTable_t *TablePtr)
 {
-    int32 Result = CFE_SUCCESS;
-    int32 NameLength;
-    int32 i = 0;
+    CFE_Status_t Result = CFE_SUCCESS;
+    int32        NameLength;
+    int32        i = 0;
 
     int32 CountGood   = 0;
     int32 CountBad    = 0;
@@ -191,7 +191,7 @@ int32 FM_ValidateTable(FM_MonitorTable_t *TablePtr)
 
 void FM_AcquireTablePointers(void)
 {
-    int32 Status;
+    CFE_Status_t Status;
 
     /* Allow cFE an opportunity to make table updates */
     CFE_TBL_Manage(FM_GlobalData.MonitorTableHandle);

--- a/fsw/src/fm_tbl.h
+++ b/fsw/src/fm_tbl.h
@@ -49,7 +49,7 @@
  *
  *  \sa /FM_AppInit
  */
-int32 FM_TableInit(void);
+CFE_Status_t FM_TableInit(void);
 
 /**
  *  \brief Table Verification Function
@@ -70,7 +70,7 @@ int32 FM_TableInit(void);
  *
  *  \sa /FM_AppInit
  */
-int32 FM_ValidateTable(FM_MonitorTable_t *TablePtr);
+CFE_Status_t FM_ValidateTable(FM_MonitorTable_t *TablePtr);
 
 /**
  *  \brief Acquire Table Data Pointer Function

--- a/unit-test/fm_tbl_tests.c
+++ b/unit-test/fm_tbl_tests.c
@@ -55,7 +55,7 @@ uint8 call_count_CFE_EVS_SendEvent;
 /************************/
 void Test_FM_TableInit_Success(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_Register), CFE_SUCCESS);
 
@@ -69,7 +69,7 @@ void Test_FM_TableInit_Success(void)
 
 void Test_FM_TableInit_Fail(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_Register), -1);
 
@@ -183,7 +183,7 @@ void Test_FM_ValidateTable_UnusedEntry(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Free Space Table verify results: good entries = %%d, bad = %%d, unused = %%d");
 
-    int32 Result = FM_ValidateTable(&Table);
+    CFE_Status_t Result = FM_ValidateTable(&Table);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -232,7 +232,7 @@ void Test_FM_ValidateTable_BadEntryState(void)
     snprintf(ExpectedEventString2, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Free Space Table verify results: good entries = %%d, bad = %%d, unused = %%d");
 
-    int32 Result = FM_ValidateTable(&Table);
+    CFE_Status_t Result = FM_ValidateTable(&Table);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -285,7 +285,7 @@ void Test_FM_ValidateTable_EmptyName(void)
     snprintf(ExpectedEventString2, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Free Space Table verify results: good entries = %%d, bad = %%d, unused = %%d");
 
-    int32 Result = FM_ValidateTable(&Table);
+    CFE_Status_t Result = FM_ValidateTable(&Table);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -342,7 +342,7 @@ void Test_FM_ValidateTable_NameTooLong(void)
     snprintf(ExpectedEventString2, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Free Space Table verify results: good entries = %%d, bad = %%d, unused = %%d");
 
-    int32 Result = FM_ValidateTable(&Table);
+    CFE_Status_t Result = FM_ValidateTable(&Table);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 

--- a/unit-test/stubs/fm_app_stubs.c
+++ b/unit-test/stubs/fm_app_stubs.c
@@ -31,13 +31,13 @@
  * Generated stub function for FM_AppInit()
  * ----------------------------------------------------
  */
-int32 FM_AppInit(void)
+CFE_Status_t FM_AppInit(void)
 {
-    UT_GenStub_SetupReturnBuffer(FM_AppInit, int32);
+    UT_GenStub_SetupReturnBuffer(FM_AppInit, CFE_Status_t);
 
     UT_GenStub_Execute(FM_AppInit, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_AppInit, int32);
+    return UT_GenStub_GetReturnValue(FM_AppInit, CFE_Status_t);
 }
 
 /*

--- a/unit-test/stubs/fm_child_stubs.c
+++ b/unit-test/stubs/fm_child_stubs.c
@@ -187,13 +187,13 @@ void FM_ChildFileInfoCmd(FM_ChildQueueEntry_t *CmdArgs)
  * Generated stub function for FM_ChildInit()
  * ----------------------------------------------------
  */
-int32 FM_ChildInit(void)
+CFE_Status_t FM_ChildInit(void)
 {
-    UT_GenStub_SetupReturnBuffer(FM_ChildInit, int32);
+    UT_GenStub_SetupReturnBuffer(FM_ChildInit, CFE_Status_t);
 
     UT_GenStub_Execute(FM_ChildInit, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_ChildInit, int32);
+    return UT_GenStub_GetReturnValue(FM_ChildInit, CFE_Status_t);
 }
 
 /*

--- a/unit-test/stubs/fm_cmd_utils_stubs.c
+++ b/unit-test/stubs/fm_cmd_utils_stubs.c
@@ -54,9 +54,9 @@ void FM_AppendPathSep(char *Directory, uint32 BufferSize)
  * Generated stub function for FM_GetDirectorySpaceEstimate()
  * ----------------------------------------------------
  */
-int32 FM_GetDirectorySpaceEstimate(const char *Directory, uint64 *BlockCount, uint64 *ByteCount)
+CFE_Status_t FM_GetDirectorySpaceEstimate(const char *Directory, uint64 *BlockCount, uint64 *ByteCount)
 {
-    UT_GenStub_SetupReturnBuffer(FM_GetDirectorySpaceEstimate, int32);
+    UT_GenStub_SetupReturnBuffer(FM_GetDirectorySpaceEstimate, CFE_Status_t);
 
     UT_GenStub_AddParam(FM_GetDirectorySpaceEstimate, const char *, Directory);
     UT_GenStub_AddParam(FM_GetDirectorySpaceEstimate, uint64 *, BlockCount);
@@ -64,7 +64,7 @@ int32 FM_GetDirectorySpaceEstimate(const char *Directory, uint64 *BlockCount, ui
 
     UT_GenStub_Execute(FM_GetDirectorySpaceEstimate, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_GetDirectorySpaceEstimate, int32);
+    return UT_GenStub_GetReturnValue(FM_GetDirectorySpaceEstimate, CFE_Status_t);
 }
 
 /*
@@ -106,9 +106,9 @@ uint32 FM_GetOpenFilesData(FM_OpenFilesEntry_t *OpenFilesData)
  * Generated stub function for FM_GetVolumeFreeSpace()
  * ----------------------------------------------------
  */
-int32 FM_GetVolumeFreeSpace(const char *FileSys, uint64 *BlockCount, uint64 *ByteCount)
+CFE_Status_t FM_GetVolumeFreeSpace(const char *FileSys, uint64 *BlockCount, uint64 *ByteCount)
 {
-    UT_GenStub_SetupReturnBuffer(FM_GetVolumeFreeSpace, int32);
+    UT_GenStub_SetupReturnBuffer(FM_GetVolumeFreeSpace, CFE_Status_t);
 
     UT_GenStub_AddParam(FM_GetVolumeFreeSpace, const char *, FileSys);
     UT_GenStub_AddParam(FM_GetVolumeFreeSpace, uint64 *, BlockCount);
@@ -116,7 +116,7 @@ int32 FM_GetVolumeFreeSpace(const char *FileSys, uint64 *BlockCount, uint64 *Byt
 
     UT_GenStub_Execute(FM_GetVolumeFreeSpace, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_GetVolumeFreeSpace, int32);
+    return UT_GenStub_GetReturnValue(FM_GetVolumeFreeSpace, CFE_Status_t);
 }
 
 /*

--- a/unit-test/stubs/fm_compression_stubs.c
+++ b/unit-test/stubs/fm_compression_stubs.c
@@ -31,9 +31,9 @@
  * Generated stub function for FM_Compress_Impl()
  * ----------------------------------------------------
  */
-int32 FM_Compress_Impl(FM_Compressor_State_t *State, const char *SrcFileName, const char *DstFileName)
+CFE_Status_t FM_Compress_Impl(FM_Compressor_State_t *State, const char *SrcFileName, const char *DstFileName)
 {
-    UT_GenStub_SetupReturnBuffer(FM_Compress_Impl, int32);
+    UT_GenStub_SetupReturnBuffer(FM_Compress_Impl, CFE_Status_t);
 
     UT_GenStub_AddParam(FM_Compress_Impl, FM_Compressor_State_t *, State);
     UT_GenStub_AddParam(FM_Compress_Impl, const char *, SrcFileName);
@@ -41,7 +41,7 @@ int32 FM_Compress_Impl(FM_Compressor_State_t *State, const char *SrcFileName, co
 
     UT_GenStub_Execute(FM_Compress_Impl, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_Compress_Impl, int32);
+    return UT_GenStub_GetReturnValue(FM_Compress_Impl, CFE_Status_t);
 }
 
 /*
@@ -49,13 +49,13 @@ int32 FM_Compress_Impl(FM_Compressor_State_t *State, const char *SrcFileName, co
  * Generated stub function for FM_CompressionService_Init()
  * ----------------------------------------------------
  */
-int32 FM_CompressionService_Init(void)
+CFE_Status_t FM_CompressionService_Init(void)
 {
-    UT_GenStub_SetupReturnBuffer(FM_CompressionService_Init, int32);
+    UT_GenStub_SetupReturnBuffer(FM_CompressionService_Init, CFE_Status_t);
 
     UT_GenStub_Execute(FM_CompressionService_Init, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_CompressionService_Init, int32);
+    return UT_GenStub_GetReturnValue(FM_CompressionService_Init, CFE_Status_t);
 }
 
 /*
@@ -63,9 +63,9 @@ int32 FM_CompressionService_Init(void)
  * Generated stub function for FM_Decompress_Impl()
  * ----------------------------------------------------
  */
-int32 FM_Decompress_Impl(FM_Decompressor_State_t *State, const char *SrcFileName, const char *DstFileName)
+CFE_Status_t FM_Decompress_Impl(FM_Decompressor_State_t *State, const char *SrcFileName, const char *DstFileName)
 {
-    UT_GenStub_SetupReturnBuffer(FM_Decompress_Impl, int32);
+    UT_GenStub_SetupReturnBuffer(FM_Decompress_Impl, CFE_Status_t);
 
     UT_GenStub_AddParam(FM_Decompress_Impl, FM_Decompressor_State_t *, State);
     UT_GenStub_AddParam(FM_Decompress_Impl, const char *, SrcFileName);
@@ -73,5 +73,5 @@ int32 FM_Decompress_Impl(FM_Decompressor_State_t *State, const char *SrcFileName
 
     UT_GenStub_Execute(FM_Decompress_Impl, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_Decompress_Impl, int32);
+    return UT_GenStub_GetReturnValue(FM_Decompress_Impl, CFE_Status_t);
 }

--- a/unit-test/stubs/fm_tbl_stubs.c
+++ b/unit-test/stubs/fm_tbl_stubs.c
@@ -53,13 +53,13 @@ void FM_ReleaseTablePointers(void)
  * Generated stub function for FM_TableInit()
  * ----------------------------------------------------
  */
-int32 FM_TableInit(void)
+CFE_Status_t FM_TableInit(void)
 {
-    UT_GenStub_SetupReturnBuffer(FM_TableInit, int32);
+    UT_GenStub_SetupReturnBuffer(FM_TableInit, CFE_Status_t);
 
     UT_GenStub_Execute(FM_TableInit, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_TableInit, int32);
+    return UT_GenStub_GetReturnValue(FM_TableInit, CFE_Status_t);
 }
 
 /*
@@ -67,13 +67,13 @@ int32 FM_TableInit(void)
  * Generated stub function for FM_ValidateTable()
  * ----------------------------------------------------
  */
-int32 FM_ValidateTable(FM_MonitorTable_t *TablePtr)
+CFE_Status_t FM_ValidateTable(FM_MonitorTable_t *TablePtr)
 {
-    UT_GenStub_SetupReturnBuffer(FM_ValidateTable, int32);
+    UT_GenStub_SetupReturnBuffer(FM_ValidateTable, CFE_Status_t);
 
     UT_GenStub_AddParam(FM_ValidateTable, FM_MonitorTable_t *, TablePtr);
 
     UT_GenStub_Execute(FM_ValidateTable, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(FM_ValidateTable, int32);
+    return UT_GenStub_GetReturnValue(FM_ValidateTable, CFE_Status_t);
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #99
  - most `int32` return codes converted over to `CFE_Status_t`
  - `int32` `status`/`return` variables holding cFE return codes converted to `CFE_Status_t`

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
No change to behavior.
`CFE_Status_t` is more expressive and improves consistency with cFE/cFS.

**Contributor Info**
Avi Weiss @thnkslprpt