### PR TITLE
Fix #106, Consolidate HK variables that are duplicated in the global struct

### DIFF
--- a/fsw/src/fm_app.c
+++ b/fsw/src/fm_app.c
@@ -248,7 +248,7 @@ CFE_Status_t FM_AppInit(void)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void FM_SendHkCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    FM_HousekeepingPkt_Payload_t *PayloadPtr;
+    FM_HousekeepingPkt_Payload_t *PayloadPtr = &FM_GlobalData.HousekeepingPkt.Payload;
 
     FM_ReleaseTablePointers();
 
@@ -258,24 +258,7 @@ void FM_SendHkCmd(const CFE_SB_Buffer_t *BufPtr)
     CFE_MSG_Init(CFE_MSG_PTR(FM_GlobalData.HousekeepingPkt.TelemetryHeader), CFE_SB_ValueToMsgId(FM_HK_TLM_MID),
                  sizeof(FM_HousekeepingPkt_t));
 
-    PayloadPtr = &FM_GlobalData.HousekeepingPkt.Payload;
-
-    /* Report application command counters */
-    PayloadPtr->CommandCounter    = FM_GlobalData.CommandCounter;
-    PayloadPtr->CommandErrCounter = FM_GlobalData.CommandErrCounter;
-
     PayloadPtr->NumOpenFiles = FM_GetOpenFilesData(NULL);
-
-    /* Report child task command counters */
-    PayloadPtr->ChildCmdCounter     = FM_GlobalData.ChildCmdCounter;
-    PayloadPtr->ChildCmdErrCounter  = FM_GlobalData.ChildCmdErrCounter;
-    PayloadPtr->ChildCmdWarnCounter = FM_GlobalData.ChildCmdWarnCounter;
-
-    PayloadPtr->ChildQueueCount = FM_GlobalData.ChildQueueCount;
-
-    /* Report current and previous commands executed by the child task */
-    PayloadPtr->ChildCurrentCC  = FM_GlobalData.ChildCurrentCC;
-    PayloadPtr->ChildPreviousCC = FM_GlobalData.ChildPreviousCC;
 
     CFE_SB_TimeStampMsg(CFE_MSG_PTR(FM_GlobalData.HousekeepingPkt.TelemetryHeader));
     CFE_SB_TransmitMsg(CFE_MSG_PTR(FM_GlobalData.HousekeepingPkt.TelemetryHeader), true);

--- a/fsw/src/fm_app.h
+++ b/fsw/src/fm_app.h
@@ -63,21 +63,9 @@ typedef struct
     osal_id_t       ChildSemaphore;     /**< \brief Child task wakeup counting semaphore */
     osal_id_t       ChildQueueCountSem; /**< \brief Child queue counter mutex semaphore */
 
-    uint8 ChildCmdCounter;     /**< \brief Child task command success counter */
-    uint8 ChildCmdErrCounter;  /**< \brief Child task command error counter */
-    uint8 ChildCmdWarnCounter; /**< \brief Child task command warning counter */
-
-    uint8 ChildWriteIndex; /**< \brief Array index for next write to command args */
-    uint8 ChildReadIndex;  /**< \brief Array index for next read from command args */
-    uint8 ChildQueueCount; /**< \brief Number of pending commands in queue */
-
-    uint8 CommandCounter;    /**< \brief Application command success counter */
-    uint8 CommandErrCounter; /**< \brief Application command error counter */
-    uint8 Spare8a;           /**< \brief Placeholder for unused command warning counter */
-
-    uint8 ChildCurrentCC;  /**< \brief Command code currently executing */
-    uint8 ChildPreviousCC; /**< \brief Command code previously executed */
-    uint8 Spare8b;         /**< \brief Structure alignment spare */
+    uint8  ChildWriteIndex; /**< \brief Array index for next write to command args */
+    uint8  ChildReadIndex;  /**< \brief Array index for next read from command args */
+    uint16 Padding;         /**< \brief Structure padding to align to 32-bit boundaries */
 
     uint32 FileStatTime; /**< \brief Modify time from most recent OS_stat */
     uint32 FileStatSize; /**< \brief File size from most recent OS_stat */

--- a/fsw/src/fm_child.c
+++ b/fsw/src/fm_child.c
@@ -151,9 +151,9 @@ void FM_ChildLoop(void)
         if (Result == CFE_SUCCESS)
         {
             /* Make sure the parent/child handshake is not broken */
-            if (FM_GlobalData.ChildQueueCount == 0)
+            if (FM_GlobalData.HousekeepingPkt.Payload.ChildQueueCount == 0)
             {
-                FM_GlobalData.ChildCmdErrCounter++;
+                FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
                 CFE_EVS_SendEvent(FM_CHILD_TERM_EMPTYQ_ERR_EID, CFE_EVS_EventType_ERROR, "%s empty queue", TaskText);
 
                 /* Set result that will terminate child task run loop */
@@ -161,7 +161,7 @@ void FM_ChildLoop(void)
             }
             else if (FM_GlobalData.ChildReadIndex >= FM_CHILD_QUEUE_DEPTH)
             {
-                FM_GlobalData.ChildCmdErrCounter++;
+                FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
                 CFE_EVS_SendEvent(FM_CHILD_TERM_QIDX_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "%s invalid queue index: index = %d", TaskText, (int)FM_GlobalData.ChildReadIndex);
 
@@ -251,7 +251,7 @@ void FM_ChildProcess(void)
             break;
 
         default:
-            FM_GlobalData.ChildCmdErrCounter++;
+            FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
             CFE_EVS_SendEvent(FM_CHILD_EXE_ERR_EID, CFE_EVS_EventType_ERROR,
                               "%s execution error: invalid command code: cc = %d", TaskText, (int)CmdArgs->CommandCode);
             break;
@@ -267,7 +267,7 @@ void FM_ChildProcess(void)
 
     /* Prevent parent/child updating queue counter at same time */
     OS_MutSemTake(FM_GlobalData.ChildQueueCountSem);
-    FM_GlobalData.ChildQueueCount--;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildQueueCount--;
     OS_MutSemGive(FM_GlobalData.ChildQueueCountSem);
 }
 
@@ -283,14 +283,14 @@ void FM_ChildCopyCmd(const FM_ChildQueueEntry_t *CmdArgs)
     int32       OS_Status = OS_SUCCESS;
 
     /* Report current child task activity */
-    FM_GlobalData.ChildCurrentCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC = CmdArgs->CommandCode;
 
     /* Note the order of the arguments to OS_cp (src,tgt) */
     OS_Status = OS_cp(CmdArgs->Source1, CmdArgs->Target);
 
     if (OS_Status != OS_SUCCESS)
     {
-        FM_GlobalData.ChildCmdErrCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
 
         /* Send command failure event (error) */
         CFE_EVS_SendEvent(FM_COPY_OS_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -299,7 +299,7 @@ void FM_ChildCopyCmd(const FM_ChildQueueEntry_t *CmdArgs)
     }
     else
     {
-        FM_GlobalData.ChildCmdCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdCounter++;
 
         /* Send command completion event (info) */
         CFE_EVS_SendEvent(FM_COPY_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: src = %s, tgt = %s", CmdText,
@@ -307,8 +307,8 @@ void FM_ChildCopyCmd(const FM_ChildQueueEntry_t *CmdArgs)
     }
 
     /* Report previous child task activity */
-    FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
-    FM_GlobalData.ChildCurrentCC  = 0;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildPreviousCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC  = 0;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -323,13 +323,13 @@ void FM_ChildMoveCmd(const FM_ChildQueueEntry_t *CmdArgs)
     int32       OS_Status = OS_SUCCESS;
 
     /* Report current child task activity */
-    FM_GlobalData.ChildCurrentCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC = CmdArgs->CommandCode;
 
     OS_Status = OS_mv(CmdArgs->Source1, CmdArgs->Target);
 
     if (OS_Status != OS_SUCCESS)
     {
-        FM_GlobalData.ChildCmdErrCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
 
         /* Send command failure event (error) */
         CFE_EVS_SendEvent(FM_MOVE_OS_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -338,7 +338,7 @@ void FM_ChildMoveCmd(const FM_ChildQueueEntry_t *CmdArgs)
     }
     else
     {
-        FM_GlobalData.ChildCmdCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdCounter++;
 
         /* Send command completion event (info) */
         CFE_EVS_SendEvent(FM_MOVE_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: src = %s, tgt = %s", CmdText,
@@ -346,8 +346,8 @@ void FM_ChildMoveCmd(const FM_ChildQueueEntry_t *CmdArgs)
     }
 
     /* Report previous child task activity */
-    FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
-    FM_GlobalData.ChildCurrentCC  = 0;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildPreviousCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC  = 0;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -362,13 +362,13 @@ void FM_ChildRenameCmd(const FM_ChildQueueEntry_t *CmdArgs)
     int32       OS_Status = OS_SUCCESS;
 
     /* Report current child task activity */
-    FM_GlobalData.ChildCurrentCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC = CmdArgs->CommandCode;
 
     OS_Status = OS_rename(CmdArgs->Source1, CmdArgs->Target);
 
     if (OS_Status != OS_SUCCESS)
     {
-        FM_GlobalData.ChildCmdErrCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
 
         /* Send command failure event (error) */
         CFE_EVS_SendEvent(FM_RENAME_OS_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -377,7 +377,7 @@ void FM_ChildRenameCmd(const FM_ChildQueueEntry_t *CmdArgs)
     }
     else
     {
-        FM_GlobalData.ChildCmdCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdCounter++;
 
         /* Send command completion event (info) */
         CFE_EVS_SendEvent(FM_RENAME_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: src = %s, tgt = %s", CmdText,
@@ -385,8 +385,8 @@ void FM_ChildRenameCmd(const FM_ChildQueueEntry_t *CmdArgs)
     }
 
     /* Report previous child task activity */
-    FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
-    FM_GlobalData.ChildCurrentCC  = 0;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildPreviousCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC  = 0;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -401,13 +401,13 @@ void FM_ChildDeleteCmd(const FM_ChildQueueEntry_t *CmdArgs)
     int32       OS_Status = OS_SUCCESS;
 
     /* Report current child task activity */
-    FM_GlobalData.ChildCurrentCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC = CmdArgs->CommandCode;
 
     OS_Status = OS_remove(CmdArgs->Source1);
 
     if (OS_Status != OS_SUCCESS)
     {
-        FM_GlobalData.ChildCmdErrCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
 
         /* Send command failure event (error) */
         CFE_EVS_SendEvent(FM_DELETE_OS_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -416,7 +416,7 @@ void FM_ChildDeleteCmd(const FM_ChildQueueEntry_t *CmdArgs)
     }
     else
     {
-        FM_GlobalData.ChildCmdCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdCounter++;
 
         /* Send command completion event (info) */
         CFE_EVS_SendEvent(FM_DELETE_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: file = %s", CmdText,
@@ -424,8 +424,8 @@ void FM_ChildDeleteCmd(const FM_ChildQueueEntry_t *CmdArgs)
     }
 
     /* Report previous child task activity */
-    FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
-    FM_GlobalData.ChildCurrentCC  = 0;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildPreviousCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC  = 0;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -460,14 +460,14 @@ void FM_ChildDeleteAllFilesCmd(FM_ChildQueueEntry_t *CmdArgs)
     memset(&DirEntry, 0, sizeof(DirEntry));
 
     /* Report current child task activity */
-    FM_GlobalData.ChildCurrentCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC = CmdArgs->CommandCode;
 
     /* Open directory so that we can read from it */
     OS_Status = OS_DirectoryOpen(&DirId, Directory);
 
     if (OS_Status != OS_SUCCESS)
     {
-        FM_GlobalData.ChildCmdErrCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
 
         /* Send command failure event (error) */
         CFE_EVS_SendEvent(FM_DELETE_ALL_OS_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -553,7 +553,7 @@ void FM_ChildDeleteAllFilesCmd(FM_ChildQueueEntry_t *CmdArgs)
         /* Send command completion event (info) */
         CFE_EVS_SendEvent(FM_DELETE_ALL_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: deleted %d files: dir = %s",
                           CmdText, (int)DeleteCount, Directory);
-        FM_GlobalData.ChildCmdCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdCounter++;
 
         if (FilesNotDeletedCount > 0)
         {
@@ -561,7 +561,7 @@ void FM_ChildDeleteAllFilesCmd(FM_ChildQueueEntry_t *CmdArgs)
             CFE_EVS_SendEvent(FM_DELETE_ALL_FILES_ND_WARNING_EID, CFE_EVS_EventType_INFORMATION,
                               "%s command: one or more files could not be deleted. Files may be open : dir = %s",
                               CmdText, Directory);
-            FM_GlobalData.ChildCmdWarnCounter++;
+            FM_GlobalData.HousekeepingPkt.Payload.ChildCmdWarnCounter++;
         }
 
         if (DirectoriesSkippedCount > 0)
@@ -569,14 +569,14 @@ void FM_ChildDeleteAllFilesCmd(FM_ChildQueueEntry_t *CmdArgs)
             /* If errors occured, report generic event(s) */
             CFE_EVS_SendEvent(FM_DELETE_ALL_SKIP_WARNING_EID, CFE_EVS_EventType_INFORMATION,
                               "%s command: one or more directories skipped : dir = %s", CmdText, Directory);
-            FM_GlobalData.ChildCmdWarnCounter++;
+            FM_GlobalData.HousekeepingPkt.Payload.ChildCmdWarnCounter++;
         }
 
     } /* end if OS_Status != OS_SUCCESS */
 
     /* Report previous child task activity */
-    FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
-    FM_GlobalData.ChildCurrentCC  = 0;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildPreviousCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC  = 0;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -591,14 +591,14 @@ void FM_ChildDecompressFileCmd(const FM_ChildQueueEntry_t *CmdArgs)
     CFE_Status_t CFE_Status = CFE_SUCCESS;
 
     /* Report current child task activity */
-    FM_GlobalData.ChildCurrentCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC = CmdArgs->CommandCode;
 
     /* Decompress source file into target file */
     CFE_Status = FM_Decompress_Impl(FM_GlobalData.DecompressorStatePtr, CmdArgs->Source1, CmdArgs->Target);
 
     if (CFE_Status != CFE_SUCCESS)
     {
-        FM_GlobalData.ChildCmdErrCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
 
         /* Send command failure event (error) */
         CFE_EVS_SendEvent(FM_DECOM_CFE_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -607,7 +607,7 @@ void FM_ChildDecompressFileCmd(const FM_ChildQueueEntry_t *CmdArgs)
     }
     else
     {
-        FM_GlobalData.ChildCmdCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdCounter++;
 
         /* Send command completion event (info) */
         CFE_EVS_SendEvent(FM_DECOM_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: src = %s, tgt = %s", CmdText,
@@ -615,8 +615,8 @@ void FM_ChildDecompressFileCmd(const FM_ChildQueueEntry_t *CmdArgs)
     }
 
     /* Report previous child task activity */
-    FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
-    FM_GlobalData.ChildCurrentCC  = 0;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildPreviousCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC  = 0;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -638,14 +638,14 @@ void FM_ChildConcatFilesCmd(const FM_ChildQueueEntry_t *CmdArgs)
     int32       BytesWritten   = 0;
 
     /* Report current child task activity */
-    FM_GlobalData.ChildCurrentCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC = CmdArgs->CommandCode;
 
     /* Copy source file #1 to the target file */
     OS_Status = OS_cp(CmdArgs->Source1, CmdArgs->Target);
 
     if (OS_Status != OS_SUCCESS)
     {
-        FM_GlobalData.ChildCmdErrCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
 
         /* Send command failure event (error) */
         CFE_EVS_SendEvent(FM_CONCAT_OSCPY_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -659,7 +659,7 @@ void FM_ChildConcatFilesCmd(const FM_ChildQueueEntry_t *CmdArgs)
 
         if (OS_Status != OS_SUCCESS)
         {
-            FM_GlobalData.ChildCmdErrCounter++;
+            FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
 
             /* Send command failure event (error) */
             CFE_EVS_SendEvent(FM_CONCAT_OPEN_SRC2_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -673,7 +673,7 @@ void FM_ChildConcatFilesCmd(const FM_ChildQueueEntry_t *CmdArgs)
 
             if (OS_Status != OS_SUCCESS)
             {
-                FM_GlobalData.ChildCmdErrCounter++;
+                FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
 
                 /* Send command failure event (error) */
                 CFE_EVS_SendEvent(FM_CONCAT_OPEN_TGT_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -698,7 +698,7 @@ void FM_ChildConcatFilesCmd(const FM_ChildQueueEntry_t *CmdArgs)
                         CopyInProgress = false;
                         ConcatResult   = true;
 
-                        FM_GlobalData.ChildCmdCounter++;
+                        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdCounter++;
 
                         /* Send command completion event (debug) */
                         CFE_EVS_SendEvent(FM_CONCAT_CMD_EID, CFE_EVS_EventType_DEBUG,
@@ -708,7 +708,7 @@ void FM_ChildConcatFilesCmd(const FM_ChildQueueEntry_t *CmdArgs)
                     else if (BytesRead < 0)
                     {
                         CopyInProgress = false;
-                        FM_GlobalData.ChildCmdErrCounter++;
+                        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
 
                         /* Send command failure event (error) */
                         CFE_EVS_SendEvent(FM_CONCAT_OSRD_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -723,7 +723,7 @@ void FM_ChildConcatFilesCmd(const FM_ChildQueueEntry_t *CmdArgs)
                         if (BytesWritten != BytesRead)
                         {
                             CopyInProgress = false;
-                            FM_GlobalData.ChildCmdErrCounter++;
+                            FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
 
                             /* Send command failure event (error) */
                             CFE_EVS_SendEvent(FM_CONCAT_OSWR_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -758,8 +758,8 @@ void FM_ChildConcatFilesCmd(const FM_ChildQueueEntry_t *CmdArgs)
     }
 
     /* Report previous child task activity */
-    FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
-    FM_GlobalData.ChildCurrentCC  = 0;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildPreviousCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC  = 0;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -781,7 +781,7 @@ void FM_ChildFileInfoCmd(FM_ChildQueueEntry_t *CmdArgs)
     FM_FileInfoPkt_Payload_t *ReportPtr;
 
     /* Report current child task activity */
-    FM_GlobalData.ChildCurrentCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC = CmdArgs->CommandCode;
 
     /*
     ** Command argument usage for this command:
@@ -814,7 +814,7 @@ void FM_ChildFileInfoCmd(FM_ChildQueueEntry_t *CmdArgs)
         if (CmdArgs->FileInfoState != FM_NAME_IS_FILE_CLOSED)
         {
             /* Can only calculate CRC for closed files */
-            FM_GlobalData.ChildCmdWarnCounter++;
+            FM_GlobalData.HousekeepingPkt.Payload.ChildCmdWarnCounter++;
 
             CFE_EVS_SendEvent(FM_GET_FILE_INFO_STATE_WARNING_EID, CFE_EVS_EventType_INFORMATION,
                               "%s warning: unable to compute CRC: invalid file state = %d, file = %s", CmdText,
@@ -826,7 +826,7 @@ void FM_ChildFileInfoCmd(FM_ChildQueueEntry_t *CmdArgs)
                  (CmdArgs->FileInfoCRC != CFE_ES_CrcType_CRC_32))
         {
             /* Can only calculate CRC using known algorithms */
-            FM_GlobalData.ChildCmdWarnCounter++;
+            FM_GlobalData.HousekeepingPkt.Payload.ChildCmdWarnCounter++;
 
             CFE_EVS_SendEvent(FM_GET_FILE_INFO_TYPE_WARNING_EID, CFE_EVS_EventType_INFORMATION,
                               "%s warning: unable to compute CRC: invalid CRC type = %d, file = %s", CmdText,
@@ -843,7 +843,7 @@ void FM_ChildFileInfoCmd(FM_ChildQueueEntry_t *CmdArgs)
 
         if (Status != OS_SUCCESS)
         {
-            FM_GlobalData.ChildCmdWarnCounter++;
+            FM_GlobalData.HousekeepingPkt.Payload.ChildCmdWarnCounter++;
 
             /* Send CRC failure event (warning) */
             CFE_EVS_SendEvent(FM_GET_FILE_INFO_OPEN_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -879,7 +879,7 @@ void FM_ChildFileInfoCmd(FM_ChildQueueEntry_t *CmdArgs)
                 OS_close(FileHandle);
 
                 /* Send CRC failure event (warning) */
-                FM_GlobalData.ChildCmdWarnCounter++;
+                FM_GlobalData.HousekeepingPkt.Payload.ChildCmdWarnCounter++;
                 CFE_EVS_SendEvent(FM_GET_FILE_INFO_READ_WARNING_EID, CFE_EVS_EventType_INFORMATION,
                                   "%s warning: unable to compute CRC: OS_read result = %d, file = %s", CmdText,
                                   (int)BytesRead, CmdArgs->Source1);
@@ -913,15 +913,15 @@ void FM_ChildFileInfoCmd(FM_ChildQueueEntry_t *CmdArgs)
     CFE_SB_TimeStampMsg(CFE_MSG_PTR(FM_GlobalData.FileInfoPkt.TelemetryHeader));
     CFE_SB_TransmitMsg(CFE_MSG_PTR(FM_GlobalData.FileInfoPkt.TelemetryHeader), true);
 
-    FM_GlobalData.ChildCmdCounter++;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCmdCounter++;
 
     /* Send command completion event (debug) */
     CFE_EVS_SendEvent(FM_GET_FILE_INFO_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: file = %s", CmdText,
                       CmdArgs->Source1);
 
     /* Report previous child task activity */
-    FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
-    FM_GlobalData.ChildCurrentCC  = 0;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildPreviousCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC  = 0;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -936,13 +936,13 @@ void FM_ChildCreateDirectoryCmd(const FM_ChildQueueEntry_t *CmdArgs)
     int32       OS_Status = OS_SUCCESS;
 
     /* Report current child task activity */
-    FM_GlobalData.ChildCurrentCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC = CmdArgs->CommandCode;
 
     OS_Status = OS_mkdir(CmdArgs->Source1, 0);
 
     if (OS_Status != OS_SUCCESS)
     {
-        FM_GlobalData.ChildCmdErrCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
 
         /* Send command failure event (error) */
         CFE_EVS_SendEvent(FM_CREATE_DIR_OS_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -951,7 +951,7 @@ void FM_ChildCreateDirectoryCmd(const FM_ChildQueueEntry_t *CmdArgs)
     }
     else
     {
-        FM_GlobalData.ChildCmdCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdCounter++;
 
         /* Send command completion event (info) */
         CFE_EVS_SendEvent(FM_CREATE_DIR_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: src = %s", CmdText,
@@ -959,8 +959,8 @@ void FM_ChildCreateDirectoryCmd(const FM_ChildQueueEntry_t *CmdArgs)
     }
 
     /* Report previous child task activity */
-    FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
-    FM_GlobalData.ChildCurrentCC  = 0;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildPreviousCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC  = 0;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -980,7 +980,7 @@ void FM_ChildDeleteDirectoryCmd(const FM_ChildQueueEntry_t *CmdArgs)
     memset(&DirEntry, 0, sizeof(DirEntry));
 
     /* Report current child task activity */
-    FM_GlobalData.ChildCurrentCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC = CmdArgs->CommandCode;
 
     /* Open the dir so we can see if it is empty */
     OS_Status = OS_DirectoryOpen(&DirId, CmdArgs->Source1);
@@ -991,7 +991,7 @@ void FM_ChildDeleteDirectoryCmd(const FM_ChildQueueEntry_t *CmdArgs)
                           "%s error: OS_DirectoryOpen failed: dir = %s", CmdText, CmdArgs->Source1);
 
         RemoveTheDir = false;
-        FM_GlobalData.ChildCmdErrCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
     }
     else
     {
@@ -1005,7 +1005,7 @@ void FM_ChildDeleteDirectoryCmd(const FM_ChildQueueEntry_t *CmdArgs)
                                   "%s error: directory is not empty: dir = %s", CmdText, CmdArgs->Source1);
 
                 RemoveTheDir = false;
-                FM_GlobalData.ChildCmdErrCounter++;
+                FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
             }
         }
 
@@ -1024,7 +1024,7 @@ void FM_ChildDeleteDirectoryCmd(const FM_ChildQueueEntry_t *CmdArgs)
                               "%s error: OS_rmdir failed: result = %d, dir = %s", CmdText, (int)OS_Status,
                               CmdArgs->Source1);
 
-            FM_GlobalData.ChildCmdErrCounter++;
+            FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
         }
         else
         {
@@ -1032,13 +1032,13 @@ void FM_ChildDeleteDirectoryCmd(const FM_ChildQueueEntry_t *CmdArgs)
             CFE_EVS_SendEvent(FM_DELETE_DIR_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: src = %s", CmdText,
                               CmdArgs->Source1);
 
-            FM_GlobalData.ChildCmdCounter++;
+            FM_GlobalData.HousekeepingPkt.Payload.ChildCmdCounter++;
         }
     }
 
     /* Report previous child task activity */
-    FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
-    FM_GlobalData.ChildCurrentCC  = 0;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildPreviousCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC  = 0;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -1056,7 +1056,7 @@ void FM_ChildDirListFileCmd(const FM_ChildQueueEntry_t *CmdArgs)
     int32       Status     = 0;
 
     /* Report current child task activity */
-    FM_GlobalData.ChildCurrentCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC = CmdArgs->CommandCode;
 
     /*
     ** Command argument usage for this command:
@@ -1072,7 +1072,7 @@ void FM_ChildDirListFileCmd(const FM_ChildQueueEntry_t *CmdArgs)
 
     if (Status != OS_SUCCESS)
     {
-        FM_GlobalData.ChildCmdErrCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
 
         /* Send command failure event (error) */
         CFE_EVS_SendEvent(FM_GET_DIR_FILE_OSOPENDIR_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -1097,8 +1097,8 @@ void FM_ChildDirListFileCmd(const FM_ChildQueueEntry_t *CmdArgs)
     }
 
     /* Report previous child task activity */
-    FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
-    FM_GlobalData.ChildCurrentCC  = 0;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildPreviousCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC  = 0;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -1126,7 +1126,7 @@ void FM_ChildDirListPktCmd(const FM_ChildQueueEntry_t *CmdArgs)
     memset(&DirEntry, 0, sizeof(DirEntry));
 
     /* Report current child task activity */
-    FM_GlobalData.ChildCurrentCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC = CmdArgs->CommandCode;
 
     /*
     ** Command argument usage for this command:
@@ -1143,7 +1143,7 @@ void FM_ChildDirListPktCmd(const FM_ChildQueueEntry_t *CmdArgs)
 
     if (Status != OS_SUCCESS)
     {
-        FM_GlobalData.ChildCmdErrCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
 
         /* Send command failure event (error) */
         CFE_EVS_SendEvent(FM_GET_DIR_PKT_OS_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -1208,7 +1208,7 @@ void FM_ChildDirListPktCmd(const FM_ChildQueueEntry_t *CmdArgs)
                     }
                     else
                     {
-                        FM_GlobalData.ChildCmdWarnCounter++;
+                        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdWarnCounter++;
 
                         /* Send command warning event (info) */
                         CFE_EVS_SendEvent(FM_GET_DIR_PKT_WARNING_EID, CFE_EVS_EventType_INFORMATION,
@@ -1229,12 +1229,12 @@ void FM_ChildDirListPktCmd(const FM_ChildQueueEntry_t *CmdArgs)
         CFE_EVS_SendEvent(FM_GET_DIR_PKT_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: offset = %d, dir = %s", CmdText,
                           (int)CmdArgs->DirListOffset, CmdArgs->Source1);
 
-        FM_GlobalData.ChildCmdCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdCounter++;
     }
 
     /* Report previous child task activity */
-    FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
-    FM_GlobalData.ChildCurrentCC  = 0;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildPreviousCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC  = 0;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -1251,7 +1251,7 @@ void FM_ChildSetPermissionsCmd(const FM_ChildQueueEntry_t *CmdArgs)
 
     if (OS_Status == OS_SUCCESS)
     {
-        FM_GlobalData.ChildCmdCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdCounter++;
 
         /* Send command completion event (info) */
         CFE_EVS_SendEvent(FM_SET_PERM_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: file = %s, access = %d", CmdText,
@@ -1259,7 +1259,7 @@ void FM_ChildSetPermissionsCmd(const FM_ChildQueueEntry_t *CmdArgs)
     }
     else
     {
-        FM_GlobalData.ChildCmdErrCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
 
         /* Send OS error message */
         CFE_EVS_SendEvent(FM_SET_PERM_OS_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -1268,8 +1268,8 @@ void FM_ChildSetPermissionsCmd(const FM_ChildQueueEntry_t *CmdArgs)
     }
 
     /* Report previous child task activity */
-    FM_GlobalData.ChildPreviousCC = CmdArgs->CommandCode;
-    FM_GlobalData.ChildCurrentCC  = 0;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildPreviousCC = CmdArgs->CommandCode;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC  = 0;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -1314,7 +1314,7 @@ bool FM_ChildDirListFileInit(osal_id_t *FileHandlePtr, const char *Directory, co
             else
             {
                 CommandResult = false;
-                FM_GlobalData.ChildCmdErrCounter++;
+                FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
 
                 /* Send command failure event (error) */
                 CFE_EVS_SendEvent(FM_GET_DIR_FILE_WRBLANK_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -1325,7 +1325,7 @@ bool FM_ChildDirListFileInit(osal_id_t *FileHandlePtr, const char *Directory, co
         else
         {
             CommandResult = false;
-            FM_GlobalData.ChildCmdErrCounter++;
+            FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
 
             /* Send command failure event (error) */
             CFE_EVS_SendEvent(FM_GET_DIR_FILE_WRHDR_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -1342,7 +1342,7 @@ bool FM_ChildDirListFileInit(osal_id_t *FileHandlePtr, const char *Directory, co
     else
     {
         CommandResult = false;
-        FM_GlobalData.ChildCmdErrCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
 
         /* Send command failure event (error) */
         CFE_EVS_SendEvent(FM_GET_DIR_FILE_OSCREAT_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -1432,7 +1432,7 @@ void FM_ChildDirListFileLoop(osal_id_t DirId, osal_id_t FileHandle, const char *
                     else
                     {
                         CommandResult = false;
-                        FM_GlobalData.ChildCmdErrCounter++;
+                        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
 
                         /* Send command failure event (error) */
                         CFE_EVS_SendEvent(FM_GET_DIR_FILE_WRENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -1442,7 +1442,7 @@ void FM_ChildDirListFileLoop(osal_id_t DirId, osal_id_t FileHandle, const char *
                 }
                 else
                 {
-                    FM_GlobalData.ChildCmdWarnCounter++;
+                    FM_GlobalData.HousekeepingPkt.Payload.ChildCmdWarnCounter++;
 
                     /* Send command failure event (error) */
                     CFE_EVS_SendEvent(FM_GET_DIR_FILE_WARNING_EID, CFE_EVS_EventType_INFORMATION,
@@ -1470,7 +1470,7 @@ void FM_ChildDirListFileLoop(osal_id_t DirId, osal_id_t FileHandle, const char *
         if (BytesWritten != WriteLength)
         {
             CommandResult = false;
-            FM_GlobalData.ChildCmdErrCounter++;
+            FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter++;
 
             /* Send command failure event (error) */
             CFE_EVS_SendEvent(FM_GET_DIR_FILE_UPSTATS_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -1482,7 +1482,7 @@ void FM_ChildDirListFileLoop(osal_id_t DirId, osal_id_t FileHandle, const char *
     /* Send command completion event (info) */
     if (CommandResult == true)
     {
-        FM_GlobalData.ChildCmdCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.ChildCmdCounter++;
 
         CFE_EVS_SendEvent(FM_GET_DIR_FILE_CMD_EID, CFE_EVS_EventType_DEBUG,
                           "%s command: wrote %d of %d names: dir = %s, filename = %s", CmdText, (int)FileEntries,

--- a/fsw/src/fm_cmd_utils.c
+++ b/fsw/src/fm_cmd_utils.c
@@ -425,7 +425,7 @@ bool FM_VerifyChildTask(uint32 EventID, const char *CmdText)
     bool Result = false;
 
     /* Copy of child queue count that child task cannot change */
-    uint8 LocalQueueCount = FM_GlobalData.ChildQueueCount;
+    uint8 LocalQueueCount = FM_GlobalData.HousekeepingPkt.Payload.ChildQueueCount;
 
     /* Verify child task is active and queue interface is healthy */
     if (!OS_ObjectIdDefined(FM_GlobalData.ChildSemaphore))
@@ -482,7 +482,7 @@ void FM_InvokeChildTask(void)
 
     /* Prevent parent/child updating queue counter at same time */
     OS_MutSemTake(FM_GlobalData.ChildQueueCountSem);
-    FM_GlobalData.ChildQueueCount++;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildQueueCount++;
     OS_MutSemGive(FM_GlobalData.ChildQueueCountSem);
 
     /* Does the child task still have a semaphore? */

--- a/fsw/src/fm_cmds.c
+++ b/fsw/src/fm_cmds.c
@@ -73,12 +73,12 @@ bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     const char *CmdText = "Reset Counters";
 
-    FM_GlobalData.CommandCounter    = 0;
-    FM_GlobalData.CommandErrCounter = 0;
+    FM_GlobalData.HousekeepingPkt.Payload.CommandCounter    = 0;
+    FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter = 0;
 
-    FM_GlobalData.ChildCmdCounter     = 0;
-    FM_GlobalData.ChildCmdErrCounter  = 0;
-    FM_GlobalData.ChildCmdWarnCounter = 0;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCmdCounter     = 0;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter  = 0;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCmdWarnCounter = 0;
 
     /* Send command completion event (debug) */
     CFE_EVS_SendEvent(FM_RESET_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command", CmdText);

--- a/fsw/src/fm_dispatch.c
+++ b/fsw/src/fm_dispatch.c
@@ -529,12 +529,12 @@ void FM_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
         /* Increment command success counter */
         if (CommandCode != FM_RESET_COUNTERS_CC)
         {
-            FM_GlobalData.CommandCounter++;
+            FM_GlobalData.HousekeepingPkt.Payload.CommandCounter++;
         }
     }
     else
     {
         /* Increment command error counter */
-        FM_GlobalData.CommandErrCounter++;
+        FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter++;
     }
 }

--- a/unit-test/fm_app_tests.c
+++ b/unit-test/fm_app_tests.c
@@ -297,14 +297,14 @@ void Test_FM_SendHkCmd(void)
     UT_SetDefaultReturnValue(UT_KEY(FM_GetOpenFilesData), 0);
 
     /* Set non-zero values to assert */
-    FM_GlobalData.CommandCounter      = 1;
-    FM_GlobalData.CommandErrCounter   = 2;
-    FM_GlobalData.ChildCmdCounter     = 3;
-    FM_GlobalData.ChildCmdErrCounter  = 4;
-    FM_GlobalData.ChildCmdWarnCounter = 5;
-    FM_GlobalData.ChildQueueCount     = 6;
-    FM_GlobalData.ChildCurrentCC      = 7;
-    FM_GlobalData.ChildPreviousCC     = 8;
+    FM_GlobalData.HousekeepingPkt.Payload.CommandCounter      = 1;
+    FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter   = 2;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCmdCounter     = 3;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter  = 4;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCmdWarnCounter = 5;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildQueueCount     = 6;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC      = 7;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildPreviousCC     = 8;
 
     /* Act */
     UtAssert_VOIDCALL(FM_SendHkCmd(NULL));
@@ -318,15 +318,15 @@ void Test_FM_SendHkCmd(void)
     UtAssert_STUB_COUNT(CFE_SB_TransmitMsg, 1);
 
     ReportPtr = &FM_GlobalData.HousekeepingPkt.Payload;
-    UtAssert_INT32_EQ(ReportPtr->CommandCounter, FM_GlobalData.CommandCounter);
-    UtAssert_INT32_EQ(ReportPtr->CommandErrCounter, FM_GlobalData.CommandErrCounter);
+    UtAssert_INT32_EQ(ReportPtr->CommandCounter, FM_GlobalData.HousekeepingPkt.Payload.CommandCounter);
+    UtAssert_INT32_EQ(ReportPtr->CommandErrCounter, FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter);
     UtAssert_INT32_EQ(ReportPtr->NumOpenFiles, 0);
-    UtAssert_INT32_EQ(ReportPtr->ChildCmdCounter, FM_GlobalData.ChildCmdCounter);
-    UtAssert_INT32_EQ(ReportPtr->ChildCmdErrCounter, FM_GlobalData.ChildCmdErrCounter);
-    UtAssert_INT32_EQ(ReportPtr->ChildCmdWarnCounter, FM_GlobalData.ChildCmdWarnCounter);
-    UtAssert_INT32_EQ(ReportPtr->ChildQueueCount, FM_GlobalData.ChildQueueCount);
-    UtAssert_INT32_EQ(ReportPtr->ChildCurrentCC, FM_GlobalData.ChildCurrentCC);
-    UtAssert_INT32_EQ(ReportPtr->ChildPreviousCC, FM_GlobalData.ChildPreviousCC);
+    UtAssert_INT32_EQ(ReportPtr->ChildCmdCounter, FM_GlobalData.HousekeepingPkt.Payload.ChildCmdCounter);
+    UtAssert_INT32_EQ(ReportPtr->ChildCmdErrCounter, FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter);
+    UtAssert_INT32_EQ(ReportPtr->ChildCmdWarnCounter, FM_GlobalData.HousekeepingPkt.Payload.ChildCmdWarnCounter);
+    UtAssert_INT32_EQ(ReportPtr->ChildQueueCount, FM_GlobalData.HousekeepingPkt.Payload.ChildQueueCount);
+    UtAssert_INT32_EQ(ReportPtr->ChildCurrentCC, FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC);
+    UtAssert_INT32_EQ(ReportPtr->ChildPreviousCC, FM_GlobalData.HousekeepingPkt.Payload.ChildPreviousCC);
 }
 
 /* * * * * * * * * * * * * *

--- a/unit-test/fm_child_tests.c
+++ b/unit-test/fm_child_tests.c
@@ -56,12 +56,12 @@
 
 void UT_FM_Child_Cmd_Assert(int32 cmd_ctr, int32 cmderr_ctr, int32 cmdwarn_ctr, int32 previous_cc)
 {
-    UtAssert_INT32_EQ(FM_GlobalData.ChildCmdCounter, cmd_ctr);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildCmdErrCounter, cmderr_ctr);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildCmdWarnCounter, cmdwarn_ctr);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.ChildCmdCounter, cmd_ctr);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter, cmderr_ctr);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.ChildCmdWarnCounter, cmdwarn_ctr);
 
-    UtAssert_INT32_EQ(FM_GlobalData.ChildPreviousCC, previous_cc);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildCurrentCC, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.ChildPreviousCC, previous_cc);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC, 0);
 }
 
 /*********************************************************************************
@@ -270,7 +270,7 @@ void Test_FM_ChildProcess_FMConcatCC(void)
 {
     /* Arrange */
     FM_GlobalData.ChildQueue[0].CommandCode = FM_CONCAT_FILES_CC;
-    FM_GlobalData.ChildCurrentCC            = 1;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC            = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_cp), !OS_SUCCESS);
 
@@ -290,7 +290,7 @@ void Test_FM_ChildProcess_FMCreateDirCC(void)
 {
     /* Arrange */
     FM_GlobalData.ChildQueue[0].CommandCode = FM_CREATE_DIRECTORY_CC;
-    FM_GlobalData.ChildCurrentCC            = 1;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC            = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_mkdir), !OS_SUCCESS);
 
@@ -310,7 +310,7 @@ void Test_FM_ChildProcess_FMDeleteDirCC(void)
 {
     /* Arrange */
     FM_GlobalData.ChildQueue[0].CommandCode = FM_DELETE_DIRECTORY_CC;
-    FM_GlobalData.ChildCurrentCC            = 1;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC            = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryOpen), !OS_SUCCESS);
 
@@ -332,7 +332,7 @@ void Test_FM_ChildProcess_FMGetFileInfoCC(void)
     FM_GlobalData.ChildQueue[0].CommandCode   = FM_GET_FILE_INFO_CC;
     FM_GlobalData.ChildQueue[0].FileInfoCRC   = !FM_IGNORE_CRC;
     FM_GlobalData.ChildQueue[0].FileInfoState = FM_NAME_IS_FILE_OPEN;
-    FM_GlobalData.ChildCurrentCC              = 1;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC              = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_MSG_Init), CFE_SUCCESS);
 
@@ -355,7 +355,7 @@ void Test_FM_ChildProcess_FMGetDirListsFileCC(void)
 {
     /* Arrange */
     FM_GlobalData.ChildQueue[0].CommandCode = FM_GET_DIR_LIST_FILE_CC;
-    FM_GlobalData.ChildCurrentCC            = 1;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC            = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryOpen), !OS_SUCCESS);
 
@@ -375,7 +375,7 @@ void Test_FM_ChildProcess_FMGetDirListsPktCC(void)
 {
     /* Arrange */
     FM_GlobalData.ChildQueue[0].CommandCode = FM_GET_DIR_LIST_PKT_CC;
-    FM_GlobalData.ChildCurrentCC            = 1;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC            = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_DirectoryRead), !OS_SUCCESS);
 
@@ -398,7 +398,7 @@ void Test_FM_ChildProcess_FMSetFilePermCC(void)
 {
     /* Arrange */
     FM_GlobalData.ChildQueue[0].CommandCode = FM_SET_PERMISSIONS_CC;
-    FM_GlobalData.ChildCurrentCC            = 1;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC            = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(OS_chmod), !OS_SUCCESS);
 
@@ -912,7 +912,7 @@ void Test_FM_ChildDecompressFileCmd_FSDecompressSuccess(void)
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DECOMPRESS_FILE_CC};
 
-    FM_GlobalData.ChildCurrentCC = 1;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC = 1;
 
     /* Act */
     UtAssert_VOIDCALL(FM_ChildDecompressFileCmd(&queue_entry));
@@ -931,7 +931,7 @@ void Test_FM_ChildDecompressFileCmd_FSDecompressNotSuccess(void)
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_DECOMPRESS_FILE_CC};
 
-    FM_GlobalData.ChildCurrentCC = 1;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC = 1;
     UT_SetDefaultReturnValue(UT_KEY(FM_Decompress_Impl), !CFE_SUCCESS);
 
     /* Act */
@@ -954,7 +954,7 @@ void Test_FM_ChildConcatFilesCmd_OSCpNotSuccess(void)
     /* Arrange */
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = FM_CONCAT_FILES_CC, .Source1 = "source1", .Source2 = "source2"};
 
-    FM_GlobalData.ChildCurrentCC = 1;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCurrentCC = 1;
     UT_SetDefaultReturnValue(UT_KEY(OS_cp), !OS_SUCCESS);
 
     /* Act */
@@ -1828,7 +1828,7 @@ void Test_FM_ChildDirListFileInit_OSOpenCreateFail(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_FILE_OSCREAT_ERR_EID);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildCmdErrCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter, 1);
 }
 
 void Test_FM_ChildDirListFileInit_FSWriteHeaderNotSameSizeFSHeadert(void)
@@ -2142,7 +2142,7 @@ void Test_FM_ChildLoop_CountSemTakeNotSuccess(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CHILD_TERM_SEM_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildCmdErrCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter, 0);
 }
 
 void Test_FM_ChildLoop_ChildQCountEqualZero(void)
@@ -2155,13 +2155,13 @@ void Test_FM_ChildLoop_ChildQCountEqualZero(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CHILD_TERM_EMPTYQ_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildCmdErrCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter, 1);
 }
 
 void Test_FM_ChildLoop_ChildReadIndexEqualChildQDepth(void)
 {
     /* Arrange */
-    FM_GlobalData.ChildQueueCount = 1;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildQueueCount = 1;
     FM_GlobalData.ChildReadIndex  = FM_CHILD_QUEUE_DEPTH;
 
     /* Act */
@@ -2172,13 +2172,13 @@ void Test_FM_ChildLoop_ChildReadIndexEqualChildQDepth(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CHILD_TERM_QIDX_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildCmdErrCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter, 1);
 }
 
 void Test_FM_ChildLoop_CountSemTakeSuccessDefault(void)
 {
     /* Arrange */
-    FM_GlobalData.ChildQueueCount    = 1;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildQueueCount = 1;
     FM_GlobalData.ChildReadIndex     = 0;
     FM_ChildQueueEntry_t queue_entry = {.CommandCode = -1};
 
@@ -2195,7 +2195,7 @@ void Test_FM_ChildLoop_CountSemTakeSuccessDefault(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_CHILD_TERM_SEM_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildCmdErrCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter, 1);
 }
 
 /* ****************

--- a/unit-test/fm_cmd_utils_tests.c
+++ b/unit-test/fm_cmd_utils_tests.c
@@ -502,19 +502,19 @@ void Test_FM_VerifyChildTask(void)
 
     /* LocalQueueCount equal to FM_CHILD_QUEUE_DEPTH */
     FM_GlobalData.ChildSemaphore  = FM_UT_OBJID_1;
-    FM_GlobalData.ChildQueueCount = FM_CHILD_QUEUE_DEPTH;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildQueueCount = FM_CHILD_QUEUE_DEPTH;
     UtAssert_BOOL_FALSE(FM_VerifyChildTask(0, "Cmd Text"));
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_CHILD_Q_FULL_EID_OFFSET);
 
     /* LocalQueueCount greater than FM_CHILD_QUEUE_DEPTH */
-    FM_GlobalData.ChildQueueCount = FM_CHILD_QUEUE_DEPTH + 1;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildQueueCount = FM_CHILD_QUEUE_DEPTH + 1;
     UtAssert_BOOL_FALSE(FM_VerifyChildTask(0, "Cmd Text"));
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 3);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[2].EventID, FM_CHILD_BROKEN_EID_OFFSET);
 
     /* ChildWriteIndex equal to FM_CHILD_QUEUE_DEPTH */
-    FM_GlobalData.ChildQueueCount = FM_CHILD_QUEUE_DEPTH - 1;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildQueueCount = FM_CHILD_QUEUE_DEPTH - 1;
     FM_GlobalData.ChildWriteIndex = FM_CHILD_QUEUE_DEPTH;
     UtAssert_BOOL_FALSE(FM_VerifyChildTask(0, "Cmd Text"));
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 4);
@@ -536,14 +536,14 @@ void Test_FM_InvokeChildTask(void)
     FM_GlobalData.ChildSemaphore  = FM_UT_OBJID_1;
     UtAssert_VOIDCALL(FM_InvokeChildTask());
     UtAssert_INT32_EQ(FM_GlobalData.ChildWriteIndex, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueueCount, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.ChildQueueCount, 1);
     UtAssert_STUB_COUNT(OS_CountSemGive, 1);
 
     /* Conditions false */
     FM_GlobalData.ChildSemaphore = OS_OBJECT_ID_UNDEFINED;
     UtAssert_VOIDCALL(FM_InvokeChildTask());
     UtAssert_INT32_EQ(FM_GlobalData.ChildWriteIndex, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildQueueCount, 2);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.ChildQueueCount, 2);
     UtAssert_STUB_COUNT(OS_CountSemGive, 1);
 }
 

--- a/unit-test/fm_cmds_tests.c
+++ b/unit-test/fm_cmds_tests.c
@@ -99,11 +99,11 @@ void Test_FM_ResetCountersCmd_Success(void)
     bool  Result;
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "%%s command");
 
-    FM_GlobalData.CommandCounter      = 1;
-    FM_GlobalData.CommandErrCounter   = 1;
-    FM_GlobalData.ChildCmdCounter     = 1;
-    FM_GlobalData.ChildCmdErrCounter  = 1;
-    FM_GlobalData.ChildCmdWarnCounter = 1;
+    FM_GlobalData.HousekeepingPkt.Payload.CommandCounter = 1;
+    FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter = 1;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCmdCounter   = 1;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter = 1;
+    FM_GlobalData.HousekeepingPkt.Payload.ChildCmdWarnCounter = 1;
 
     Result = FM_ResetCountersCmd(&UT_CmdBuf.Buf);
 
@@ -122,11 +122,11 @@ void Test_FM_ResetCountersCmd_Success(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildCmdCounter, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildCmdErrCounter, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.ChildCmdWarnCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.ChildCmdCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.ChildCmdErrCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.ChildCmdWarnCounter, 0);
 }
 
 void add_FM_ResetCountersCmd_tests(void)

--- a/unit-test/fm_dispatch_tests.c
+++ b/unit-test/fm_dispatch_tests.c
@@ -71,8 +71,8 @@ void Test_FM_ProcessCmd_NoopCmdCCReturn(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_NoopCmd, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter, 0);
 }
 
 void Test_FM_ProcessCmd_ResetCountersCCReturn(void)
@@ -93,8 +93,8 @@ void Test_FM_ProcessCmd_ResetCountersCCReturn(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_ResetCountersCmd, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter, 0);
 }
 
 void Test_FM_ProcessCmd_CopyFileCCReturn(void)
@@ -115,8 +115,8 @@ void Test_FM_ProcessCmd_CopyFileCCReturn(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_CopyFileCmd, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter, 0);
 }
 
 void Test_FM_ProcessCmd_MoveFileCCReturn(void)
@@ -137,8 +137,8 @@ void Test_FM_ProcessCmd_MoveFileCCReturn(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_MoveFileCmd, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter, 0);
 }
 
 void Test_FM_ProcessCmd_RenameFileCCReturn(void)
@@ -159,8 +159,8 @@ void Test_FM_ProcessCmd_RenameFileCCReturn(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_RenameFileCmd, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter, 0);
 }
 
 void Test_FM_ProcessCmd_DeleteFileCCReturn(void)
@@ -181,8 +181,8 @@ void Test_FM_ProcessCmd_DeleteFileCCReturn(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_DeleteFileCmd, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter, 0);
 }
 
 void Test_FM_ProcessCmd_DeleteAllFilesCCReturn(void)
@@ -203,8 +203,8 @@ void Test_FM_ProcessCmd_DeleteAllFilesCCReturn(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_DeleteAllFilesCmd, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter, 0);
 }
 
 void Test_FM_ProcessCmd_DecompressFileCCReturn(void)
@@ -225,8 +225,8 @@ void Test_FM_ProcessCmd_DecompressFileCCReturn(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_DecompressFileCmd, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter, 0);
 }
 
 void Test_FM_ProcessCmd_ConcatFilesCCReturn(void)
@@ -247,8 +247,8 @@ void Test_FM_ProcessCmd_ConcatFilesCCReturn(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_ConcatFilesCmd, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter, 0);
 }
 
 void Test_FM_ProcessCmd_GetFileInfoCCReturn(void)
@@ -269,8 +269,8 @@ void Test_FM_ProcessCmd_GetFileInfoCCReturn(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_GetFileInfoCmd, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter, 0);
 }
 
 void Test_FM_ProcessCmd_GetOpenFilesCCReturn(void)
@@ -291,8 +291,8 @@ void Test_FM_ProcessCmd_GetOpenFilesCCReturn(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_GetOpenFilesCmd, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter, 0);
 }
 
 void Test_FM_ProcessCmd_CreateDirectoryCCReturn(void)
@@ -313,8 +313,8 @@ void Test_FM_ProcessCmd_CreateDirectoryCCReturn(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_CreateDirectoryCmd, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter, 0);
 }
 
 void Test_FM_ProcessCmd_DeleteDirectoryCCReturn(void)
@@ -335,8 +335,8 @@ void Test_FM_ProcessCmd_DeleteDirectoryCCReturn(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_DeleteDirectoryCmd, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter, 0);
 }
 
 void Test_FM_ProcessCmd_GetDirListFileCCReturn(void)
@@ -357,8 +357,8 @@ void Test_FM_ProcessCmd_GetDirListFileCCReturn(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_GetDirListFileCmd, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter, 0);
 }
 
 void Test_FM_ProcessCmd_GetDirListPktCCReturn(void)
@@ -379,8 +379,8 @@ void Test_FM_ProcessCmd_GetDirListPktCCReturn(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_GetDirListPktCmd, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter, 0);
 }
 
 void Test_FM_ProcessCmd_MonitorFilesystemSpaceCCReturn(void)
@@ -401,8 +401,8 @@ void Test_FM_ProcessCmd_MonitorFilesystemSpaceCCReturn(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_MonitorFilesystemSpaceCmd, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter, 0);
 }
 
 void Test_FM_ProcessCmd_SetTableStateCCReturn(void)
@@ -423,8 +423,8 @@ void Test_FM_ProcessCmd_SetTableStateCCReturn(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_SetTableStateCmd, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter, 0);
 }
 
 void Test_FM_ProcessCmd_SetPermissionsCCReturn(void)
@@ -445,8 +445,8 @@ void Test_FM_ProcessCmd_SetPermissionsCCReturn(void)
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(FM_SetPermissionsCmd, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter, 0);
 }
 
 void Test_FM_ProcessCmd_DefaultReturn(void)
@@ -462,8 +462,8 @@ void Test_FM_ProcessCmd_DefaultReturn(void)
 
     /* Assert */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandCounter, 0);
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandCounter, 0);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CC_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 }
@@ -565,7 +565,7 @@ void Test_FM_ProcessPkt_CheckMessageReturnGroundCommand(void)
     UtAssert_VOIDCALL(FM_ProcessPkt(NULL));
 
     /* Assert */
-    UtAssert_INT32_EQ(FM_GlobalData.CommandErrCounter, 1);
+    UtAssert_INT32_EQ(FM_GlobalData.HousekeepingPkt.Payload.CommandErrCounter, 1);
     UtAssert_STUB_COUNT(CFE_MSG_GetFcnCode, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CC_ERR_EID);


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #106 
  - Consolidates the variables common to both the global struct and the housekeeping packet to only exist (and be updated/accessed) in the housekeeping struct

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
No change to behavior other than storage location of the variables as outlined above.

Simpler pattern, reduces duplication and eases future maintenance.

**Contributor Info**
Avi Weiss @thnkslprpt