### PR TITLE
Fix #109, Uninitialized FileStats in FM_GetVolumeFreeSpace

### DIFF
--- a/fsw/src/fm_cmd_utils.c
+++ b/fsw/src/fm_cmd_utils.c
@@ -533,7 +533,7 @@ void FM_AppendPathSep(char *Directory, uint32 BufferSize)
 
 CFE_Status_t FM_GetVolumeFreeSpace(const char *FileSys, uint64 *BlockCount, uint64 *ByteCount)
 {
-    OS_statvfs_t  FileStats;
+    OS_statvfs_t  FileStats = {0};
     osal_status_t OS_Status;
     CFE_Status_t  Result;
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/FM/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #109

**Testing performed**
CI

**Expected behavior changes**
No static analysis uninitialized variable warnings

**System(s) tested on**
CI

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC