### PR TITLE
Fix #114, Convert command success events to `INFORMATION` type

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ A clear and concise description of what the contribution is.
 **Testing performed**
 Steps taken to test the contribution:
 1. Build steps '...'
-1. Execution steps '...'
+2. Execution steps '...'
 
 **Expected behavior changes**
 A clear and concise description of how this contribution will change behavior and level of impact.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ add_cfe_app(fm ${APP_SRC_FILES} ${FM_OPTION_SRC_FILES})
 # This permits direct access to public headers in the fsw/inc directory
 target_include_directories(fm PUBLIC fsw/inc)
 
-# Add dependencies based on the type of compression algoritm selected (if any)
+# Add dependencies based on the type of compression algorithm selected (if any)
 if (FM_DEPENDENCY_LIST)
   add_cfe_app_dependency(fm ${FM_DEPENDENCY_LIST})
 endif()

--- a/fsw/inc/fm_events.h
+++ b/fsw/inc/fm_events.h
@@ -244,7 +244,7 @@
 /**
  * \brief FM Copy File Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause
  *
@@ -256,7 +256,7 @@
  *  occur until some time after the command was invoked.  However, this
  *  event message does signal the actual completion of the command.
  */
-#define FM_COPY_CMD_EID 16
+#define FM_COPY_CMD_INF_EID 16
 
 /**
  * \brief FM Copy File Command Length Invalid Event ID
@@ -303,14 +303,14 @@
 /**
  * \brief FM Move File Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause
  *
  *  This event message signals the successful completion of a
  *  /FM_Move command.
  */
-#define FM_MOVE_CMD_EID 20
+#define FM_MOVE_CMD_INF_EID 20
 
 /**
  * \brief FM Move File Command Length Invalid Event ID
@@ -357,14 +357,14 @@
 /**
  * \brief FM Rename File Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause
  *
  *  This event message signals the successful completion of a
  *  /FM_Rename command.
  */
-#define FM_RENAME_CMD_EID 24
+#define FM_RENAME_CMD_INF_EID 24
 
 /**
  * \brief FM Rename File Command Length Invalid Event ID
@@ -411,14 +411,14 @@
 /**
  * \brief FM Delete File Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause
  *
  *  This event message signals the successful completion of a
  *  /FM_Delete command.
  */
-#define FM_DELETE_CMD_EID 28
+#define FM_DELETE_CMD_INF_EID 28
 
 /**
  * \brief FM Delete File Command Length Invalid Event ID
@@ -450,7 +450,7 @@
 /**
  * \brief FM Delete All Files Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause
  *
@@ -462,7 +462,7 @@
  *  occur until some time after the command was invoked.  However, this
  *  event message does signal the actual completion of the command.
  */
-#define FM_DELETE_ALL_CMD_EID 31
+#define FM_DELETE_ALL_CMD_INF_EID 31
 
 /**
  * \brief FM Delete All Files Unable To Delete All Event ID
@@ -518,7 +518,7 @@
 /**
  * \brief FM Decompress File Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause
  *
@@ -530,7 +530,7 @@
  *  occur until some time after the command was invoked.  However, this
  *  event message does signal the actual completion of the command.
  */
-#define FM_DECOM_CMD_EID 36
+#define FM_DECOM_CMD_INF_EID 36
 
 /**
  * \brief FM Decompress File Command Length Invalid Event ID
@@ -562,7 +562,7 @@
 /**
  * \brief FM Concat Files Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause
  *
@@ -574,7 +574,7 @@
  *  occur until some time after the command was invoked.  However, this
  *  event message does signal the actual completion of the command.
  */
-#define FM_CONCAT_CMD_EID 39
+#define FM_CONCAT_CMD_INF_EID 39
 
 /**
  * \brief FM Concat Files Command Length Invalid Event ID
@@ -679,10 +679,7 @@
 /**
  * \brief FM Get File Info Command Event ID
  *
- *  \par Type: DEBUG
- *
- *  This event is type debug because the command generates a telemetry
- *  packet that also signals the completion of the command.
+ *  \par Type: INFORMATION
  *
  *  \par Cause
  *
@@ -694,7 +691,7 @@
  *  occur until some time after the command was invoked.  However, this
  *  event message does signal the actual completion of the command.
  */
-#define FM_GET_FILE_INFO_CMD_EID 46
+#define FM_GET_FILE_INFO_CMD_INF_EID 46
 
 /**
  * \brief FM Get File Info Unable To Compute CRC File State Invalid Event ID
@@ -795,17 +792,14 @@
 /**
  * \brief FM Get Open Files Command Event ID
  *
- *  \par Type: DEBUG
- *
- *  This event is type debug because the command generates a telemetry
- *  packet that also signals the completion of the command.
+ *  \par Type: INFORMATION
  *
  *  \par Cause
  *
  *  This event message signals the successful completion of a
  *  /FM_GetOpenFiles command.
  */
-#define FM_GET_OPEN_FILES_CMD_EID 53
+#define FM_GET_OPEN_FILES_CMD_INF_EID 53
 
 /**
  * \brief FM Get Open Files Command Length Invalid Event ID
@@ -822,14 +816,14 @@
 /**
  * \brief FM Create Directory Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause
  *
  *  This event message signals the successful completion of a
  *  /FM_CreateDir command.
  */
-#define FM_CREATE_DIR_CMD_EID 55
+#define FM_CREATE_DIR_CMD_INF_EID 55
 
 /**
  * \brief FM Create Directory Command Length Invalid Event ID
@@ -860,14 +854,14 @@
 /**
  * \brief FM Delete Directory Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause
  *
  *  This event message signals the successful completion of a
  *  /FM_DeleteDir command.
  */
-#define FM_DELETE_DIR_CMD_EID 58
+#define FM_DELETE_DIR_CMD_INF_EID 58
 
 /**
  * \brief FM Delete Directory Command Length Invalid Event ID
@@ -924,7 +918,7 @@
 /**
  * \brief FM Directory List To File Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause
  *
@@ -936,7 +930,7 @@
  *  occur until some time after the command was invoked.  However, this
  *  event message does signal the actual completion of the command.
  */
-#define FM_GET_DIR_FILE_CMD_EID 63
+#define FM_GET_DIR_FILE_CMD_INF_EID 63
 
 /**
  * \brief FM Directory List To File Command Length Invalid Event ID
@@ -1078,10 +1072,7 @@
 /**
  * \brief FM Directory List To Packet Command Event ID
  *
- *  \par Type: DEBUG
- *
- *  This event is type debug because the command generates a telemetry
- *  packet that also signals the completion of the command.
+ *  \par Type: INFORMATION
  *
  *  \par Cause
  *
@@ -1093,7 +1084,7 @@
  *  occur until some time after the command was invoked.  However, this
  *  event message does signal the actual completion of the command.
  */
-#define FM_GET_DIR_PKT_CMD_EID 72
+#define FM_GET_DIR_PKT_CMD_INF_EID 72
 
 /**
  * \brief FM Directory List To Packet Command Directory and Entry Too Long Event ID
@@ -1138,17 +1129,14 @@
 /**
  * \brief FM Monitor Filesystem Command Event ID
  *
- *  \par Type: DEBUG
- *
- *  This event is type debug because the command generates a telemetry
- *  packet that also signals the completion of the command.
+ *  \par Type: INFORMATION
  *
  *  \par Cause
  *
  *  This event message signals the successful completion of a
  *  /FM_MonitorFilesystemSpace command.
  */
-#define FM_MONITOR_FILESYSTEM_SPACE_CMD_EID 76
+#define FM_MONITOR_FILESYSTEM_SPACE_CMD_INF_EID 76
 
 /**
  * \brief FM Get Free Space Command Length Invalid Event ID
@@ -1453,14 +1441,14 @@
 /**
  * \brief FM Set Permissions Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause
  *
  *  This event message signals the successful completion of a
  *  /FM_SetPerm command.
  */
-#define FM_SET_PERM_CMD_EID 99
+#define FM_SET_PERM_CMD_INF_EID 99
 
 /**
  * \brief FM Set Permissions Command Chmod Error Event ID

--- a/fsw/inc/fm_msgdefs.h
+++ b/fsw/inc/fm_msgdefs.h
@@ -115,7 +115,7 @@
  *  \par Command Success Verification
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
  *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
- *       - Debug event #FM_COPY_CMD_EID will be sent
+ *       - Informational event #FM_COPY_CMD_INF_EID will be sent
  *
  *  \par Command Error Conditions
  *       - Invalid command packet length
@@ -187,7 +187,7 @@
  *  \par Command Success Verification
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
  *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
- *       - Debug event #FM_MOVE_CMD_EID will be sent
+ *       - Informational event #FM_MOVE_CMD_INF_EID will be sent
  *
  *  \par Command Error Conditions
  *       - Invalid command packet length
@@ -249,7 +249,7 @@
  *  \par Command Success Verification
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
  *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
- *       - Debug event #FM_RENAME_CMD_EID will be sent
+ *       - Informational event #FM_RENAME_CMD_INF_EID will be sent
  *
  *  \par Command Error Conditions
  *       - Invalid command packet length
@@ -303,7 +303,7 @@
  *  \par Command Success Verification
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
  *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
- *       - Debug event #FM_DELETE_CMD_EID will be sent
+ *       - Informational event #FM_DELETE_CMD_INF_EID will be sent
  *
  *  \par Command Error Conditions
  *       - Invalid command packet length
@@ -356,7 +356,7 @@
  *  \par Command Success Verification
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
  *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
- *       - Debug event #FM_DELETE_ALL_CMD_EID will be sent
+ *       - Informational event #FM_DELETE_ALL_CMD_INF_EID will be sent
  *
  *  \par Command Warning Conditions
  *       - Directory entry is not a file (sub-directory)
@@ -423,7 +423,7 @@
  *  \par Command Success Verification
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
  *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
- *       - Debug event #FM_DECOM_CMD_EID will be sent
+ *       - Informational event #FM_DECOM_CMD_INF_EID will be sent
  *
  *  \par Command Error Conditions
  *       - Invalid command packet length
@@ -479,7 +479,7 @@
  *  \par Command Success Verification
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
  *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
- *       - Debug event #FM_CONCAT_CMD_EID will be sent
+ *       - Informational event #FM_CONCAT_CMD_INF_EID will be sent
  *
  *  \par Command Error Conditions
  *       - Invalid command packet length
@@ -547,7 +547,7 @@
  *  \par Command Success Verification
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
  *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
- *       - Debug event #FM_GET_FILE_INFO_CMD_EID will be sent
+ *       - Informational event #FM_GET_FILE_INFO_CMD_INF_EID will be sent
  *
  *  \par Command Warning Conditions
  *       - File is open and CRC cannot be calculated
@@ -597,7 +597,7 @@
  *
  *  \par Command Success Verification
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment
- *       - Debug event #FM_GET_OPEN_FILES_CMD_EID will be sent
+ *       - Informational event #FM_GET_OPEN_FILES_CMD_INF_EID will be sent
  *
  *  \par Command Error Conditions
  *       - Invalid command packet length
@@ -633,7 +633,7 @@
  *  \par Command Success Verification
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
  *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
- *       - Debug event #FM_CREATE_DIR_CMD_EID will be sent
+ *       - Informational event #FM_CREATE_DIR_CMD_INF_EID will be sent
  *
  *  \par Command Error Conditions
  *       - Invalid command packet length
@@ -681,7 +681,7 @@
  *  \par Command Success Verification
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
  *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
- *       - Debug event #FM_DELETE_DIR_CMD_EID will be sent
+ *       - Informational event #FM_DELETE_DIR_CMD_INF_EID will be sent
  *
  *  \par Command Error Conditions
  *       - Invalid command packet length
@@ -736,7 +736,7 @@
  *  \par Command Success Verification
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
  *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
- *       - Debug event #FM_GET_DIR_FILE_CMD_EID will be sent
+ *       - Informational event #FM_GET_DIR_FILE_CMD_INF_EID will be sent
  *
  *  \par Command Warning Conditions
  *       - Combined directory and entry name is too long
@@ -819,7 +819,7 @@
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
  *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
  *       - The #FM_DirListPkt_t telemetry packet will be sent
- *       - The #FM_GET_DIR_PKT_CMD_EID debug event will be sent
+ *       - The #FM_GET_DIR_PKT_CMD_INF_EID informational event will be sent
  *
  *  \par Command Warning Conditions
  *       - Combined directory and entry name is too long
@@ -869,7 +869,7 @@
  *
  *  \par Evidence of success may be found in the following telemetry:
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment
- *       - Debug event #FM_MONITOR_FILESYSTEM_SPACE_CMD_EID will be sent
+ *       - Informational event #FM_MONITOR_FILESYSTEM_SPACE_CMD_INF_EID will be sent
  *       - Telemetry packet #FM_MonitorReportPkt_t will be sent
  *
  *  \par Error Conditions
@@ -948,7 +948,7 @@
  *  \par Command Success Verification
  *       - #FM_HousekeepingPkt_Payload_t.CommandCounter will increment after validation
  *       - #FM_HousekeepingPkt_Payload_t.ChildCmdCounter will increment after completion
- *       - Debug event #FM_SET_PERM_CMD_EID will be sent
+ *       - Informational event #FM_SET_PERM_CMD_INF_EID will be sent
  *
  *  \par Error Conditions
  *       - Invalid command packet length

--- a/fsw/src/fm_child.c
+++ b/fsw/src/fm_child.c
@@ -302,7 +302,7 @@ void FM_ChildCopyCmd(const FM_ChildQueueEntry_t *CmdArgs)
         FM_GlobalData.ChildCmdCounter++;
 
         /* Send command completion event (info) */
-        CFE_EVS_SendEvent(FM_COPY_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: src = %s, tgt = %s", CmdText,
+        CFE_EVS_SendEvent(FM_COPY_CMD_INF_EID, CFE_EVS_EventType_INFORMATION, "%s command: src = %s, tgt = %s", CmdText,
                           CmdArgs->Source1, CmdArgs->Target);
     }
 
@@ -341,7 +341,7 @@ void FM_ChildMoveCmd(const FM_ChildQueueEntry_t *CmdArgs)
         FM_GlobalData.ChildCmdCounter++;
 
         /* Send command completion event (info) */
-        CFE_EVS_SendEvent(FM_MOVE_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: src = %s, tgt = %s", CmdText,
+        CFE_EVS_SendEvent(FM_MOVE_CMD_INF_EID, CFE_EVS_EventType_INFORMATION, "%s command: src = %s, tgt = %s", CmdText,
                           CmdArgs->Source1, CmdArgs->Target);
     }
 
@@ -380,8 +380,8 @@ void FM_ChildRenameCmd(const FM_ChildQueueEntry_t *CmdArgs)
         FM_GlobalData.ChildCmdCounter++;
 
         /* Send command completion event (info) */
-        CFE_EVS_SendEvent(FM_RENAME_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: src = %s, tgt = %s", CmdText,
-                          CmdArgs->Source1, CmdArgs->Target);
+        CFE_EVS_SendEvent(FM_RENAME_CMD_INF_EID, CFE_EVS_EventType_INFORMATION, "%s command: src = %s, tgt = %s",
+                          CmdText, CmdArgs->Source1, CmdArgs->Target);
     }
 
     /* Report previous child task activity */
@@ -419,7 +419,7 @@ void FM_ChildDeleteCmd(const FM_ChildQueueEntry_t *CmdArgs)
         FM_GlobalData.ChildCmdCounter++;
 
         /* Send command completion event (info) */
-        CFE_EVS_SendEvent(FM_DELETE_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: file = %s", CmdText,
+        CFE_EVS_SendEvent(FM_DELETE_CMD_INF_EID, CFE_EVS_EventType_INFORMATION, "%s command: file = %s", CmdText,
                           CmdArgs->Source1);
     }
 
@@ -551,13 +551,13 @@ void FM_ChildDeleteAllFilesCmd(FM_ChildQueueEntry_t *CmdArgs)
         OS_DirectoryClose(DirId);
 
         /* Send command completion event (info) */
-        CFE_EVS_SendEvent(FM_DELETE_ALL_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: deleted %d files: dir = %s",
-                          CmdText, (int)DeleteCount, Directory);
+        CFE_EVS_SendEvent(FM_DELETE_ALL_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "%s command: deleted %d files: dir = %s", CmdText, (int)DeleteCount, Directory);
         FM_GlobalData.ChildCmdCounter++;
 
         if (FilesNotDeletedCount > 0)
         {
-            /* If errors occured, report generic event(s) */
+            /* If errors occurred, report generic event(s) */
             CFE_EVS_SendEvent(FM_DELETE_ALL_FILES_ND_WARNING_EID, CFE_EVS_EventType_INFORMATION,
                               "%s command: one or more files could not be deleted. Files may be open : dir = %s",
                               CmdText, Directory);
@@ -566,7 +566,7 @@ void FM_ChildDeleteAllFilesCmd(FM_ChildQueueEntry_t *CmdArgs)
 
         if (DirectoriesSkippedCount > 0)
         {
-            /* If errors occured, report generic event(s) */
+            /* If errors occurred, report generic event(s) */
             CFE_EVS_SendEvent(FM_DELETE_ALL_SKIP_WARNING_EID, CFE_EVS_EventType_INFORMATION,
                               "%s command: one or more directories skipped : dir = %s", CmdText, Directory);
             FM_GlobalData.ChildCmdWarnCounter++;
@@ -610,8 +610,8 @@ void FM_ChildDecompressFileCmd(const FM_ChildQueueEntry_t *CmdArgs)
         FM_GlobalData.ChildCmdCounter++;
 
         /* Send command completion event (info) */
-        CFE_EVS_SendEvent(FM_DECOM_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: src = %s, tgt = %s", CmdText,
-                          CmdArgs->Source1, CmdArgs->Target);
+        CFE_EVS_SendEvent(FM_DECOM_CMD_INF_EID, CFE_EVS_EventType_INFORMATION, "%s command: src = %s, tgt = %s",
+                          CmdText, CmdArgs->Source1, CmdArgs->Target);
     }
 
     /* Report previous child task activity */
@@ -700,8 +700,8 @@ void FM_ChildConcatFilesCmd(const FM_ChildQueueEntry_t *CmdArgs)
 
                         FM_GlobalData.ChildCmdCounter++;
 
-                        /* Send command completion event (debug) */
-                        CFE_EVS_SendEvent(FM_CONCAT_CMD_EID, CFE_EVS_EventType_DEBUG,
+                        /* Send command completion event (info) */
+                        CFE_EVS_SendEvent(FM_CONCAT_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
                                           "%s command: src1 = %s, src2 = %s, tgt = %s", CmdText, CmdArgs->Source1,
                                           CmdArgs->Source2, CmdArgs->Target);
                     }
@@ -915,8 +915,8 @@ void FM_ChildFileInfoCmd(FM_ChildQueueEntry_t *CmdArgs)
 
     FM_GlobalData.ChildCmdCounter++;
 
-    /* Send command completion event (debug) */
-    CFE_EVS_SendEvent(FM_GET_FILE_INFO_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: file = %s", CmdText,
+    /* Send command completion event (info) */
+    CFE_EVS_SendEvent(FM_GET_FILE_INFO_CMD_INF_EID, CFE_EVS_EventType_INFORMATION, "%s command: file = %s", CmdText,
                       CmdArgs->Source1);
 
     /* Report previous child task activity */
@@ -954,7 +954,7 @@ void FM_ChildCreateDirectoryCmd(const FM_ChildQueueEntry_t *CmdArgs)
         FM_GlobalData.ChildCmdCounter++;
 
         /* Send command completion event (info) */
-        CFE_EVS_SendEvent(FM_CREATE_DIR_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: src = %s", CmdText,
+        CFE_EVS_SendEvent(FM_CREATE_DIR_CMD_INF_EID, CFE_EVS_EventType_INFORMATION, "%s command: src = %s", CmdText,
                           CmdArgs->Source1);
     }
 
@@ -1029,7 +1029,7 @@ void FM_ChildDeleteDirectoryCmd(const FM_ChildQueueEntry_t *CmdArgs)
         else
         {
             /* Send command completion event (info) */
-            CFE_EVS_SendEvent(FM_DELETE_DIR_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: src = %s", CmdText,
+            CFE_EVS_SendEvent(FM_DELETE_DIR_CMD_INF_EID, CFE_EVS_EventType_INFORMATION, "%s command: src = %s", CmdText,
                               CmdArgs->Source1);
 
             FM_GlobalData.ChildCmdCounter++;
@@ -1226,8 +1226,8 @@ void FM_ChildDirListPktCmd(const FM_ChildQueueEntry_t *CmdArgs)
         CFE_SB_TransmitMsg(CFE_MSG_PTR(FM_GlobalData.DirListPkt.TelemetryHeader), true);
 
         /* Send command completion event (info) */
-        CFE_EVS_SendEvent(FM_GET_DIR_PKT_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: offset = %d, dir = %s", CmdText,
-                          (int)CmdArgs->DirListOffset, CmdArgs->Source1);
+        CFE_EVS_SendEvent(FM_GET_DIR_PKT_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "%s command: offset = %d, dir = %s", CmdText, (int)CmdArgs->DirListOffset, CmdArgs->Source1);
 
         FM_GlobalData.ChildCmdCounter++;
     }
@@ -1254,8 +1254,8 @@ void FM_ChildSetPermissionsCmd(const FM_ChildQueueEntry_t *CmdArgs)
         FM_GlobalData.ChildCmdCounter++;
 
         /* Send command completion event (info) */
-        CFE_EVS_SendEvent(FM_SET_PERM_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command: file = %s, access = %d", CmdText,
-                          CmdArgs->Source1, (int)CmdArgs->Mode);
+        CFE_EVS_SendEvent(FM_SET_PERM_CMD_INF_EID, CFE_EVS_EventType_INFORMATION, "%s command: file = %s, access = %d",
+                          CmdText, CmdArgs->Source1, (int)CmdArgs->Mode);
     }
     else
     {
@@ -1484,9 +1484,9 @@ void FM_ChildDirListFileLoop(osal_id_t DirId, osal_id_t FileHandle, const char *
     {
         FM_GlobalData.ChildCmdCounter++;
 
-        CFE_EVS_SendEvent(FM_GET_DIR_FILE_CMD_EID, CFE_EVS_EventType_DEBUG,
-                          "%s command: wrote %d of %d names: dir = %s, filename = %s", CmdText, (int)FileEntries,
-                          (int)DirEntries, Directory, Filename);
+        CFE_EVS_SendEvent(FM_GET_DIR_FILE_CMD_INF_EID,
+                          CFE_EVS_EventType_INFORMATION, "%s command: wrote %d of %d names: dir = %s, filename = %s",
+                          CmdText, (int)FileEntries, (int)DirEntries, Directory, Filename);
     }
 }
 

--- a/fsw/src/fm_cmds.c
+++ b/fsw/src/fm_cmds.c
@@ -536,8 +536,8 @@ bool FM_GetOpenFilesCmd(const CFE_SB_Buffer_t *BufPtr)
     CFE_SB_TimeStampMsg(CFE_MSG_PTR(FM_GlobalData.OpenFilesPkt.TelemetryHeader));
     CFE_SB_TransmitMsg(CFE_MSG_PTR(FM_GlobalData.OpenFilesPkt.TelemetryHeader), true);
 
-    /* Send command completion event (debug) */
-    CFE_EVS_SendEvent(FM_GET_OPEN_FILES_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command", CmdText);
+    /* Send command completion event (info) */
+    CFE_EVS_SendEvent(FM_GET_OPEN_FILES_CMD_INF_EID, CFE_EVS_EventType_INFORMATION, "%s command", CmdText);
 
     return true;
 }
@@ -830,8 +830,8 @@ bool FM_MonitorFilesystemSpaceCmd(const CFE_SB_Buffer_t *BufPtr)
         CFE_SB_TimeStampMsg(CFE_MSG_PTR(FM_GlobalData.MonitorReportPkt.TelemetryHeader));
         CFE_SB_TransmitMsg(CFE_MSG_PTR(FM_GlobalData.MonitorReportPkt.TelemetryHeader), true);
 
-        /* Send command completion event (debug) */
-        CFE_EVS_SendEvent(FM_MONITOR_FILESYSTEM_SPACE_CMD_EID, CFE_EVS_EventType_DEBUG, "%s command", CmdText);
+        /* Send command completion event (info) */
+        CFE_EVS_SendEvent(FM_MONITOR_FILESYSTEM_SPACE_CMD_INF_EID, CFE_EVS_EventType_INFORMATION, "%s command", CmdText);
     }
 
     return CommandResult;

--- a/fsw/src/fm_cmds.h
+++ b/fsw/src/fm_cmds.h
@@ -421,7 +421,7 @@ bool FM_SetTableStateCmd(const CFE_SB_Buffer_t *BufPtr);
  *  \retval true  Command successful
  *  \retval false Command not successful
  *
- *  \sa #FM_SET_PERMISSIONS_CC, #FM_SetPermissionsCmd_t, #FM_SET_PERM_CMD_EID, #FM_SET_PERM_ERR_EID
+ *  \sa #FM_SET_PERMISSIONS_CC, #FM_SetPermissionsCmd_t, #FM_SET_PERM_CMD_INF_EID, #FM_SET_PERM_ERR_EID
  */
 bool FM_SetPermissionsCmd(const CFE_SB_Buffer_t *BufPtr);
 

--- a/unit-test/fm_child_tests.c
+++ b/unit-test/fm_child_tests.c
@@ -172,8 +172,8 @@ void Test_FM_ChildProcess_FMCopyCC(void)
 
     UtAssert_STUB_COUNT(OS_cp, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_COPY_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_COPY_CMD_INF_EID);
 }
 
 void Test_FM_ChildProcess_FMMoveCC(void)
@@ -189,8 +189,8 @@ void Test_FM_ChildProcess_FMMoveCC(void)
 
     UtAssert_STUB_COUNT(OS_mv, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_MOVE_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_MOVE_CMD_INF_EID);
 }
 
 void Test_FM_ChildProcess_FMRenameCC(void)
@@ -206,8 +206,8 @@ void Test_FM_ChildProcess_FMRenameCC(void)
 
     UtAssert_STUB_COUNT(OS_rename, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_RENAME_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_RENAME_CMD_INF_EID);
 }
 
 void Test_FM_ChildProcess_FMDeleteCC(void)
@@ -223,8 +223,8 @@ void Test_FM_ChildProcess_FMDeleteCC(void)
 
     UtAssert_STUB_COUNT(OS_remove, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_CMD_INF_EID);
 }
 
 void Test_FM_ChildProcess_FMDeleteAllCC(void)
@@ -347,8 +347,8 @@ void Test_FM_ChildProcess_FMGetFileInfoCC(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_FILE_INFO_STATE_WARNING_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_GET_FILE_INFO_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_GET_FILE_INFO_CMD_INF_EID);
 }
 
 void Test_FM_ChildProcess_FMGetDirListsFileCC(void)
@@ -390,8 +390,8 @@ void Test_FM_ChildProcess_FMGetDirListsPktCC(void)
     UtAssert_STUB_COUNT(CFE_MSG_Init, 1);
     UtAssert_STUB_COUNT(OS_DirectoryClose, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_PKT_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_PKT_CMD_INF_EID);
 }
 
 void Test_FM_ChildProcess_FMSetFilePermCC(void)
@@ -444,8 +444,8 @@ void Test_FM_ChildCopyCmd_OScpIsSuccess(void)
     UT_FM_Child_Cmd_Assert(1, 0, 0, queue_entry.CommandCode);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_COPY_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_COPY_CMD_INF_EID);
 }
 
 void Test_FM_ChildCopyCmd_OScpNotSuccess(void)
@@ -500,8 +500,8 @@ void Test_FM_ChildMoveCmd_OSmvSuccess(void)
 
     UtAssert_STUB_COUNT(OS_mv, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_MOVE_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_MOVE_CMD_INF_EID);
 }
 
 /* ****************
@@ -520,8 +520,8 @@ void Test_FM_ChildRenameCmd_OSRenameSuccess(void)
 
     UtAssert_STUB_COUNT(OS_rename, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_RENAME_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_RENAME_CMD_INF_EID);
 }
 
 void Test_FM_ChildRenameCmd_OSRenameNotSuccess(void)
@@ -559,8 +559,8 @@ void Test_FM_ChildDeleteCmd_OSRemoveSuccess(void)
 
     UtAssert_STUB_COUNT(OS_remove, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_CMD_INF_EID);
 }
 
 void Test_FM_ChildDeleteCmd_OSRemoveNotSuccess(void)
@@ -623,8 +623,8 @@ void Test_FM_ChildDeleteAllFilesCmd_DirReadNotSuccess(void)
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
     UtAssert_STUB_COUNT(OS_DirectoryClose, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_INF_EID);
 }
 
 void Test_FM_ChildDeleteAllFilesCmd_DirEntryThisDirectory(void)
@@ -648,8 +648,8 @@ void Test_FM_ChildDeleteAllFilesCmd_DirEntryThisDirectory(void)
     UtAssert_STUB_COUNT(OS_DirectoryRead, 2);
     UtAssert_STUB_COUNT(FM_GetFilenameState, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_INF_EID);
 }
 
 void Test_FM_ChildDeleteAllFilesCmd_DirEntryParentDirectory(void)
@@ -673,8 +673,8 @@ void Test_FM_ChildDeleteAllFilesCmd_DirEntryParentDirectory(void)
     UtAssert_STUB_COUNT(OS_DirectoryRead, 2);
     UtAssert_STUB_COUNT(FM_GetFilenameState, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_INF_EID);
 }
 
 void Test_FM_ChildDeleteAllFilesCmd_PathFilenameLengthGreaterMaxPthLen(void)
@@ -699,8 +699,8 @@ void Test_FM_ChildDeleteAllFilesCmd_PathFilenameLengthGreaterMaxPthLen(void)
     UtAssert_STUB_COUNT(OS_DirectoryRead, 2);
     UtAssert_STUB_COUNT(FM_GetFilenameState, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_DELETE_ALL_FILES_ND_WARNING_EID);
 }
@@ -727,8 +727,8 @@ void Test_FM_ChildDeleteAllFilesCmd_InvalidFilenameState(void)
     UtAssert_STUB_COUNT(OS_DirectoryRead, 2);
     UtAssert_STUB_COUNT(FM_GetFilenameState, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_DELETE_ALL_FILES_ND_WARNING_EID);
 }
@@ -755,8 +755,8 @@ void Test_FM_ChildDeleteAllFilesCmd_NotInUseFilenameState(void)
     UtAssert_STUB_COUNT(OS_DirectoryRead, 2);
     UtAssert_STUB_COUNT(FM_GetFilenameState, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_DELETE_ALL_FILES_ND_WARNING_EID);
 }
@@ -783,8 +783,8 @@ void Test_FM_ChildDeleteAllFilesCmd_DirectoryFilenameState(void)
     UtAssert_STUB_COUNT(OS_DirectoryRead, 2);
     UtAssert_STUB_COUNT(FM_GetFilenameState, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_DELETE_ALL_SKIP_WARNING_EID);
 }
@@ -811,8 +811,8 @@ void Test_FM_ChildDeleteAllFilesCmd_OpenFilenameState(void)
     UtAssert_STUB_COUNT(OS_DirectoryRead, 2);
     UtAssert_STUB_COUNT(FM_GetFilenameState, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_DELETE_ALL_FILES_ND_WARNING_EID);
 }
@@ -841,8 +841,8 @@ void Test_FM_ChildDeleteAllFilesCmd_ClosedFilename_OSRmNotSuccess(void)
     UtAssert_STUB_COUNT(FM_GetFilenameState, 1);
     UtAssert_STUB_COUNT(OS_remove, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_DELETE_ALL_FILES_ND_WARNING_EID);
 }
@@ -871,8 +871,8 @@ void Test_FM_ChildDeleteAllFilesCmd_ClosedFilename_OSrmSuccess(void)
     UtAssert_STUB_COUNT(OS_remove, 1);
     UtAssert_STUB_COUNT(OS_DirectoryRewind, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_INF_EID);
 }
 
 void Test_FM_ChildDeleteAllFilesCmd_FilenameStateDefaultReturn(void)
@@ -897,8 +897,8 @@ void Test_FM_ChildDeleteAllFilesCmd_FilenameStateDefaultReturn(void)
     UtAssert_STUB_COUNT(OS_DirectoryRead, 2);
     UtAssert_STUB_COUNT(FM_GetFilenameState, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_ALL_CMD_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_DELETE_ALL_FILES_ND_WARNING_EID);
 }
@@ -922,8 +922,8 @@ void Test_FM_ChildDecompressFileCmd_FSDecompressSuccess(void)
 
     UtAssert_STUB_COUNT(FM_Decompress_Impl, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DECOM_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DECOM_CMD_INF_EID);
 }
 
 void Test_FM_ChildDecompressFileCmd_FSDecompressNotSuccess(void)
@@ -1031,8 +1031,8 @@ void Test_FM_ChildConcatFilesCmd_OSReadBytesZero(void)
     UtAssert_STUB_COUNT(OS_remove, 0);
     UtAssert_STUB_COUNT(OS_close, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CONCAT_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CONCAT_CMD_INF_EID);
 }
 
 void Test_FM_ChildConcatFilesCmd_OSReadBytesLessThanZero(void)
@@ -1128,8 +1128,8 @@ void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualIgnoreCRC(void)
 
     UtAssert_STUB_COUNT(OS_OpenCreate, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_FILE_INFO_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_FILE_INFO_CMD_INF_EID);
 }
 
 void Test_FM_ChildFileInfoCmd_FileInfoStateIsNotFileClosed(void)
@@ -1151,8 +1151,8 @@ void Test_FM_ChildFileInfoCmd_FileInfoStateIsNotFileClosed(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_FILE_INFO_STATE_WARNING_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_GET_FILE_INFO_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_GET_FILE_INFO_CMD_INF_EID);
 }
 
 void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualMission8(void)
@@ -1176,8 +1176,8 @@ void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualMission8(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_FILE_INFO_OPEN_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_GET_FILE_INFO_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_GET_FILE_INFO_CMD_INF_EID);
 }
 
 void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualMission16(void)
@@ -1201,8 +1201,8 @@ void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualMission16(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_FILE_INFO_OPEN_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_GET_FILE_INFO_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_GET_FILE_INFO_CMD_INF_EID);
 }
 
 void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualMission32(void)
@@ -1226,8 +1226,8 @@ void Test_FM_ChildFileInfoCmd_FileInfoCRCEqualMission32(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_FILE_INFO_OPEN_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_GET_FILE_INFO_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_GET_FILE_INFO_CMD_INF_EID);
 }
 
 void Test_FM_ChildFileInfoCmd_FileInfoCRCNotEqualToAnyMissionES(void)
@@ -1249,8 +1249,8 @@ void Test_FM_ChildFileInfoCmd_FileInfoCRCNotEqualToAnyMissionES(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_FILE_INFO_TYPE_WARNING_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_GET_FILE_INFO_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_GET_FILE_INFO_CMD_INF_EID);
 }
 
 void Test_FM_ChildFileInfoCmd_OSOpenCreateTrueBytesReadZero(void)
@@ -1274,8 +1274,8 @@ void Test_FM_ChildFileInfoCmd_OSOpenCreateTrueBytesReadZero(void)
     UtAssert_STUB_COUNT(OS_OpenCreate, 1);
     UtAssert_STUB_COUNT(OS_close, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_FILE_INFO_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_FILE_INFO_CMD_INF_EID);
 }
 
 void Test_FM_ChildFileInfoCmd_BytesReadLessThanZero(void)
@@ -1301,8 +1301,8 @@ void Test_FM_ChildFileInfoCmd_BytesReadLessThanZero(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_FILE_INFO_READ_WARNING_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_GET_FILE_INFO_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_GET_FILE_INFO_CMD_INF_EID);
 }
 
 void Test_FM_ChildFileInfoCmd_BytesReadGreaterThanZero(void)
@@ -1329,8 +1329,8 @@ void Test_FM_ChildFileInfoCmd_BytesReadGreaterThanZero(void)
     UtAssert_STUB_COUNT(OS_OpenCreate, 1);
     UtAssert_STUB_COUNT(OS_close, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_FILE_INFO_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_FILE_INFO_CMD_INF_EID);
 }
 
 /* ****************
@@ -1349,8 +1349,8 @@ void Test_FM_ChildCreateDirectoryCmd_OSMkDirSuccess(void)
 
     UtAssert_STUB_COUNT(OS_mkdir, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CREATE_DIR_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_CREATE_DIR_CMD_INF_EID);
 }
 
 void Test_FM_ChildCreateDirectoryCmd_OSMkDirNotSuccess(void)
@@ -1411,8 +1411,8 @@ void Test_FM_ChildDeleteDirectoryCmd_OSDirectoryReadNoSuccess(void)
     UtAssert_STUB_COUNT(OS_DirectoryRead, 1);
     UtAssert_STUB_COUNT(OS_DirectoryClose, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_DIR_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_DIR_CMD_INF_EID);
 }
 
 void Test_FM_ChildDeleteDirectoryCmd_StrCmpThisDirectoryZero(void)
@@ -1433,8 +1433,8 @@ void Test_FM_ChildDeleteDirectoryCmd_StrCmpThisDirectoryZero(void)
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
     UtAssert_STUB_COUNT(OS_DirectoryRead, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_DIR_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_DIR_CMD_INF_EID);
 }
 
 void Test_FM_ChildDeleteDirectoryCmd_StrCmpParentDirectoryZero(void)
@@ -1474,8 +1474,8 @@ void Test_FM_ChildDeleteDirectoryCmd_RemoveTheDirIsTrueRmDirSuccess(void)
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
     UtAssert_STUB_COUNT(OS_DirectoryRead, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_DIR_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_DELETE_DIR_CMD_INF_EID);
 }
 
 void Test_FM_ChildDeleteDirectoryCmd_RemoveDirTrueOSRmDirNotSuccess(void)
@@ -1562,8 +1562,8 @@ void Test_FM_ChildDirListFileCmd_ChildDirListFileInitTrue(void)
     UtAssert_STUB_COUNT(OS_DirectoryClose, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_STUB_COUNT(OS_close, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_FILE_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_FILE_CMD_INF_EID);
 }
 
 /* ****************
@@ -1608,8 +1608,8 @@ void Test_FM_ChildDirListPktCmd_OSDirReadNotSuccess(void)
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
     UtAssert_STUB_COUNT(OS_DirectoryRead, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_PKT_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_PKT_CMD_INF_EID);
 
     ReportPtr = &FM_GlobalData.DirListPkt.Payload;
     UtAssert_UINT32_EQ(ReportPtr->PacketFiles, 0);
@@ -1636,8 +1636,8 @@ void Test_FM_ChildDirListPktCmd_DirEntryNameThisDirectory(void)
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
     UtAssert_STUB_COUNT(OS_DirectoryRead, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_PKT_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_PKT_CMD_INF_EID);
 
     ReportPtr = &FM_GlobalData.DirListPkt.Payload;
     UtAssert_UINT32_EQ(ReportPtr->PacketFiles, 0);
@@ -1664,8 +1664,8 @@ void Test_FM_ChildDirListPktCmd_DirEntryNameParentDirectory(void)
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
     UtAssert_STUB_COUNT(OS_DirectoryRead, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_PKT_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_PKT_CMD_INF_EID);
 
     ReportPtr = &FM_GlobalData.DirListPkt.Payload;
     UtAssert_UINT32_EQ(ReportPtr->PacketFiles, 0);
@@ -1692,8 +1692,8 @@ void Test_FM_ChildDirListPktCmd_DirListOffsetNotExceeded(void)
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
     UtAssert_STUB_COUNT(OS_DirectoryRead, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_PKT_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_PKT_CMD_INF_EID);
 
     ReportPtr = &FM_GlobalData.DirListPkt.Payload;
     UtAssert_UINT32_EQ(ReportPtr->FirstFile, 1);
@@ -1726,8 +1726,8 @@ void Test_FM_ChildDirListPktCmd_DirListOffsetExceeded(void)
     UtAssert_STUB_COUNT(OS_DirectoryOpen, 1);
     UtAssert_STUB_COUNT(OS_DirectoryRead, sizeof(direntry) / sizeof(direntry[0]) + 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_PKT_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_PKT_CMD_INF_EID);
 
     ReportPtr = &FM_GlobalData.DirListPkt.Payload;
     UtAssert_UINT32_EQ(ReportPtr->FirstFile, 0);
@@ -1782,8 +1782,8 @@ void Test_FM_ChildSetPermissionsCmd_OSChmodSuccess(void)
 
     UtAssert_STUB_COUNT(OS_chmod, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_SET_PERM_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_SET_PERM_CMD_INF_EID);
 }
 
 void Test_FM_ChildSetPermissionsCmd_OSChmodNotSuccess(void)
@@ -1920,8 +1920,8 @@ void Test_FM_ChildDirListFileLoop_OSDirReadNotSuccess(void)
     UtAssert_STUB_COUNT(OS_write, 0);
     UtAssert_STUB_COUNT(OS_lseek, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_FILE_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_FILE_CMD_INF_EID);
 
     UtAssert_UINT32_EQ(FM_GlobalData.DirListFileStats.DirEntries, 0);
     UtAssert_UINT32_EQ(FM_GlobalData.DirListFileStats.FileEntries, 0);
@@ -1945,8 +1945,8 @@ void Test_FM_ChildDirListFileLoop_OSDirEntryNameIsThisDirectory(void)
     UtAssert_STUB_COUNT(OS_write, 0);
     UtAssert_STUB_COUNT(OS_lseek, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_FILE_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_FILE_CMD_INF_EID);
 
     UtAssert_UINT32_EQ(FM_GlobalData.DirListFileStats.DirEntries, 0);
     UtAssert_UINT32_EQ(FM_GlobalData.DirListFileStats.FileEntries, 0);
@@ -1970,8 +1970,8 @@ void Test_FM_ChildDirListFileLoop_OSDirEntryNameIsParentDirectory(void)
     UtAssert_STUB_COUNT(OS_write, 0);
     UtAssert_STUB_COUNT(OS_lseek, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_FILE_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_FILE_CMD_INF_EID);
 }
 
 void Test_FM_ChildDirListFileLoop_PathLengthAndEntryLengthGreaterMaxPathLen(void)
@@ -1998,8 +1998,8 @@ void Test_FM_ChildDirListFileLoop_PathLengthAndEntryLengthGreaterMaxPathLen(void
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_FILE_WARNING_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_GET_DIR_FILE_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, FM_GET_DIR_FILE_CMD_INF_EID);
 
     UtAssert_INT32_EQ(FM_GlobalData.DirListFileStats.DirEntries, 1);
     UtAssert_INT32_EQ(FM_GlobalData.DirListFileStats.FileEntries, 0);
@@ -2023,8 +2023,8 @@ void Test_FM_ChildDirListFileLoop_FileEntriesGreaterFMDirListFileEntries(void)
     UtAssert_STUB_COUNT(OS_write, FM_DIR_LIST_FILE_ENTRIES + 1);
     UtAssert_STUB_COUNT(OS_lseek, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_FILE_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_DIR_FILE_CMD_INF_EID);
 
     UtAssert_INT32_EQ(FM_GlobalData.DirListFileStats.DirEntries, entrycnt);
     UtAssert_INT32_EQ(FM_GlobalData.DirListFileStats.FileEntries, FM_DIR_LIST_FILE_ENTRIES);

--- a/unit-test/fm_cmds_tests.c
+++ b/unit-test/fm_cmds_tests.c
@@ -1106,9 +1106,9 @@ void Test_FM_GetOpenFilesCmd_Success(void)
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_OPEN_FILES_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_GET_OPEN_FILES_CMD_INF_EID);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
@@ -1572,9 +1572,9 @@ void Test_FM_MonitorFilesystemSpaceCmd_Success(void)
     UtAssert_BOOL_TRUE(FM_MonitorFilesystemSpaceCmd(&UT_CmdBuf.Buf));
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_MONITOR_FILESYSTEM_SPACE_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_MONITOR_FILESYSTEM_SPACE_CMD_INF_EID);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
@@ -1648,9 +1648,9 @@ void Test_FM_MonitorFilesystemSpaceCmd_ImplCallFails(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_MONITOR_FILESYSTEM_SPACE_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_MONITOR_FILESYSTEM_SPACE_CMD_INF_EID);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult = strncmp(ExpectedEventString2, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
@@ -1690,9 +1690,9 @@ void Test_FM_MonitorFilesystemSpaceCmd_NotImpl(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_MONITOR_FILESYSTEM_SPACE_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_MONITOR_FILESYSTEM_SPACE_CMD_INF_EID);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult = strncmp(ExpectedEventString2, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 

--- a/unit-test/fm_dispatch_tests.c
+++ b/unit-test/fm_dispatch_tests.c
@@ -495,36 +495,36 @@ void add_FM_ProcessCmd_tests(void)
                "Test_FM_ProcessCmd_DecompressFileCCReturn");
 
     UtTest_Add(Test_FM_ProcessCmd_ConcatFilesCCReturn, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_PRocessCmd_ConcatFilesCCReturn");
+               "Test_FM_ProcessCmd_ConcatFilesCCReturn");
 
     UtTest_Add(Test_FM_ProcessCmd_GetFileInfoCCReturn, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_PRocessCmd_GetFileInfoCCReturn");
+               "Test_FM_ProcessCmd_GetFileInfoCCReturn");
 
     UtTest_Add(Test_FM_ProcessCmd_GetOpenFilesCCReturn, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_PRocessCmd_GetOpenFilesCCReturn");
+               "Test_FM_ProcessCmd_GetOpenFilesCCReturn");
 
     UtTest_Add(Test_FM_ProcessCmd_CreateDirectoryCCReturn, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_PRocessCmd_CreateDirectoryCCReturn");
+               "Test_FM_ProcessCmd_CreateDirectoryCCReturn");
 
     UtTest_Add(Test_FM_ProcessCmd_DeleteDirectoryCCReturn, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_PRocessCmd_DeleteDirectoryCCReturn");
+               "Test_FM_ProcessCmd_DeleteDirectoryCCReturn");
 
     UtTest_Add(Test_FM_ProcessCmd_GetDirListFileCCReturn, FM_Test_Setup, FM_Test_Teardown,
                "Test_FM_ProcessCmd_GetDirListFIleCCReturn");
 
     UtTest_Add(Test_FM_ProcessCmd_GetDirListPktCCReturn, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_PRocessCmd_GetDirListPktCCReturn");
+               "Test_FM_ProcessCmd_GetDirListPktCCReturn");
 
     UtTest_Add(Test_FM_ProcessCmd_MonitorFilesystemSpaceCCReturn, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_PRocessCmd_MonitorFilesystemSpaceCCReturn");
+               "Test_FM_ProcessCmd_MonitorFilesystemSpaceCCReturn");
 
     UtTest_Add(Test_FM_ProcessCmd_SetTableStateCCReturn, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_PRocessCmd_SetTableStateCCReturn");
+               "Test_FM_ProcessCmd_SetTableStateCCReturn");
 
     UtTest_Add(Test_FM_ProcessCmd_SetPermissionsCCReturn, FM_Test_Setup, FM_Test_Teardown,
-               "Test_FM_PRocessCmd_SetPermissionsCCReturn");
+               "Test_FM_ProcessCmd_SetPermissionsCCReturn");
 
-    UtTest_Add(Test_FM_ProcessCmd_DefaultReturn, FM_Test_Setup, FM_Test_Teardown, "Test_FM_PRocessCmd_DefaultReturn");
+    UtTest_Add(Test_FM_ProcessCmd_DefaultReturn, FM_Test_Setup, FM_Test_Teardown, "Test_FM_ProcessCmd_DefaultReturn");
 }
 
 /* ********************************

--- a/unit-test/utilities/fm_test_utils.c
+++ b/unit-test/utilities/fm_test_utils.c
@@ -22,8 +22,6 @@
  *   Test utility implementations
  */
 #include <stdlib.h>
-#include <math.h>
-#include <time.h>
 #include "fm_app.h"
 
 /* UT includes */


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #114
  - Updates successful command events to `INFO` type rather than `DEBUG` as per the nominal pattern across cFE/cFS 

- Also fixed a couple of typos and removed some headers no longer needed in fm_test_utils.c

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
These commands will now be defined as `INFO` type and will not be filtered out when `DEBUG` events are turned off.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt