### PR TITLE
Fix #117, Replaces strncpy and strlen

### DIFF
--- a/fsw/src/fm_cmd_utils.c
+++ b/fsw/src/fm_cmd_utils.c
@@ -508,7 +508,7 @@ void FM_AppendPathSep(char *Directory, uint32 BufferSize)
     */
     size_t StringLength = 0;
 
-    StringLength = strlen(Directory);
+    StringLength = OS_strnlen(Directory, OS_MAX_PATH_LEN);
 
     /* Do nothing if string already ends with a path separator */
     if ((StringLength != 0) && (Directory[StringLength - 1] != '/'))
@@ -577,9 +577,8 @@ CFE_Status_t FM_GetDirectorySpaceEstimate(const char *Directory, uint64 *BlockCo
     TotalBytes = 0;
 
     memset(&DirEntry, 0, sizeof(DirEntry));
-    strncpy(FullPath, Directory, sizeof(FullPath) - 1);
-    FullPath[sizeof(FullPath) - 1] = 0;
-    DirLen                         = strlen(FullPath);
+    snprintf(FullPath, sizeof(FullPath), "%s", Directory);
+    DirLen = OS_strnlen(FullPath, OS_MAX_PATH_LEN);
     if (DirLen < (sizeof(FullPath) - 2))
     {
         FullPath[DirLen] = '/';
@@ -607,7 +606,7 @@ CFE_Status_t FM_GetDirectorySpaceEstimate(const char *Directory, uint64 *BlockCo
         /* Read each directory entry and stat the files */
         while (OS_DirectoryRead(DirId, &DirEntry) == OS_SUCCESS)
         {
-            strncpy(&FullPath[DirLen], OS_DIRENTRY_NAME(DirEntry), sizeof(FullPath) - DirLen - 1);
+            snprintf(&FullPath[DirLen], sizeof(FullPath) - DirLen, "%s", OS_DIRENTRY_NAME(DirEntry));
 
             OS_Status = OS_stat(FullPath, &FileStat);
             if (OS_Status != OS_SUCCESS)

--- a/fsw/src/fm_cmds.c
+++ b/fsw/src/fm_cmds.c
@@ -387,10 +387,8 @@ bool FM_DecompressFileCmd(const CFE_SB_Buffer_t *BufPtr)
 
         /* Set handshake queue command args */
         CmdArgs->CommandCode = FM_DECOMPRESS_FILE_CC;
-        strncpy(CmdArgs->Source1, CmdPtr->Source, OS_MAX_PATH_LEN - 1);
-        CmdArgs->Source1[OS_MAX_PATH_LEN - 1] = '\0';
-        strncpy(CmdArgs->Target, CmdPtr->Target, OS_MAX_PATH_LEN - 1);
-        CmdArgs->Target[OS_MAX_PATH_LEN - 1] = '\0';
+        snprintf(CmdArgs->Source1, OS_MAX_PATH_LEN, "%s", CmdPtr->Source);
+        snprintf(CmdArgs->Target, OS_MAX_PATH_LEN, "%s", CmdPtr->Target);
 
         /* Invoke lower priority child task */
         FM_InvokeChildTask();
@@ -831,7 +829,8 @@ bool FM_MonitorFilesystemSpaceCmd(const CFE_SB_Buffer_t *BufPtr)
         CFE_SB_TransmitMsg(CFE_MSG_PTR(FM_GlobalData.MonitorReportPkt.TelemetryHeader), true);
 
         /* Send command completion event (info) */
-        CFE_EVS_SendEvent(FM_MONITOR_FILESYSTEM_SPACE_CMD_INF_EID, CFE_EVS_EventType_INFORMATION, "%s command", CmdText);
+        CFE_EVS_SendEvent(FM_MONITOR_FILESYSTEM_SPACE_CMD_INF_EID, CFE_EVS_EventType_INFORMATION, "%s command",
+                          CmdText);
     }
 
     return CommandResult;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/FM/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #117, Adds snprintf to lines that previously had strncpy. snprintf is preferable for its guarenteed null-termination.

**Testing performed**
N/A

**Expected behavior changes**
N/A

**System(s) tested on**
N/A

**Additional context**
Depends on https://github.com/nasa/osal/pull/1465

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage Systems
