### PR TITLE
Fix #118, Standardize command responses

### DIFF
--- a/fsw/inc/fm_events.h
+++ b/fsw/inc/fm_events.h
@@ -217,10 +217,7 @@
 /**
  * \brief FM Reset Counters Command Event ID
  *
- *  \par Type: DEBUG
- *
- *  This event is type debug because the command resets housekeeping
- *  telemetry counters that also signal the completion of the command.
+ *  \par Type: INFORMATION
  *
  *  \par Cause
  *

--- a/fsw/inc/fm_msgdefs.h
+++ b/fsw/inc/fm_msgdefs.h
@@ -75,7 +75,7 @@
  *
  *  \par Command Success Verification
  *       - Command counters will be set to zero (see description)
- *       - Debug event #FM_RESET_INF_EID will be sent
+ *       - Informational event #FM_RESET_INF_EID will be sent
  *
  *  \par Command Error Conditions
  *       - Invalid command packet length

--- a/fsw/src/fm_cmds.c
+++ b/fsw/src/fm_cmds.c
@@ -81,7 +81,7 @@ bool FM_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
     FM_GlobalData.ChildCmdWarnCounter = 0;
 
     /* Send command completion event (debug) */
-    CFE_EVS_SendEvent(FM_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "%s command", CmdText);
+    CFE_EVS_SendEvent(FM_RESET_INF_EID, CFE_EVS_EventType_INFORMATION, "%s command", CmdText);
 
     return true;
 }

--- a/unit-test/fm_cmds_tests.c
+++ b/unit-test/fm_cmds_tests.c
@@ -116,7 +116,7 @@ void Test_FM_ResetCountersCmd_Success(void)
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, FM_RESET_INF_EID);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #118
  - `RESET` command changed to `INFO` type

As per the [discussion](https://github.com/nasa/FM/issues/118#issuecomment-2200423651) in the issue, most of the first list were already fixed, and the 2nd list I have left alone to maintain consistency - of the 8 'partial success' events that increment the `ChildCmdWarnCounter`, all are `INFORMATION` type, except `FM_GET_FILE_INFO_OPEN_ERR_EID` which is of `ERROR` type (perhaps need a separate issue to align this).

- Note: will need to rebase this if #60 is merged first

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
As above.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt