### PR TITLE
Fix #123, declare FilenameState as uint32

### DIFF
--- a/fsw/src/fm_cmds.c
+++ b/fsw/src/fm_cmds.c
@@ -911,7 +911,7 @@ bool FM_SetPermissionsCmd(const CFE_SB_Buffer_t *BufPtr)
     FM_ChildQueueEntry_t *CmdArgs       = NULL;
     const char *          CmdText       = "Set Permissions";
     bool                  CommandResult = true;
-    bool                  FilenameState = FM_NAME_IS_INVALID;
+    uint32                FilenameState = FM_NAME_IS_INVALID;
 
     const FM_FilenameAndMode_Payload_t *CmdPtr = FM_GET_CMD_PAYLOAD(BufPtr, FM_SetPermissionsCmd_t);
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #123 

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
No change with current logic - but avoids future issues if `FM_SetPermissionsCmd` is updated.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt