### PR TITLE
Fix CodeSonar Uninitialized Variable warning

### DIFF
--- a/fsw/src/fm_cmd_utils.c
+++ b/fsw/src/fm_cmd_utils.c
@@ -537,6 +537,8 @@ CFE_Status_t FM_GetVolumeFreeSpace(const char *FileSys, uint64 *BlockCount, uint
     osal_status_t OS_Status;
     CFE_Status_t  Result;
 
+    memset(&FileStats, 0, sizeof(FileStats));
+
     /* Get file system free space */
     OS_Status = OS_FileSysStatVolume(FileSys, &FileStats);
     if (OS_Status == OS_SUCCESS)


### PR DESCRIPTION
Location: fsw/src/fm_cmd_utils.c:544
Function: FM_GetVolumeFreeSpace
Rule: Uninitialized Variable
Level: error
Rank: 62.739559173583984/100

Description:
FileStats was not initialized. - FileStats was defined at fm_cmd_utils.c:536. The issue can occur if the highlighted code executes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Checklist (Please check before submitting)**

* [ ] I reviewed the [Contributing Guide](https://github.com/nasa/FM/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
- Include explicitly what issue it addresses [e.g. Fixes #X]

**Testing performed**
Steps taken to test the contribution:
1. Build steps '...'
2. Execution steps '...'

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: xxx (if applicable)
 - Behavior Change: xxx (if applicable)
 - Or no impact to behavior

**System(s) tested on**
 - Hardware: [e.g. PC, SP0, MCP750]
 - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
 - Note CLA's apply to software contributions.
