### PR TITLE
fm: handle all CFE_TBL_GetAddress failure codes (not just NEVER_LOADED)

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,6 +1,5 @@
 name: Static Analysis
 
-# Run on all push and pull requests
 on:
   push:
     branches:
@@ -16,4 +15,6 @@ on:
 jobs:
   static-analysis:
     name: Static Analysis
-    uses: nasa/cFS/.github/workflows/app-static-analysis-reusable.yml@dev
+    uses: nasa/cFS/.github/workflows/static-analysis-reusable.yml@dev
+    with:
+      source-dir: 'source/fsw'

--- a/fsw/src/fm_cmds.c
+++ b/fsw/src/fm_cmds.c
@@ -861,8 +861,14 @@ CFE_Status_t FM_MonitorFilesystemSpaceCmd(const FM_MonitorFilesystemSpaceCmd_t *
     /* Acquire pointer to file system free space table, also locks table */
     Status = CFE_TBL_GetAddress((void *)&FM_AppData.MonitorTablePtr, FM_AppData.MonitorTableHandle);
 
-    /* Verify that we have a pointer to the file system table data */
-    if (Status == CFE_TBL_ERR_NEVER_LOADED)
+    /*
+    ** Per cfe_tbl.h, CFE_TBL_GetAddress leaves the table pointer undefined on
+    ** any non-success return. Only CFE_SUCCESS and CFE_TBL_INFO_UPDATED set
+    ** the pointer. Prior versions only handled CFE_TBL_ERR_NEVER_LOADED and
+    ** would dereference an undefined pointer on _INVALID_HANDLE / _NO_ACCESS /
+    ** CFE_ES_ERR_RESOURCEID_NOT_VALID / CFE_TBL_BAD_ARGUMENT.
+    */
+    if (Status != CFE_SUCCESS && Status != CFE_TBL_INFO_UPDATED)
     {
         /* Make sure we don't try to use the empty table buffer */
         FM_AppData.MonitorTablePtr = NULL;
@@ -974,7 +980,14 @@ CFE_Status_t FM_SetTableStateCmd(const FM_SetTableStateCmd_t *Msg)
 
     /* Acquire pointer to file system free space table */
     Status = CFE_TBL_GetAddress((void *)&FM_AppData.MonitorTablePtr, FM_AppData.MonitorTableHandle);
-    if (Status == CFE_TBL_ERR_NEVER_LOADED)
+    /*
+    ** Per cfe_tbl.h, CFE_TBL_GetAddress leaves the table pointer undefined on
+    ** any non-success return. Only CFE_SUCCESS and CFE_TBL_INFO_UPDATED set
+    ** the pointer. Prior versions only handled CFE_TBL_ERR_NEVER_LOADED and
+    ** would dereference an undefined pointer on _INVALID_HANDLE / _NO_ACCESS /
+    ** CFE_ES_ERR_RESOURCEID_NOT_VALID / CFE_TBL_BAD_ARGUMENT.
+    */
+    if (Status != CFE_SUCCESS && Status != CFE_TBL_INFO_UPDATED)
     {
         /* Make sure we don't try to use the empty table buffer */
         FM_AppData.MonitorTablePtr = NULL;

--- a/fsw/src/fm_table_utils.c
+++ b/fsw/src/fm_table_utils.c
@@ -55,7 +55,9 @@ CFE_Status_t FM_TableInit(void)
     if (Status == CFE_SUCCESS)
     {
         /* Make an attempt to load the default table data - OK if this fails */
-        CFE_TBL_Load(FM_AppData.MonitorTableHandle, CFE_TBL_SRC_FILE, FM_TABLE_DEF_NAME);
+        /* SAD: Suppress Ignored Return Value warning from CodeSonar.  CFE_TBL_Load() will send event message if
+         * there is any error */
+        (void)CFE_TBL_Load(FM_AppData.MonitorTableHandle, CFE_TBL_SRC_FILE, FM_TABLE_DEF_NAME);
 
         /* Allow cFE a chance to dump, update, etc. */
         FM_AcquireTablePointers();

--- a/fsw/src/fm_table_utils.c
+++ b/fsw/src/fm_table_utils.c
@@ -213,9 +213,16 @@ void FM_AcquireTablePointers(void)
     /* Acquire pointer to file system free space table */
     Status = CFE_TBL_GetAddress((void *)&FM_AppData.MonitorTablePtr, FM_AppData.MonitorTableHandle);
 
-    if (Status == CFE_TBL_ERR_NEVER_LOADED)
+    /*
+    ** Per cfe_tbl.h, CFE_TBL_GetAddress leaves the table pointer undefined on
+    ** any non-success return (CFE_TBL_ERR_NEVER_LOADED, _INVALID_HANDLE,
+    ** _NO_ACCESS, CFE_ES_ERR_RESOURCEID_NOT_VALID, CFE_TBL_BAD_ARGUMENT).
+    ** Only CFE_SUCCESS and CFE_TBL_INFO_UPDATED set the pointer. NULL out
+    ** the local copy on any other return so callers see a clean NULL rather
+    ** than a stale or undefined pointer.
+    */
+    if (Status != CFE_SUCCESS && Status != CFE_TBL_INFO_UPDATED)
     {
-        /* Make sure we don't try to use the empty table buffer */
         FM_AppData.MonitorTablePtr = NULL;
     }
 }


### PR DESCRIPTION
## Summary

Three call sites in FM check only `Status == CFE_TBL_ERR_NEVER_LOADED` after `CFE_TBL_GetAddress()` and dereference `FM_AppData.MonitorTablePtr` in the `else` branch. Per [`cfe_tbl.h`](https://github.com/nasa/cFE/blob/main/modules/core_api/fsw/inc/cfe_tbl.h), the pointer is *undefined* on any of the other four documented failure codes — `CFE_TBL_ERR_INVALID_HANDLE`, `CFE_TBL_ERR_NO_ACCESS`, `CFE_ES_ERR_RESOURCEID_NOT_VALID`, `CFE_TBL_BAD_ARGUMENT` — so those paths reach an undefined-pointer deref.

Affected sites:

| File | Function | Behaviour on non-`NEVER_LOADED` error |
|---|---|---|
| `fsw/src/fm_cmds.c` | `FM_MonitorFilesystemSpaceCmd` (line 855) | reads `FM_AppData.MonitorTablePtr->Entries` |
| `fsw/src/fm_cmds.c` | `FM_SetTableStateCmd` (line 967) | reads `FM_AppData.MonitorTablePtr->Entries[Index].Type` and writes `.Enabled` |
| `fsw/src/fm_table_utils.c` | `FM_AcquireTablePointers` (line 206) | leaves stale pointer for later callers |

This is the same defense-in-depth shape as nasa/MM#116 (DataSize switch with no default case) — a `switch` / `if` that covers some but not all of the failure modes of an upstream API.

## Change

At all three sites, invert the predicate: only `CFE_SUCCESS` and `CFE_TBL_INFO_UPDATED` are documented to set the pointer; everything else NULLs it (and for the two command handlers, also flips `CommandResult` false and emits the existing `*_TBL_ERR_EID` error event so the ground operator sees the failure).

```diff
- if (Status == CFE_TBL_ERR_NEVER_LOADED)
+ if (Status != CFE_SUCCESS && Status != CFE_TBL_INFO_UPDATED)
```

## Provenance

Surfaced by scj-hunt + Gigi ATTEND on a fresh ingest of FM `v1.2.0` into the `cfs_apps_fm_v01` fiber bundle. `FM_SetTableStateCmd` was the rank-1 hit at risk_score 8.8; drilling its structural twins surfaced the matching pattern in the other two sites. scj-hunt is open source at [nurdymuny/shadow-clone-jutsu](https://github.com/nurdymuny/shadow-clone-jutsu).

## Test plan

- [ ] Build under existing CI (no new symbols, no new headers)
- [ ] Mock-fault `CFE_TBL_GetAddress` with `CFE_TBL_ERR_INVALID_HANDLE`, observe `FM_SET_TABLE_STATE_TBL_ERR_EID` / `FM_GET_FREE_SPACE_TBL_ERR_EID` emitted instead of the prior undefined-pointer deref. Happy to add a unit test for this if reviewers want.
