### PR TITLE
Fix #146, Add Null Terminator for FileName in FM_GetDirListFileCmd

### DIFF
--- a/fsw/src/fm_cmds.c
+++ b/fsw/src/fm_cmds.c
@@ -736,7 +736,8 @@ CFE_Status_t FM_GetDirListFileCmd(const FM_GetDirListFileCmd_t *Msg)
         }
         else
         {
-            memcpy(Filename, CmdPtr->OutputFilePath, sizeof(Filename));
+            strncpy(Filename, CmdPtr->OutputFilePath, sizeof(Filename) - 1);
+            Filename[sizeof(Filename) - 1] = '\0';
         }
 
         /* Note: it is OK for this file to overwrite a previous version of the file */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/FM/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #146 

**Testing performed**
Reran the internal static code analysis to ensure warning was resolved. Used the following commands to build:

```
git clone https://github.com/nasa/cFS.git
cd cFS
git submodule init
git submodule update
cp -f ./cfe/cmake/Makefile.sample Makefile
rm -rf sample_defs && cp -r ./cfe/cmake/sample_defs sample_defs
```
Update sample_defs/targets.cmake
```
LIST(APPEND MISSION_GLOBAL_APPLIST fm)
```
Run make prep and install
```
make SIMULATION=native OMIT_DEPRECATED=false BUILDTYPE=debug ENABLE_UNIT_TESTS=false CMAKE_EXPORT_COMPILE_COMMANDS=ON MISSIONCONFIG=sample prep
make install
```

**Expected behavior changes**
Resolves static code analysis warning of non-null-terminated-string

**System(s) tested on**
Internal static code analysis tool, RedHat, cFS dev

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH.