### PR TITLE
Fix #149, Remove Dead Functions

### DIFF
--- a/unit-test/stubs/fm_cmd_utils_handlers.c
+++ b/unit-test/stubs/fm_cmd_utils_handlers.c
@@ -43,12 +43,6 @@ static void UT_fm_cmd_utils_bool_conversion(UT_EntryKey_t FuncKey, const UT_Stub
 }
 
 /*------------------------------------------------------------*/
-void UT_DefaultHandler_FM_IsValidCmdPktLength(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
-{
-    UT_fm_cmd_utils_bool_conversion(FuncKey, Context);
-}
-
-/*------------------------------------------------------------*/
 void UT_DefaultHandler_FM_VerifyChildTask(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
     UT_fm_cmd_utils_bool_conversion(FuncKey, Context);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #149

**Testing performed**
Ran the native_std commands which includes prep, install, runtest, and lcov. Compared these lcov results against the unchanged cFS bundle and found no changes. Ran the old build commands with unit tests enabled to ensure that the internal static code analysis tool no longer flags these functions. Also ran the bundle with -Wunused flags which only flagged unrelated macros.

**Expected behavior changes**
Removes UT_DefaultHandler_FM_IsValidCmdPktLength

**System(s) tested on**
RedHat, cFS dev

**Additional context**
Lcov bundle results using native_std:
```
Overall coverage rate:
  lines......: 99.2% (30304 of 30537 lines)
  functions..: 99.2% (2428 of 2447 functions)
  branches...: no data found
```
Lcov bundle results using the old build commands:
```
Overall coverage rate:
  lines......: 99.2% (30167 of 30396 lines)
  functions..: 99.2% (2417 of 2436 functions)
  branches...: 98.7% (12931 of 13095 branches)
```

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH.
