### PR TITLE
Fix #152, remove table pointer global and simplify

### DIFF
--- a/fsw/src/fm_app.h
+++ b/fsw/src/fm_app.h
@@ -49,14 +49,13 @@ typedef struct
  */
 typedef struct
 {
-    FM_MonitorTable_t *MonitorTablePtr;    /** \brief File System Table Pointer */
-    CFE_TBL_Handle_t   MonitorTableHandle; /** \brief File System Table Handle */
-    CFE_SB_PipeId_t    CmdPipe;            /** \brief cFE software bus command pipe */
-    CFE_ES_TaskId_t    ChildTaskID;        /** \brief Child task ID */
-    osal_id_t          ChildSemaphore;     /** \brief Child task wakeup counting semaphore */
-    osal_id_t          ChildQueueCountSem; /** \brief Child queue counter mutex semaphore */
-    uint8              ChildWriteIndex;    /** \brief Array index for next write to command args */
-    uint8              ChildReadIndex;     /** \brief Array index for next read from command args */
+    CFE_TBL_Handle_t MonitorTableHandle; /** \brief File System Table Handle */
+    CFE_SB_PipeId_t  CmdPipe;            /** \brief cFE software bus command pipe */
+    CFE_ES_TaskId_t  ChildTaskID;        /** \brief Child task ID */
+    osal_id_t        ChildSemaphore;     /** \brief Child task wakeup counting semaphore */
+    osal_id_t        ChildQueueCountSem; /** \brief Child queue counter mutex semaphore */
+    uint8            ChildWriteIndex;    /** \brief Array index for next write to command args */
+    uint8            ChildReadIndex;     /** \brief Array index for next read from command args */
 
     uint8 Spare8a; /** \brief Placeholder for unused command warning counter */
     uint8 Spare8b; /** \brief Structure alignment spare */

--- a/fsw/src/fm_cmds.c
+++ b/fsw/src/fm_cmds.c
@@ -855,24 +855,26 @@ CFE_Status_t FM_MonitorFilesystemSpaceCmd(const FM_MonitorFilesystemSpaceCmd_t *
     uint32       i;
     int32        OpResult;
     CFE_Status_t Status;
+    void        *TablePtr;
 
     const FM_MonitorTableEntry_t *MonitorPtr;
     FM_MonitorReportEntry_t      *ReportPtr;
 
     /* Acquire pointer to file system free space table, also locks table */
-    Status = CFE_TBL_GetAddress((void *)&FM_AppData.MonitorTablePtr, FM_AppData.MonitorTableHandle);
+    Status = CFE_TBL_GetAddress(&TablePtr, FM_AppData.MonitorTableHandle);
 
     /* Verify that we have a pointer to the file system table data */
-    if (Status == CFE_TBL_ERR_NEVER_LOADED)
+    if (Status < CFE_SUCCESS)
     {
         /* Make sure we don't try to use the empty table buffer */
-        FM_AppData.MonitorTablePtr = NULL;
+        TablePtr = NULL;
 
         CommandResult = false;
         CFE_EVS_SendEvent(FM_GET_FREE_SPACE_TBL_ERR_EID,
                           CFE_EVS_EventType_ERROR,
-                          "%s error: file system free space table is not loaded",
-                          CmdText);
+                          "%s error: file system free space table unavailable: status=%08x",
+                          CmdText,
+                          (unsigned int)Status);
     }
     else
     {
@@ -882,7 +884,7 @@ CFE_Status_t FM_MonitorFilesystemSpaceCmd(const FM_MonitorFilesystemSpaceCmd_t *
                      sizeof(FM_MonitorReportPkt_t));
 
         /* Process enabled file system table entries */
-        MonitorPtr = FM_AppData.MonitorTablePtr->Entries;
+        MonitorPtr = TablePtr;
         ReportPtr  = FM_AppData.MonitorReportPkt.Payload.FileSys;
         for (i = 0; i < FM_TABLE_ENTRY_COUNT; i++)
         {
@@ -942,9 +944,6 @@ CFE_Status_t FM_MonitorFilesystemSpaceCmd(const FM_MonitorFilesystemSpaceCmd_t *
 
         /* Release pointer to file system free space table */
         CFE_TBL_ReleaseAddress(FM_AppData.MonitorTableHandle);
-
-        /* Prevent table pointer use while released */
-        FM_AppData.MonitorTablePtr = NULL;
     }
 
     if (CommandResult == true)
@@ -967,27 +966,16 @@ CFE_Status_t FM_MonitorFilesystemSpaceCmd(const FM_MonitorFilesystemSpaceCmd_t *
 
 CFE_Status_t FM_SetTableStateCmd(const FM_SetTableStateCmd_t *Msg)
 {
-    const char  *CmdText       = "Set Table State";
-    bool         CommandResult = true;
-    CFE_Status_t Status;
+    const char             *CmdText       = "Set Table State";
+    bool                    CommandResult = true;
+    CFE_Status_t            Status;
+    void                   *TablePtr;
+    FM_MonitorTableEntry_t *MonitorPtr;
 
     const FM_SetTableStateCmd_Payload_t *CmdPtr = &Msg->Payload;
 
-    /* Acquire pointer to file system free space table */
-    Status = CFE_TBL_GetAddress((void *)&FM_AppData.MonitorTablePtr, FM_AppData.MonitorTableHandle);
-    if (Status == CFE_TBL_ERR_NEVER_LOADED)
-    {
-        /* Make sure we don't try to use the empty table buffer */
-        FM_AppData.MonitorTablePtr = NULL;
-
-        /* File system table has not been loaded */
-        CommandResult = false;
-        CFE_EVS_SendEvent(FM_SET_TABLE_STATE_TBL_ERR_EID,
-                          CFE_EVS_EventType_ERROR,
-                          "%s error: file system free space table is not loaded",
-                          CmdText);
-    }
-    else if (CmdPtr->Index >= FM_TABLE_ENTRY_COUNT)
+    /* do the basic command checks first before getting the address */
+    if (CmdPtr->Index >= FM_TABLE_ENTRY_COUNT)
     {
         /* Table index argument is out of range */
         CommandResult = false;
@@ -1009,39 +997,58 @@ CFE_Status_t FM_SetTableStateCmd(const FM_SetTableStateCmd_t *Msg)
                           CmdText,
                           (int)CmdPtr->State);
     }
-    else if (FM_AppData.MonitorTablePtr->Entries[CmdPtr->Index].Type == FM_MonitorTableEntry_Type_UNUSED)
-    {
-        /* Current table entry state must not be unused */
-        CommandResult = false;
-
-        CFE_EVS_SendEvent(FM_SET_TABLE_STATE_UNUSED_ERR_EID,
-                          CFE_EVS_EventType_ERROR,
-                          "%s error: cannot modify unused table entry: index = %d",
-                          CmdText,
-                          (int)CmdPtr->Index);
-    }
     else
     {
-        /* Update the table entry state as commanded */
-        FM_AppData.MonitorTablePtr->Entries[CmdPtr->Index].Enabled = CmdPtr->State;
+        /* Now we need the table */
+        /* Acquire pointer to file system free space table */
+        Status = CFE_TBL_GetAddress(&TablePtr, FM_AppData.MonitorTableHandle);
+        if (Status < CFE_SUCCESS)
+        {
+            /* File system table has not been loaded */
+            CommandResult = false;
+            CFE_EVS_SendEvent(FM_SET_TABLE_STATE_TBL_ERR_EID,
+                              CFE_EVS_EventType_ERROR,
+                              "%s error: file system free space table unavailable: status=%08x",
+                              CmdText,
+                              (unsigned int)Status);
+        }
+        else
+        {
+            MonitorPtr  = TablePtr;
+            MonitorPtr += CmdPtr->Index; /* move to the specified index (already validated) */
 
-        /* Notify cFE that we have modified the table data */
-        CFE_TBL_Modified(FM_AppData.MonitorTableHandle);
+            if (MonitorPtr->Type == FM_MonitorTableEntry_Type_UNUSED)
+            {
+                /* Current table entry state must not be unused */
+                CommandResult = false;
 
-        /* Send command completion event (info) */
-        CFE_EVS_SendEvent(FM_SET_TABLE_STATE_CMD_EID,
-                          CFE_EVS_EventType_INFORMATION,
-                          "%s command: index = %d, state = %d",
-                          CmdText,
-                          (int)CmdPtr->Index,
-                          (int)CmdPtr->State);
+                CFE_EVS_SendEvent(FM_SET_TABLE_STATE_UNUSED_ERR_EID,
+                                  CFE_EVS_EventType_ERROR,
+                                  "%s error: cannot modify unused table entry: index = %d",
+                                  CmdText,
+                                  (int)CmdPtr->Index);
+            }
+            else
+            {
+                /* Update the table entry state as commanded */
+                MonitorPtr->Enabled = CmdPtr->State;
+
+                /* Notify cFE that we have modified the table data */
+                CFE_TBL_Modified(FM_AppData.MonitorTableHandle);
+
+                /* Send command completion event (info) */
+                CFE_EVS_SendEvent(FM_SET_TABLE_STATE_CMD_EID,
+                                  CFE_EVS_EventType_INFORMATION,
+                                  "%s command: index = %d, state = %d",
+                                  CmdText,
+                                  (int)CmdPtr->Index,
+                                  (int)CmdPtr->State);
+            }
+
+            /* Release pointer to file system free space table */
+            CFE_TBL_ReleaseAddress(FM_AppData.MonitorTableHandle);
+        }
     }
-
-    /* Release pointer to file system free space table */
-    CFE_TBL_ReleaseAddress(FM_AppData.MonitorTableHandle);
-
-    /* Prevent table pointer use while released */
-    FM_AppData.MonitorTablePtr = NULL;
 
     if (CommandResult == true)
     {

--- a/fsw/src/fm_table_utils.c
+++ b/fsw/src/fm_table_utils.c
@@ -42,9 +42,6 @@ CFE_Status_t FM_TableInit(void)
 {
     CFE_Status_t Status;
 
-    /* Initialize file system free space table pointer */
-    FM_AppData.MonitorTablePtr = NULL;
-
     /* Register the file system free space table - this must succeed! */
     Status = CFE_TBL_Register(&FM_AppData.MonitorTableHandle,
                               FM_TABLE_CFE_NAME,
@@ -58,9 +55,6 @@ CFE_Status_t FM_TableInit(void)
         /* SAD: Suppress Ignored Return Value warning from CodeSonar.  CFE_TBL_Load() will send event message if
          * there is any error */
         (void)CFE_TBL_Load(FM_AppData.MonitorTableHandle, CFE_TBL_SRC_FILE, FM_TABLE_DEF_NAME);
-
-        /* Allow cFE a chance to dump, update, etc. */
-        FM_AcquireTablePointers();
     }
 
     return Status;
@@ -195,42 +189,4 @@ CFE_Status_t FM_ValidateTable(FM_MonitorTable_t *TablePtr)
     }
 
     return Result;
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM table function -- acquire table data pointer                 */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void FM_AcquireTablePointers(void)
-{
-    CFE_Status_t Status;
-
-    /* Allow cFE an opportunity to make table updates */
-    CFE_TBL_Manage(FM_AppData.MonitorTableHandle);
-
-    /* Acquire pointer to file system free space table */
-    Status = CFE_TBL_GetAddress((void *)&FM_AppData.MonitorTablePtr, FM_AppData.MonitorTableHandle);
-
-    if (Status == CFE_TBL_ERR_NEVER_LOADED)
-    {
-        /* Make sure we don't try to use the empty table buffer */
-        FM_AppData.MonitorTablePtr = NULL;
-    }
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* FM table function -- release table data pointer                 */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void FM_ReleaseTablePointers(void)
-{
-    /* Release pointer to file system free space table */
-    CFE_TBL_ReleaseAddress(FM_AppData.MonitorTableHandle);
-
-    /* Prevent table pointer use while released */
-    FM_AppData.MonitorTablePtr = NULL;
 }

--- a/fsw/src/fm_table_utils.h
+++ b/fsw/src/fm_table_utils.h
@@ -71,35 +71,4 @@ CFE_Status_t FM_TableInit(void);
  */
 CFE_Status_t FM_ValidateTable(FM_MonitorTable_t *TablePtr);
 
-/**
- *  \brief Acquire Table Data Pointer Function
- *
- *  \par Description
- *       This function is invoked to acquire a pointer to the FM file system free
- *       space table data.  The pointer is maintained in the FM global data
- *       structure.  Note that the table data pointer will be set to NULL if the
- *       table has not yet been successfully loaded.
- *
- *  \par Assumptions, External Events, and Notes:
- *
- *  \sa #FM_AppData_t
- */
-void FM_AcquireTablePointers(void);
-
-/**
- *  \brief Release Table Data Pointer Function
- *
- *  \par Description
- *       This function is invoked to release the pointer to the FM file system free
- *       space table data.  The pointer is maintained in the FM global data
- *       structure.  The table data pointer must be periodically released to allow
- *       CFE Table Services an opportunity to load or dump the table without risk
- *       of interfering with users of the table data.
- *
- *  \par Assumptions, External Events, and Notes:
- *
- *  \sa #FM_AppData_t
- */
-void FM_ReleaseTablePointers(void);
-
 #endif

--- a/unit-test/fm_cmds_tests.c
+++ b/unit-test/fm_cmds_tests.c
@@ -1409,7 +1409,7 @@ void Test_FM_MonitorFilesystemSpaceCmd_NullFreeSpaceTable(void)
     FM_Test_Verify_Event(0,
                          FM_GET_FREE_SPACE_TBL_ERR_EID,
                          CFE_EVS_EventType_ERROR,
-                         "%s error: file system free space table is not loaded");
+                         "%s error: file system free space table unavailable: status=%08x");
 }
 
 void Test_FM_MonitorFilesystemSpaceCmd_ImplCallFails(void)
@@ -1521,7 +1521,6 @@ void Test_FM_SetTableStateCmd_NullFreeSpaceTable(void)
     SetTableStateCmd.Payload.State = FM_TABLE_ENTRY_ENABLED;
     SetTableStateCmd.Payload.Index = 0;
 
-    FM_AppData.MonitorTablePtr = NULL;
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_TBL_ERR_NEVER_LOADED);
 
     Status = FM_SetTableStateCmd(&SetTableStateCmd);
@@ -1533,7 +1532,7 @@ void Test_FM_SetTableStateCmd_NullFreeSpaceTable(void)
     FM_Test_Verify_Event(0,
                          FM_SET_TABLE_STATE_TBL_ERR_EID,
                          CFE_EVS_EventType_ERROR,
-                         "%s error: file system free space table is not loaded");
+                         "%s error: file system free space table unavailable: status=%08x");
 }
 
 void Test_FM_SetTableStateCmd_IndexTooLarge(void)

--- a/unit-test/fm_table_utils_tests.c
+++ b/unit-test/fm_table_utils_tests.c
@@ -388,41 +388,6 @@ void Test_FM_ValidateTable_NameTooLong(void)
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 }
 
-void Test_FM_AcquireTablePointers_Success(void)
-{
-    FM_MonitorTable_t Table;
-
-    UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), CFE_SUCCESS);
-
-    FM_AppData.MonitorTablePtr = &Table;
-
-    UtAssert_VOIDCALL(FM_AcquireTablePointers());
-
-    UtAssert_NOT_NULL(FM_AppData.MonitorTablePtr);
-}
-
-void Test_FM_AcquireTablePointers_Fail(void)
-{
-    FM_MonitorTable_t Table;
-
-    UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), CFE_TBL_ERR_NEVER_LOADED);
-
-    FM_AppData.MonitorTablePtr = &Table;
-
-    UtAssert_VOIDCALL(FM_AcquireTablePointers());
-
-    UtAssert_NULL(FM_AppData.MonitorTablePtr);
-}
-
-void Test_FM_ReleaseTablePointers(void)
-{
-    FM_MonitorTable_t Table;
-
-    FM_AppData.MonitorTablePtr = &Table;
-
-    UtAssert_VOIDCALL(FM_ReleaseTablePointers());
-}
-
 /*
  * Register the test cases to execute with the unit test tool
  */
@@ -446,11 +411,4 @@ void UtTest_Setup(void)
     UtTest_Add(Test_FM_ValidateTable_EmptyName, FM_Test_Setup, FM_Test_Teardown, "Test_FM_ValidateTable_EmptyName");
 
     UtTest_Add(Test_FM_ValidateTable_NameTooLong, FM_Test_Setup, FM_Test_Teardown, "Test_FM_ValidateTable_NameTooLong");
-
-    UtTest_Add(Test_FM_AcquireTablePointers_Success,
-               FM_Test_Setup,
-               FM_Test_Teardown,
-               "Test_FM_AcquireTablePointers_Success");
-    UtTest_Add(Test_FM_AcquireTablePointers_Fail, FM_Test_Setup, FM_Test_Teardown, "Test_FM_AcquireTablePointers_Fail");
-    UtTest_Add(Test_FM_ReleaseTablePointers, FM_Test_Setup, FM_Test_Teardown, "Test_FM_ReleaseTablePointers");
 }

--- a/unit-test/stubs/fm_table_utils_stubs.c
+++ b/unit-test/stubs/fm_table_utils_stubs.c
@@ -27,26 +27,6 @@
 
 /*
  * ----------------------------------------------------
- * Generated stub function for FM_AcquireTablePointers()
- * ----------------------------------------------------
- */
-void FM_AcquireTablePointers(void)
-{
-    UT_GenStub_Execute(FM_AcquireTablePointers, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for FM_ReleaseTablePointers()
- * ----------------------------------------------------
- */
-void FM_ReleaseTablePointers(void)
-{
-    UT_GenStub_Execute(FM_ReleaseTablePointers, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
  * Generated stub function for FM_TableInit()
  * ----------------------------------------------------
  */


### PR DESCRIPTION
---
name: FSW Code Change
about: Flight Software code changes
labels: fsw
---

## Description of Change

The FM monitor table is only referenced during the execution of commands involving that table.  These commands obtain the pointer at the beginning of operation and release it before returning.  There is no need to store the pointer in the global - it is always NULL outside of these command contexts.

## Linked Issue

Closes #152

## Testing Evidence

Confirm affected commands are functioning normally

